### PR TITLE
Filter out JVM debugging properties for coursier fetch process

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -100,9 +100,11 @@ function fetchAndLaunchMetals(context: ExtensionContext, javaHome: string) {
 
   const javaOptions = getJavaOptions(outputChannel);
 
+  const fetchProperties = serverProperties.filter(p => !p.startsWith("-agentlib"));
+
   const fetchProcess = spawn(
     javaPath,
-    javaOptions.concat(serverProperties).concat([
+    javaOptions.concat(fetchProperties).concat([
       "-jar",
       coursierPath,
       "fetch",


### PR DESCRIPTION
Previously, the coursier fetch process used the Metals server system properties
including JVM debugging options like `-agentlib*`.

Now, we filter out server properties starting with `-agentlib` so that it's easier to debug the Metals process.