### PR TITLE
Bump default serverVersion to 0.3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
       "properties": {
         "metals.serverVersion": {
           "type": "string",
-          "default": "0.3.1",
+          "default": "0.3.2",
           "markdownDescription": "The version of the Metals server artifact. Requires reloading the window.\n\n**Change only if you know what you're doing**"
         },
         "metals.serverProperties": {


### PR DESCRIPTION
In preparation for the upcoming 0.3.2 release of Metals.