### PR TITLE
Remove default GC options, fixes #85.

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -100,7 +100,9 @@ function fetchAndLaunchMetals(context: ExtensionContext, javaHome: string) {
 
   const javaOptions = getJavaOptions(outputChannel);
 
-  const fetchProperties = serverProperties.filter(p => !p.startsWith("-agentlib"));
+  const fetchProperties = serverProperties.filter(
+    p => !p.startsWith("-agentlib")
+  );
 
   const fetchProcess = spawn(
     javaPath,
@@ -183,9 +185,7 @@ function launchMetals(
     `-Dmetals.input-box=on`,
     `-Dmetals.client=vscode`,
     `-Xss4m`,
-    `-Xms100m`,
-    `-XX:+UseG1GC`,
-    `-XX:+UseStringDeduplication`
+    `-Xms100m`
   ];
   const mainArgs = ["-classpath", metalsClasspath, "scala.meta.metals.Main"];
   // let user properties override base properties


### PR DESCRIPTION
Previously, Metals failed to start if the workspace .jvmopts file
declared custom GC options because they conflicted with the default GC
options we used.

Now, we don't declare any default GC options so Metals can start in
workspaces with custom GC and other VM options.

The string deduplication option is not necessary because Metals uses
little memory by default anyways. We started recommending this setting
by default with the old Metals prototype that could sometimes consume
multiple gigabytes of ram even on medium sized projects. If people want
the old behavior, they can enable string deduplication in .jvmopts or in
the "server properties" setting.