### PR TITLE
Un-revert Debug Adapter Protocol changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -211,7 +211,16 @@
           "when": "metals:enabled"
         }
       ]
-    }
+    },
+    "debuggers": [
+      {
+        "type": "scala",
+        "label": "Scala Debugger",
+        "languages": [
+          "scala"
+        ]
+      }
+    ]
   },
   "main": "./out/extension",
   "scripts": {

--- a/src/MetalsFeatures.ts
+++ b/src/MetalsFeatures.ts
@@ -13,6 +13,7 @@ export class MetalsFeatures implements StaticFeature {
       params.capabilities.experimental = {};
     }
     params.capabilities.experimental.treeViewProvider = true;
+    params.capabilities.experimental.debuggingProvider = true;
   }
   fillClientCapabilities(): void {}
   initialize(capabilities: ServerCapabilities): void {

--- a/src/MetalsFeatures.ts
+++ b/src/MetalsFeatures.ts
@@ -5,9 +5,12 @@ import {
 } from "vscode-languageclient";
 
 export interface TreeViewProvider {}
+export interface DebuggingProvider {}
 
 export class MetalsFeatures implements StaticFeature {
   treeViewProvider?: TreeViewProvider;
+  debuggingProvider?: DebuggingProvider;
+
   fillInitializeParams(params: InitializeParams): void {
     if (!params.capabilities.experimental) {
       params.capabilities.experimental = {};
@@ -19,6 +22,7 @@ export class MetalsFeatures implements StaticFeature {
   initialize(capabilities: ServerCapabilities): void {
     if (capabilities.experimental) {
       this.treeViewProvider = capabilities.experimental.treeViewProvider;
+      this.debuggingProvider = capabilities.experimental.debuggingProvider;
     }
   }
 }

--- a/src/client-commands.ts
+++ b/src/client-commands.ts
@@ -4,5 +4,6 @@
 export const ClientCommands = {
   toggleLogs: "metals-logs-toggle",
   focusDiagnostics: "metals-diagnostics-focus",
-  runDoctor: "metals-doctor-run"
+  runDoctor: "metals-doctor-run",
+  startDebugSession: "metals-debug-session-start"
 };

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,6 +7,9 @@ import {
   ExtensionContext,
   window,
   commands,
+  CodeLens,
+  CodeLensProvider,
+  EventEmitter,
   StatusBarAlignment,
   ProgressLocation,
   IndentAction,
@@ -19,6 +22,7 @@ import {
   Uri,
   Range,
   Selection,
+  TextDocument as VscodeTextDocument,
   TextEditorRevealType,
   TextEditor
 } from "vscode";
@@ -53,6 +57,7 @@ import { getJavaOptions } from "./getJavaOptions";
 import { startTreeView } from "./treeview";
 import { MetalsFeatures } from "./MetalsFeatures";
 import { MetalsTreeViewReveal, MetalsTreeViews } from "./tree-view-protocol";
+import * as scalaDebugger from "./scalaDebugger";
 
 const outputChannel = window.createOutputChannel("Metals");
 const openSettingsAction = "Open settings";
@@ -329,10 +334,38 @@ function launchMetals(
           client.outputChannel.show(true);
           channelOpen = true;
         }
+      },
+      startDebugSession: args => {
+        if (!features.debuggingProvider) return;
+
+        scalaDebugger.start(args).then(wasStarted => {
+          if (!wasStarted) {
+            window.showErrorMessage("Debug session not started");
+          }
+        });
       }
     };
     Object.entries(clientCommands).forEach(([name, command]) =>
       registerCommand(name, command)
+    );
+
+    // should be the compilation of a currently opened file
+    // but some race conditions may apply
+    let compilationDoneEmitter = new EventEmitter<void>();
+
+    let codeLensRefresher: CodeLensProvider = {
+      onDidChangeCodeLenses: compilationDoneEmitter.event,
+      provideCodeLenses: (
+        document: VscodeTextDocument,
+        token: CancellationToken
+      ) => undefined,
+      resolveCodeLens: (codeLens: CodeLens, token: CancellationToken) =>
+        undefined
+    };
+
+    languages.registerCodeLensProvider(
+      { scheme: "file", language: "scala" },
+      codeLensRefresher
     );
 
     // Handle the metals/executeClientCommand extension notification.
@@ -367,6 +400,9 @@ function launchMetals(
                   editor.revealRange(range, TextEditorRevealType.InCenter);
                 });
             }
+            break;
+          case "metals-model-refresh":
+            compilationDoneEmitter.fire();
             break;
           default:
             outputChannel.appendLine(`unknown command: ${params.command}`);
@@ -539,6 +575,14 @@ function launchMetals(
       );
       treeViews = startTreeView(client, outputChannel, context, viewIds);
       context.subscriptions.concat(treeViews.disposables);
+    }
+    if (features.debuggingProvider) {
+      scalaDebugger
+        .initialize(outputChannel)
+        .forEach(disposable => context.subscriptions.push(disposable));
+      registerCommand(scalaDebugger.startSessionCommand, scalaDebugger.start);
+    } else {
+      outputChannel.appendLine("Debugging Scala sources is not supported");
     }
   });
 }

--- a/src/scalaDebugger.ts
+++ b/src/scalaDebugger.ts
@@ -1,0 +1,65 @@
+import * as vscode from "vscode";
+import {
+  CancellationToken,
+  DebugConfiguration,
+  Disposable,
+  ProviderResult,
+  WorkspaceFolder
+} from "vscode";
+
+export const startAdapterCommand = "debug-adapter-start";
+export const startSessionCommand = "metals-debug-session-start";
+const configurationType = "scala";
+
+export function initialize(outputChannel: vscode.OutputChannel): Disposable[] {
+  outputChannel.appendLine("Initializing Scala Debugger");
+  return [
+    vscode.debug.registerDebugConfigurationProvider(
+      configurationType,
+      new ScalaConfigProvider()
+    )
+  ];
+}
+
+export async function start(parameters: any): Promise<Boolean> {
+  return vscode.commands
+    .executeCommand<DebugSession>(startAdapterCommand, parameters)
+    .then(response => {
+      if (response === undefined) return false;
+
+      const debugServer = vscode.Uri.parse(response.uri);
+      const segments = debugServer.authority.split(":");
+      const port = parseInt(segments[segments.length - 1]);
+
+      const configuration: vscode.DebugConfiguration = {
+        type: configurationType,
+        name: response.name,
+        request: "launch",
+        debugServer: port // note: MUST be a number. vscode magic - automatically connects to the server
+      };
+
+      return vscode.debug.startDebugging(undefined, configuration);
+    });
+}
+
+class ScalaConfigProvider implements vscode.DebugConfigurationProvider {
+  provideDebugConfigurations(
+    folder: WorkspaceFolder | undefined,
+    token?: CancellationToken
+  ): ProviderResult<DebugConfiguration[]> {
+    return [];
+  }
+
+  resolveDebugConfiguration(
+    folder: WorkspaceFolder | undefined,
+    debugConfiguration: DebugConfiguration,
+    token?: CancellationToken
+  ): ProviderResult<DebugConfiguration> {
+    return debugConfiguration;
+  }
+}
+
+export interface DebugSession {
+  name: string;
+  uri: string;
+}


### PR DESCRIPTION
It would be great to have a new release with these changes included so users can try out the new run/test support in the latest Metals SNAPSHOTs.