### PR TITLE
Add build.sc to workspace detection

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   "activationEvents": [
     "onLanguage:scala",
     "workspaceContains:build.sbt",
+    "workspaceContains:build.sc",
     "workspaceContains:project/build.properties",
     "workspaceContains:**/scala/**"
   ],


### PR DESCRIPTION
Realised that mill doesn't by default use `scala` directory.