### PR TITLE
Use the CI to publish the extension on the Marketplace

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,25 @@ node_js:
 
 stages:
   - name: build
+  - name: release
+    if: tag IS present
 
 jobs:
   include:
-    - script:
+    - stage: build
+      script:
         # test that the extension builds correctly
         - yarn build
+    - stage: release
+      script:
+        # configure git so that we can commit and push the new version
+        - git config --global user.email "metals@scalameta.org"
+        - git config --global user.name "Metals CI"
+        # drop the v prefix in vX.Y.Z
+        - NEW_VERSION=${TRAVIS_TAG#"v"}
+        # set the version and publish the extension to the Marketplace
+        - yarn vscode:publish $NEW_VERSION -p $VS_MARKETPLACE_TOKEN
+        # sync back the new version
+        - git push && git push --tags
 
 cache: yarn

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,11 @@ jobs:
         - git config --global user.name "Metals CI"
         # drop the v prefix in vX.Y.Z
         - NEW_VERSION=${TRAVIS_TAG#"v"}
-        # set the version and publish the extension to the Marketplace
-        - yarn vscode:publish $NEW_VERSION -p $VS_MARKETPLACE_TOKEN
-        # sync back the new version
-        - git push && git push --tags
+        # change the version in package.json
+        - yarn version --new-version $NEW_VERSION
+        # push the changes to package.json
+        - git push "https://${GITHUB_TOKEN}@github.com/$TRAVIS_REPO_SLUG} master"
+        # publish the extension to the Marketplace
+        - yarn vscode:publish -p $VS_MARKETPLACE_TOKEN
 
 cache: yarn

--- a/package.json
+++ b/package.json
@@ -109,11 +109,11 @@
     "@types/mocha": "^2.2.42",
     "@types/node": "^8.10.25",
     "typescript": "^2.6.1",
-    "vsce": "^1.51.6"
+    "vsce": "^1.53.2"
   },
   "dependencies": {
-    "promisify-child-process": "3.1.0",
     "find-java-home": "0.2.0",
+    "promisify-child-process": "3.1.0",
     "vscode": "^1.1.21",
     "vscode-languageclient": "^5.1.0"
   },

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "language server",
     "scalameta"
   ],
-  "version": "0.3.0",
+  "version": "0.3.1",
   "publisher": "scalameta",
   "contributors": [
     {

--- a/package.json
+++ b/package.json
@@ -97,13 +97,13 @@
   },
   "main": "./out/extension",
   "scripts": {
-    "vscode:prepublish": "npm run compile",
+    "vscode:prepublish": "yarn compile",
     "compile": "tsc -p ./",
     "watch": "tsc -watch -p ./",
     "postinstall": "node ./node_modules/vscode/bin/install",
-    "test": "npm run compile && node ./node_modules/vscode/bin/test",
-    "build": "vsce package",
-    "vscode:publish": "vsce publish"
+    "test": "yarn compile && node ./node_modules/vscode/bin/test",
+    "build": "vsce package --yarn",
+    "vscode:publish": "vsce publish --yarn"
   },
   "devDependencies": {
     "@types/mocha": "^2.2.42",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15,9 +15,9 @@
   integrity sha512-nlK/iyETgafGli8Zh9zJVCTicvU3iajSkRwOh3Hhiva598CMqNJ4NcVCGMTGKpGpTYj/9R8RLzS9NAykSSCqGw==
 
 "@types/node@*":
-  version "10.12.11"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.12.11.tgz#715c476c99a5f6898a1ae61caf9825e43c03912e"
-  integrity sha512-3iIOhNiPGTdcUNVCv9e5G7GotfvJJe2pc9w2UgDXlUwnxSZ3RgcUocIU+xYm+rTU54jIKih998QE4dMOyMN1NQ==
+  version "10.12.12"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.12.12.tgz#e15a9d034d9210f00320ef718a50c4a799417c47"
+  integrity sha512-Pr+6JRiKkfsFvmU/LK68oBRCQeEg36TyAbPhc2xpez24OOZZCuoIhWGTd39VZy6nGafSbxzGouFPTFD/rR1A0A==
 
 "@types/node@^8.10.25":
   version "8.10.38"
@@ -368,15 +368,10 @@ dom-serializer@0, dom-serializer@~0.1.0:
     domelementtype "~1.1.1"
     entities "~1.1.1"
 
-domelementtype@1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-1.2.1.tgz#578558ef23befac043a1abb0db07635509393479"
-  integrity sha512-SQVCLFS2E7G5CRCMdn6K9bIhRj1bS6QBWZfF0TUPh4V/BbqrQ619IdSS3/izn0FZ+9l+uODzaZjb08fjOfablA==
-
-domelementtype@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-1.3.0.tgz#b17aed82e8ab59e52dd9c19b1756e0fc187204c2"
-  integrity sha1-sXrtguirWeUt2cGbF1bg/BhyBMI=
+domelementtype@1, domelementtype@^1.3.0:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-1.3.1.tgz#d048c44b37b0d10a7f2a3d5fee3f4333d790481f"
+  integrity sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==
 
 domelementtype@~1.1.1:
   version "1.1.3"
@@ -2074,7 +2069,7 @@ vinyl@^2.0.0, vinyl@^2.0.1, vinyl@^2.0.2:
     remove-trailing-separator "^1.0.1"
     replace-ext "^1.0.0"
 
-vsce@^1.51.6:
+vsce@^1.53.2:
   version "1.53.2"
   resolved "https://registry.yarnpkg.com/vsce/-/vsce-1.53.2.tgz#50ec10cf698638ce37fa191caf7faf259c8d23df"
   integrity sha512-yo7ctgQPK7hKnez/be3Tj7RG3eZzgkFhx/27y9guwzhMxHfjlU1pusAsFT8wBEZKZlYA5HNJAx8oClw4WDWi+A==


### PR DESCRIPTION
The idea is to:
- trigger the release stage upon tags
- update the `package.json` version to match the tag using `yarn version` (I couldn't make `vsce publish <version>` work, see last commit). This will generate a commit and a tag.
- push the commit (but not the tag!) back to GitHub from Travis using an access token
- publish the extension to the Marketplace using a token

Tokens are (already) stored as secure env variables in Travis

So many things will go wrong when we merge this, but it's the only way of testing it...
