### PR TITLE
Warn on out-of-date server version

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,12 +118,14 @@
   "devDependencies": {
     "@types/mocha": "^2.2.42",
     "@types/node": "^8.10.25",
+    "@types/semver": "^5.5.0",
     "typescript": "^2.6.1",
     "vsce": "^1.53.2"
   },
   "dependencies": {
     "find-java-home": "0.2.0",
     "promisify-child-process": "3.1.0",
+    "semver": "^5.6.0",
     "vscode": "^1.1.21",
     "vscode-languageclient": "^5.1.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -24,6 +24,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-8.10.38.tgz#e05c201a668492e534b48102aca0294898f449f6"
   integrity sha512-EibsnbJerd0hBFaDjJStFrVbVBAtOy4dgL8zZFw0uOvPqzBAX59Ci8cgjg3+RgJIWhsB5A4c+pi+D4P9tQQh/A==
 
+"@types/semver@^5.5.0":
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/@types/semver/-/semver-5.5.0.tgz#146c2a29ee7d3bae4bf2fcb274636e264c813c45"
+  integrity sha512-41qEJgBH/TWgo5NFSvBCJ1qkoi3Q6ONSF2avrHq1LVEZfYpdHmj0y9SuTK+u9ZhG1sYQKBL1AWXKyLWP4RaUoQ==
+
 ajv@^6.5.5:
   version "6.6.1"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.6.1.tgz#6360f5ed0d80f232cc2b294c362d5dc2e538dd61"
@@ -1661,7 +1666,7 @@ safer-buffer@^2.0.2, safer-buffer@^2.1.0, safer-buffer@~2.1.0:
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
-semver@^5.1.0, semver@^5.4.1, semver@^5.5.0:
+semver@^5.1.0, semver@^5.4.1, semver@^5.5.0, semver@^5.6.0:
   version "5.6.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.6.0.tgz#7e74256fbaa49c75aa7c7a205cc22799cac80004"
   integrity sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==


### PR DESCRIPTION

Closes #23

Tested also with SNAPSHOT versions:

If the current version is 0.3.1, this warns on:

- `0.3.0`
- `0.3.0+10-dba8c0aa-SNAPSHOT
- `0.3.1-SNAPSHOT`

but __does not__ warn on

- `0.3.1`
- `0.3.2`
- `0.3.1+15-dba8c0aa-SNAPSHOT`

![kapture 2018-12-09 at 21 16 16](https://user-images.githubusercontent.com/691940/49702449-8369a480-fbf8-11e8-823f-400c54854db2.gif)
