### PR TITLE
Update default for "editor.suggestSelection" to "first", fixes #86.

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,11 @@
     "workspaceContains:project/build.properties"
   ],
   "contributes": {
+    "configurationDefaults": {
+      "[scala]": {
+        "editor.suggestSelection": "first"
+      }
+    },
     "configuration": {
       "title": "Metals",
       "properties": {


### PR DESCRIPTION
Previously, the default "editor.suggestSelection" value was "last"
causing VS Code to pre-select counter-intuitive completions items.
For example, if you selected `toString()` once, then VS Code would
pre-select `toString()` in the following completion regardless of the
order of completions returned by Metals.

Metals already orders completion items in a "smart" order based on the
local scope and completion position (pattern matching vs. type vs.
term). Now with this change, VS Code always pre-selects the first
completion item returned by Metals.