### PR TITLE
Focus on webview when running doctor, fixes #52.

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -207,7 +207,7 @@ function launchMetals(
 
   client.onReady().then(_ => {
     let doctor: WebviewPanel;
-    function getDoctorPanel(): WebviewPanel {
+    function getDoctorPanel(isReload: boolean): WebviewPanel {
       if (!doctor) {
         doctor = window.createWebviewPanel(
           "metals-doctor",
@@ -218,6 +218,8 @@ function launchMetals(
         doctor.onDidDispose(() => {
           doctor = undefined;
         });
+      } else if (!isReload) {
+        doctor.reveal();
       }
       return doctor;
     }
@@ -260,13 +262,12 @@ function launchMetals(
 
     // Handle the metals/executeClientCommand extension notification.
     client.onNotification(ExecuteClientCommand.type, params => {
-      if (
-        params.command === "metals-doctor-run" ||
-        (doctor && params.command === "metals-doctor-reload")
-      ) {
+      const isRun = params.command === "metals-doctor-run";
+      const isReload = params.command === "metals-doctor-reload";
+      if (isRun || (doctor && isReload)) {
         const html = params.arguments[0];
         if (typeof html === "string") {
-          const panel = getDoctorPanel();
+          const panel = getDoctorPanel(isReload);
           panel.webview.html = html;
         }
       }


### PR DESCRIPTION
Previously, if the user clicked on "learn more" to open the doctor and
there existed a doctor webview then nothing happened. With this commit,
we move the focus to the webview if it already exists so clicking on
"Learn more" has impact.