### PR TITLE
 Link to HTTP proxy instructions in "failed to download" error.

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -143,7 +143,7 @@ function fetchAndLaunchMetals(context: ExtensionContext, javaHome: string) {
       const msg = (() => {
         const proxy =
           `See https://scalameta.org/metals/docs/editors/vscode.html#http-proxy for instructions ` +
-          `if you are using a corporate HTTP proxy.`;
+          `if you are using an HTTP proxy.`;
         if (process.env.FLATPAK_SANDBOX_DIR) {
           return (
             `Failed to download Metals. It seems you are running Visual Studio Code inside the` +

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -141,6 +141,9 @@ function fetchAndLaunchMetals(context: ExtensionContext, javaHome: string) {
     },
     () => {
       const msg = (() => {
+        const proxy =
+          `See https://scalameta.org/metals/docs/editors/vscode.html#http-proxy for instructions ` +
+          `if you are using a corporate HTTP proxy.`;
         if (process.env.FLATPAK_SANDBOX_DIR) {
           return (
             `Failed to download Metals. It seems you are running Visual Studio Code inside the` +
@@ -150,13 +153,15 @@ function fetchAndLaunchMetals(context: ExtensionContext, javaHome: string) {
         } else if (serverVersion === defaultServerVersion) {
           return (
             `Failed to download Metals, make sure you have an internet connection and` +
-            `the Java Home '${javaPath}' is valid. You can configure the Java Home in the settings.`
+            `the Java Home '${javaPath}' is valid. You can configure the Java Home in the settings.` +
+            proxy
           );
         } else {
           return (
             `Failed to download Metals, make sure you have an internet connection, ` +
             `the Metals version '${serverVersion}' is correct and the Java Home '${javaPath}' is valid. ` +
-            `You can configure the Metals version and Java Home in the settings.`
+            `You can configure the Metals version and Java Home in the settings.` +
+            proxy
           );
         }
       })();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -100,7 +100,9 @@ function fetchAndLaunchMetals(context: ExtensionContext, javaHome: string) {
 
   const javaOptions = getJavaOptions(outputChannel);
 
-  const fetchProperties = serverProperties.filter(p => !p.startsWith("-agentlib"));
+  const fetchProperties = serverProperties.filter(
+    p => !p.startsWith("-agentlib")
+  );
 
   const fetchProcess = spawn(
     javaPath,
@@ -183,9 +185,7 @@ function launchMetals(
     `-Dmetals.input-box=on`,
     `-Dmetals.client=vscode`,
     `-Xss4m`,
-    `-Xms100m`,
-    `-XX:+UseG1GC`,
-    `-XX:+UseStringDeduplication`
+    `-Xms100m`
   ];
   const mainArgs = ["-classpath", metalsClasspath, "scala.meta.metals.Main"];
   // let user properties override base properties


### PR DESCRIPTION
Fixes #84. Previously, the download error message only said "make sure
you have an internet connection" when the most common cause for this
problem was HTTP proxies. Now, the error message links to the Metals
website for how to configure HTTP proxies.