### PR TITLE
Implement metals/inputBox extension

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -23,7 +23,8 @@ import {
   RevealOutputChannelOn,
   ExecuteCommandRequest,
   ShutdownRequest,
-  ExitNotification
+  ExitNotification,
+  CancellationToken
 } from "vscode-languageclient";
 import { exec } from "child_process";
 import { Commands } from "./commands";
@@ -31,7 +32,8 @@ import {
   MetalsSlowTask,
   MetalsStatus,
   MetalsDidFocus,
-  ExecuteClientCommand
+  ExecuteClientCommand,
+  MetalsInputBox
 } from "./protocol";
 import { LazyProgress } from "./lazy-progress";
 import * as fs from "fs";
@@ -290,6 +292,16 @@ function launchMetals(
           editor.document.uri.toString()
         );
       }
+    });
+
+    client.onRequest(MetalsInputBox.type, (options, requestToken) => {
+      return window.showInputBox(options, requestToken).then(result => {
+        if (result === undefined) {
+          return { cancelled: true };
+        } else {
+          return { value: result };
+        }
+      });
     });
 
     // Long running tasks such as "import project" trigger start a progress

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -1,5 +1,6 @@
 import { RequestType, NotificationType } from "vscode-jsonrpc";
 import { ExecuteCommandParams } from "vscode-languageclient";
+import { InputBoxOptions } from "vscode";
 
 "use strict";
 
@@ -40,4 +41,18 @@ export interface MetalsStatusParams {
   hide?: boolean;
   tooltip?: string;
   command?: string;
+}
+
+export namespace MetalsInputBox {
+  export const type = new RequestType<
+    InputBoxOptions,
+    MetalsInputBoxResult,
+    void,
+    void
+  >("metals/inputBox");
+}
+
+export interface MetalsInputBoxResult {
+  value?: string;
+  cancelled?: boolean;
 }


### PR DESCRIPTION
This endpoint will soon be used by Metals to allow users to write a
custom Scalafmt version to add to `.scalafmt.conf`.

![2019-01-10 23 07 37](https://user-images.githubusercontent.com/1408093/51000189-9ee40a00-152c-11e9-9fb5-778cd27d1895.gif)
