### PR TITLE
Fixing metals not being able to start on Windows

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -139,7 +139,7 @@ function fetchAndLaunchMetals(context: ExtensionContext, javaHome: string) {
       "sonatype:snapshots",
       "-p"
     ]),
-    { env: { COURSIER_NO_TERM: "true", ...customRepositoriesEnv } }
+    { env: { COURSIER_NO_TERM: "true", ...customRepositoriesEnv, ...process.env } }
   );
   const title = `Downloading Metals v${serverVersion}`;
   trackDownloadProgress(title, outputChannel, fetchProcess).then(


### PR DESCRIPTION
Fixes #116 

After several attempts to understand what is happening, I stumbled on [this comment](https://github.com/nodejs/node/issues/12986), explaining that according to nodejs docs, the third argument to the `spawn` can specify additional environment variables to the spawned process, *having the default being `process.env`*.
On my Windows machine, before the change, these are all the envvars that were passed to the spawned coursier process:
```
PATH: C:\Windows\system32;C:\Windows;C:\Windows\System32\Wbem;C:\Windows\System32\WindowsPowerShell\v1.0\...;c:\Users\<username>\.coursier;
HOMEPATH: \Users\<username>
SYSTEMDRIVE: C:
TEMP: C:\Users\<username>\AppData\Local\Temp
HOMEDRIVE: C:
USERPROFILE: C:\Users\<username>
USERDOMAIN: <...>
LOGONSERVER: \\<...>
SYSTEMROOT: C:\Windows
USERNAME: <username>
COURSIER_NO_TERM: true
WINDIR: C:\Windows
```
After the change, the entire set of original envvars is passed, in addition to the `COURSIER_NO_TERM` value (and custom coursier repos, if exists).

I have a suspicion that on Windows, coursier relies on an external library to look up `%LOCALAPPDATA%` paths, etc, and those values are missing from spawned environment variables.