### PR TITLE
More accurate configuration description for metals.javaHome

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
         },
         "metals.javaHome": {
           "type": "string",
-          "markdownDescription": "Optional path to the Java home directory. Requires reloading the window.\n\nDefaults to the environment variable `JAVA_HOME` computed by the `locate-java-home` npm package."
+          "markdownDescription": "Optional path to the Java home directory. Requires reloading the window.\n\nDefaults to the most recent Java 8 version computed by the `locate-java-home` npm package."
         },
         "metals.sbtScript": {
           "type": "string",


### PR DESCRIPTION
Just a minor nit, but we don't actually default to `JAVA_HOME`