### PR TITLE
Handle exceptions thrown by semver

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -438,7 +438,16 @@ function checkServerVersion() {
   const serverVersion = config.get<string>("serverVersion");
   const latestServerVersion = config.inspect<string>("serverVersion")
     .defaultValue;
-  const isOutdated = semver.lt(serverVersion, latestServerVersion);
+  const isOutdated = (() => {
+    try {
+      return semver.lt(serverVersion, latestServerVersion);
+    } catch (_e) {
+      // serverVersion has an invalid format
+      // ignore the exception here, and let subsequent checks handle this
+      return false;
+    }
+  })();
+
   if (isOutdated) {
     const upgradeAction = `Upgrade to ${latestServerVersion} now`;
     const openSettingsAction = "Open settings";


### PR DESCRIPTION
Fix an error reported by @olafurpg.
`semver` throws an exception when it can't parse the version.

In this PR we handle it by ignoring misformatted versions in the out-of-date check.
I thought about giving another custom warning, but I prefer not to overlap with the download checks.

It will fail any way with a meaningful error, which is the important part.