### PR TITLE
Update manifest categories

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,9 +39,7 @@
   },
   "icon": "images/logo.png",
   "categories": [
-    "Linters",
-    "Formatters",
-    "Other"
+    "Programming Languages"
   ],
   "activationEvents": [
     "onLanguage:scala",


### PR DESCRIPTION
Metals is not a linter nor a formatter anymore. `"Programming Languages"` is used also by the Java extension and it seems appropriate.