### PR TITLE
Add -Dmetals.input-box property, fixes #53.

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -148,6 +148,7 @@ function launchMetals(
   enableScaladocIndentation();
 
   const baseProperties = [
+    `-Dmetals.input-box=on`,
     `-Dmetals.client=vscode`,
     `-Xss4m`,
     `-Xms100m`,


### PR DESCRIPTION
This property is needed for the Scalafmt version dialogue.