### PR TITLE
Client command registration fix

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -330,8 +330,9 @@ function launchMetals(
         }
       }
     };
-    Object.entries(clientCommands).forEach(([name, command]) =>
-      registerCommand(name, command)
+    Object.entries(clientCommands).forEach(([name, command]) => {
+      registerCommand((ClientCommands as any)[name], command)
+    }
     );
 
     // Handle the metals/executeClientCommand extension notification.


### PR DESCRIPTION
Registration is using `ClientCommands` keys instead of names which leads to an error message when clicking on  compilation status (specifically `metals-diagnostics-focus`)