### PR TITLE
Add debugging provider to client capabilities.

### DIFF
--- a/src/MetalsFeatures.ts
+++ b/src/MetalsFeatures.ts
@@ -16,6 +16,7 @@ export class MetalsFeatures implements StaticFeature {
       params.capabilities.experimental = {};
     }
     params.capabilities.experimental.treeViewProvider = true;
+    params.capabilities.experimental.debuggingProvider = true;
   }
   fillClientCapabilities(): void {}
   initialize(capabilities: ServerCapabilities): void {


### PR DESCRIPTION
Previously, it was not possible for the Metals server to know if the LSP
client supported debugging. This meant that "run" and "test" code lenses
appeared even for clients that don't support debugging.

Now, the VS Code client communicates to Metals that it supports
debugging so that Metals can disable code lenses for other clients.