### PR TITLE
Prefer JDK over JRE

### DIFF
--- a/src/getJavaHome.ts
+++ b/src/getJavaHome.ts
@@ -13,7 +13,12 @@ export function getJavaHome(): Promise<string> {
         } else if (javaHomes.length === 0) {
           reject(new Error("No suitable Java version found"));
         } else {
-          resolve(javaHomes[0].path);
+          const jdkHome = javaHomes.find(j => j.isJDK);
+          if (jdkHome) {
+            resolve(jdkHome.path);
+          } else {
+            resolve(javaHomes[0].path);
+          }
         }
       });
     });


### PR DESCRIPTION
Fixes #37 

When looking for Java home, try finding a JDK path first, then fall back on whatever else is there.