### PR TITLE
stop inserting pipes when editing scala files

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -601,11 +601,6 @@ function enableScaladocIndentation() {
         action: { indentAction: IndentAction.IndentOutdent, appendText: " * " }
       },
       {
-        // e.g. |
-        beforeText: /^(\s*\|.*|.*"""\|)$/,
-        action: { indentAction: IndentAction.Indent, appendText: "|" }
-      },
-      {
         // e.g. /** ...|
         beforeText: /^\s*\/\*\*(?!\/)([^\*]|\*(?!\/))*$/,
         action: { indentAction: IndentAction.None, appendText: " * " }


### PR DESCRIPTION
Previously, we were inserting pipes in multiline string using the vscode extension. Now, after https://github.com/scalameta/metals/issues/859, metals is providing necessary text edits via onTypeFormatting endpoint.

This reverts changes from #121. 