### PR TITLE
Add metals/windowStateDidChange notification

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -34,7 +34,9 @@ import {
   MetalsStatus,
   MetalsDidFocus,
   ExecuteClientCommand,
-  MetalsInputBox
+  MetalsInputBox,
+  MetalsWindowStateDidChange,
+  MetalsWindowStateDidChangeParams
 } from "./protocol";
 import { LazyProgress } from "./lazy-progress";
 import * as fs from "fs";
@@ -354,6 +356,10 @@ function launchMetals(
           editor.document.uri.toString()
         );
       }
+    });
+
+    window.onDidChangeWindowState(windowState => {
+      client.sendNotification(MetalsWindowStateDidChange.type, { focused: windowState.focused })
     });
 
     client.onRequest(MetalsInputBox.type, (options, requestToken) => {

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -56,3 +56,13 @@ export interface MetalsInputBoxResult {
   value?: string;
   cancelled?: boolean;
 }
+
+export namespace MetalsWindowStateDidChange {
+  export const type = new NotificationType<MetalsWindowStateDidChangeParams, void>(
+    "metals/windowStateDidChange"
+  );
+}
+
+export interface MetalsWindowStateDidChangeParams {
+  focused: boolean;
+}


### PR DESCRIPTION
Publish `metals/windowStateDidChange` notification to indicate whether
vscode window is focused or not.

The client-side implementation of the https://github.com/scalameta/metals/issues/668