### PR TITLE
Synchronize client commands with latest Metals.

### DIFF
--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
     "@types/mocha": "^2.2.42",
     "@types/node": "^8.10.25",
     "@types/semver": "^5.5.0",
-    "typescript": "^2.6.1",
+    "typescript": "^3.2.2",
     "vsce": "^1.54.0"
   },
   "dependencies": {

--- a/src/client-commands.ts
+++ b/src/client-commands.ts
@@ -1,0 +1,8 @@
+"use strict";
+
+// Metals expects clients to implement the following commands: https://scalameta.org/metals/docs/editors/new-editor.html#metals-client-commands
+export namespace ClientCommands {
+  export const TOGGLE_LOGS = "metals-logs-toggle";
+  export const FOCUS_DIAGNOSTICS = "metals-diagnostics-focus";
+  export const RUN_DOCTOR = "metals-doctor-run";
+}

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1,6 +1,0 @@
-"use strict";
-
-export namespace Commands {
-  export const TOGGLE_LOGS = "metals.logs.toggle";
-  export const FOCUS_DIAGNOSTICS = "metals.diagnostics.focus";
-}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -27,7 +27,7 @@ import {
   CancellationToken
 } from "vscode-languageclient";
 import { exec } from "child_process";
-import { Commands } from "./commands";
+import { ClientCommands } from "./client-commands";
 import {
   MetalsSlowTask,
   MetalsStatus,
@@ -225,7 +225,7 @@ function launchMetals(
     // this command twice in case the channel has been focused through another
     // button. There is no `isFocused` API to check if a channel is focused.
     let channelOpen = false;
-    commands.registerCommand(Commands.TOGGLE_LOGS, () => {
+    commands.registerCommand(ClientCommands.TOGGLE_LOGS, () => {
       if (channelOpen) {
         client.outputChannel.hide();
         channelOpen = false;
@@ -235,8 +235,12 @@ function launchMetals(
       }
     });
 
-    commands.registerCommand(Commands.FOCUS_DIAGNOSTICS, () => {
+    commands.registerCommand(ClientCommands.FOCUS_DIAGNOSTICS, () => {
       commands.executeCommand("workbench.action.problems.focus");
+    });
+
+    commands.registerCommand(ClientCommands.RUN_DOCTOR, () => {
+      commands.executeCommand("metals.doctor-run");
     });
 
     // Handle the metals/executeClientCommand extension notification.
@@ -257,7 +261,7 @@ function launchMetals(
     // The server updates the client with a brief text message about what
     // it is currently doing, for example "Compiling..".
     const item = window.createStatusBarItem(StatusBarAlignment.Right, 100);
-    item.command = Commands.TOGGLE_LOGS;
+    item.command = ClientCommands.TOGGLE_LOGS;
     item.hide();
     client.onNotification(MetalsStatus.type, params => {
       item.text = params.text;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1903,10 +1903,10 @@ typed-rest-client@^0.9.0:
     tunnel "0.0.4"
     underscore "1.8.3"
 
-typescript@^2.6.1:
-  version "2.9.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.9.2.tgz#1cbf61d05d6b96269244eb6a3bce4bd914e0f00c"
-  integrity sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w==
+typescript@^3.2.2:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.2.2.tgz#fe8101c46aa123f8353523ebdcf5730c2ae493e5"
+  integrity sha512-VCj5UiSyHBjwfYacmDuc/NOk4QQixbE+Wn7MFJuS0nRuPQbof132Pw4u53dm264O8LPc2MVsc7RJNml5szurkg==
 
 uc.micro@^1.0.1, uc.micro@^1.0.5:
   version "1.0.5"


### PR DESCRIPTION
It seems we forgot to update these in the shift to kebab-case.
Also, "run doctor" was missing.

These are commands that metals expects the client to support, for
example "focus diagnostics" or "run doctor". Status bar messages
can have attached client commands so that for example if we update the
status bar with "Build mis-configuration" the user can click on it to
open the doctor.