### PR TITLE
Rename Marketplace extension to "Scala (Metals)" for discoverability.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metals",
-  "displayName": "Metals",
+  "displayName": "Scala (Metals)",
   "description": "Work in progress language server for Scala",
   "keywords": [
     "scala",


### PR DESCRIPTION
Fixes #42. This naming convention is consistent with "Scala (sbt)" for
the sbt language server.