### PR TITLE
Automatically add | when using multiline strings

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -139,7 +139,13 @@ function fetchAndLaunchMetals(context: ExtensionContext, javaHome: string) {
       "sonatype:snapshots",
       "-p"
     ]),
-    { env: { COURSIER_NO_TERM: "true", ...customRepositoriesEnv, ...process.env } }
+    {
+      env: {
+        COURSIER_NO_TERM: "true",
+        ...customRepositoriesEnv,
+        ...process.env
+      }
+    }
   );
   const title = `Downloading Metals v${serverVersion}`;
   trackDownloadProgress(title, outputChannel, fetchProcess).then(
@@ -370,7 +376,9 @@ function launchMetals(
     });
 
     window.onDidChangeWindowState(windowState => {
-      client.sendNotification(MetalsWindowStateDidChange.type, { focused: windowState.focused })
+      client.sendNotification(MetalsWindowStateDidChange.type, {
+        focused: windowState.focused
+      });
     });
 
     client.onRequest(MetalsInputBox.type, (options, requestToken) => {
@@ -488,6 +496,11 @@ function enableScaladocIndentation() {
         beforeText: /^\s*\/\*\*(?!\/)([^\*]|\*(?!\/))*$/,
         afterText: /^\s*\*\/$/,
         action: { indentAction: IndentAction.IndentOutdent, appendText: " * " }
+      },
+      {
+        // e.g. |
+        beforeText: /^(\s*\|.*|.*"""\|)$/,
+        action: { indentAction: IndentAction.Indent, appendText: "|" }
       },
       {
         // e.g. /** ...|


### PR DESCRIPTION
I finally got annoyed when adding new tests and came up with a working(?) solution for automatically adding `|`

This will not break when using `|` as an operator since we require either only `\s` before or `"""|` and we can't get just the operator without anything on the left.

![working](https://user-images.githubusercontent.com/3807253/59799653-0fb1fe00-92e5-11e9-90b6-0e8c2f073254.gif)

The only problem I have is when doing enter after `"""|` indentation doesn't go all the way up to where it should. Any ideas? Thoughts?

![problem](https://user-images.githubusercontent.com/3807253/59799663-16407580-92e5-11e9-8733-bf9c36cdecf1.gif)

There are two formatting changes that came up probably because I installed prettifier.

Side note: I learned to make GIFs! Was actually pretty easy :D