### PR TITLE
Bail when no directory has been opened and enable strict mode in TypeScript

### DIFF
--- a/src/getJavaHome.ts
+++ b/src/getJavaHome.ts
@@ -10,7 +10,7 @@ export function getJavaHome(): Promise<string> {
       locateJavaHome({ version: "1.8" }, (err, javaHomes) => {
         if (err) {
           reject(err);
-        } else if (javaHomes.length === 0) {
+        } else if (!javaHomes || javaHomes.length === 0) {
           reject(new Error("No suitable Java version found"));
         } else {
           // Sort by reverse security number so the highest number comes first.

--- a/src/lazy-progress.ts
+++ b/src/lazy-progress.ts
@@ -6,7 +6,7 @@ import { OutputChannel, window, ProgressLocation } from "vscode";
  * A progress bar that starts only the first time `startOrContinue` is called.
  */
 export class LazyProgress {
-  private progress;
+  private progress: Thenable<void> | undefined;
   startOrContinue(
     title: string,
     output: OutputChannel,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,16 +1,12 @@
 {
-    "compilerOptions": {
-        "module": "commonjs",
-        "target": "es6",
-        "outDir": "out",
-        "lib": [
-            "es6"
-        ],
-        "sourceMap": true,
-        "rootDir": "src"
-    },
-    "exclude": [
-        "node_modules",
-        ".vscode-test"
-    ]
+  "compilerOptions": {
+    "strict": true,
+    "module": "commonjs",
+    "target": "es6",
+    "outDir": "out",
+    "lib": ["es2018"],
+    "sourceMap": true,
+    "rootDir": "src"
+  },
+  "exclude": ["node_modules", ".vscode-test"]
 }


### PR DESCRIPTION
This PR enables the `strict: true` compiler option, which finally highlighted a lot of potentially unsafe accesses to `any` or `undefined` structures.

This also turns the bug reported in #79 into a type error 🎉 

The PR fixes #79 and all other potentially unsafe accesses.