### PR TITLE
Add qna link to extension manifest

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "url": "https://github.com/scalameta/metals-vscode.git"
   },
   "homepage": "http://metals.rocks",
+  "qna": "https://github.com/scalameta/metals/issues",
   "engines": {
     "vscode": "^1.27.0"
   },


### PR DESCRIPTION
If I read the docs correctly, this should set the Q&A link, which currently points to the issues in this repo, which are turned-off in favor of scalameta/metals issues.

