### PR TITLE
Activate the extension upon presence of build.sbt or build.properties

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,9 @@
     "Other"
   ],
   "activationEvents": [
-    "onLanguage:scala"
+    "onLanguage:scala",
+    "workspaceContains:build.sbt",
+    "workspaceContains:project/build.properties"
   ],
   "contributes": {
     "configuration": {


### PR DESCRIPTION
Currently the extension activates when a file with "scala" language (`.scala` or `.sbt`) is opened.

This PR makes the extension activate also when `build.sbt` or `project/build.properties` are detected, allowing for the extension to start even before the user has opened a Scala file.

This allows Metals to be responsive a little earlier.

It's important noticing that potential false positives should not be a problem, since Metals performs its own more fine-grained checks at launch anyway.


Here's a demo of Metals launching even without opening any Scala file

![kapture 2018-12-06 at 12 49 39](https://user-images.githubusercontent.com/691940/49582948-eb00c500-f956-11e8-8276-4513a601d340.gif)
