### PR TITLE
Ask to reload window on changes to server properties.

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -428,7 +428,7 @@ function dottyIdeArtifact(): string {
 
 function detectLaunchConfigurationChanges() {
   workspace.onDidChangeConfiguration(e => {
-    const promptRestartKeys = ["serverVersion", "javaHome"];
+    const promptRestartKeys = ["serverVersion", "serverProperties", "javaHome"];
     const shouldPromptRestart = promptRestartKeys.some(k =>
       e.affectsConfiguration(`metals.${k}`)
     );


### PR DESCRIPTION
If the user changes memory options or enables features like statistics logging
then the server needs to restart to pick it up.