### PR TITLE
Show Metals commands only when the active buffer is a Scala file

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,31 @@
         "category": "Metals",
         "title": "Run doctor"
       }
-    ]
+    ],
+    "menus": {
+      "commandPalette": [
+        {
+          "command": "metals.restartServer",
+          "when": "editorLangId == scala"
+        },
+        {
+          "command": "metals.build-import",
+          "when": "editorLangId == scala"
+        },
+        {
+          "command": "metals.build-connect",
+          "when": "editorLangId == scala"
+        },
+        {
+          "command": "metals.sources-scan",
+          "when": "editorLangId == scala"
+        },
+        {
+          "command": "metals.doctor-run",
+          "when": "editorLangId == scala"
+        }
+      ]
+    }
   },
   "main": "./out/extension",
   "scripts": {


### PR DESCRIPTION
Thanks to https://stackoverflow.com/questions/53711092/how-to-prevent-commands-from-being-displayed-if-the-extension-is-not-active/53711448?noredirect=1#comment94300288_53711448 I've found a way to prevent Metals commands from showing in the Command Palette even out of context, using a `when` clause.

The best `when` clause that I could find is `editorLangId == scala` which has this effect:

![kapture 2018-12-11 at 12 52 58](https://user-images.githubusercontent.com/691940/49799144-76f26280-fd44-11e8-8945-04ea805ec01f.gif)

Pros of this PR:
- you don't see Metals commands when not in a Scala file (meaning you can't accidentally run it and get an error in VSCode)

Drawbacks of this PR:
- if you're are in a Scala project, but not focused on a `.scala`/`.sbt` file (e.g. you are in `.scalafmt.conf`, you can't access those commands.

Unchanged with this PR:
- commands can still fail if you invoke them before the server has started (it's a tiny time window, unless the server has failed to launch)

wdyt @olafurpg?