### PR TITLE
Improve version upgrade logic

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "language server",
     "scalameta"
   ],
-  "version": "1.3.0",
+  "version": "1.3.1",
   "publisher": "scalameta",
   "contributors": [
     {


### PR DESCRIPTION
Before this PR we detected when the user was running and old version of
Metals, and proposed to upgrade. However the upgrade happened only in
the Global (aka User) configuration, meaning that a user that had an
outdated version set in the Workspace or Workspace Folder Configuration
would see the "Old version detected" message again.

This PR fixes it by inspecting the chain of configurations and finding the
one that is setting the old version, and upgrading it.

E.g. if you had

Target | Value
-------|-----
Global | 0.4.0
Workspace | 0.4.0
WorkspaceFolder | not set

Now we correctly bring you to

Target | Value
-------|-----
Global | 0.4.0
Workspace | 0.5.0
WorkspaceFolder | not set

If you then open another workspace where there is no specific setting:

Target | Value
-------|-----
Global | 0.4.0
Workspace | not set
WorkspaceFolder | not set

we then propose to upgrade again and bring you to

Target | Value
-------|-----
Global | 0.5.0
Workspace | not set
WorkspaceFolder | not set