### PR TITLE
Upgrade to v0.4.2.

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
       "properties": {
         "metals.serverVersion": {
           "type": "string",
-          "default": "0.4.1",
+          "default": "0.4.2",
           "markdownDescription": "The version of the Metals server artifact. Requires reloading the window.\n\n**Change only if you know what you're doing**"
         },
         "metals.serverProperties": {


### PR DESCRIPTION
It shouldn't affect VS Code since it always sends `workspaceFolders`.