### PR TITLE
Use markdown for configuration description

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,17 +53,15 @@
         "metals.serverVersion": {
           "type": "string",
           "default": "0.3.0",
-          "description": "The version of the Metals server artifact. Requires reloading the window. Change only if you know what you're doing"
+          "markdownDescription": "The version of the Metals server artifact. Requires reloading the window.\n\n**Change only if you know what you're doing**"
         },
         "metals.serverProperties": {
           "type": "string",
-          "default": "",
-          "description": "Optional space separated system properties to pass along to the Metals server, for example -Dmetals.bloop-protocol=tcp"
+          "markdownDescription": "Optional space separated system properties to pass along to the Metals server.\n\nExample: `-Dmetals.bloop-protocol=tcp`"
         },
         "metals.javaHome": {
           "type": "string",
-          "default": "",
-          "description": "Optional path to the Java home directory. Defaults to the environment variable JAVA_HOME computed by the `find-java-home` npm package."
+          "markdownDescription": "Optional path to the Java home directory. Requires reloading the window.\n\nDefaults to the environment variable `JAVA_HOME` computed by the `find-java-home` npm package."
         }
       }
     },


### PR DESCRIPTION
Super tiny improvements to the configuration section, after I found out about `markdownDescription`.

Before:

![image](https://user-images.githubusercontent.com/691940/49656065-a8b1b380-fa3c-11e8-92e5-37dc8be8a4c1.png)


After:

![image](https://user-images.githubusercontent.com/691940/49656070-abaca400-fa3c-11e8-9812-92effc88f5d1.png)
