### PR TITLE
Refine Java Home detection

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -68,11 +68,12 @@ export async function activate(context: ExtensionContext) {
   detectLaunchConfigurationChanges();
   checkServerVersion();
 
-  getJavaHome()
+  getJavaHome(outputChannel)
     .then(javaHome => fetchAndLaunchMetals(context, javaHome))
     .catch(err => {
       const message =
-        "Unable to find Java 8 home. To fix this problem, update the 'Java Home' setting to point to a Java 8 home directory";
+        "Unable to find a Java 8 or Java 11 installation on this computer. " +
+        "To fix this problem, update the 'Java Home' setting to point to a Java 8 or Java 11 home directory";
       outputChannel.appendLine(message);
       outputChannel.appendLine(err);
       window.showErrorMessage(message, openSettingsAction).then(choice => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -68,7 +68,7 @@ export async function activate(context: ExtensionContext) {
   detectLaunchConfigurationChanges();
   checkServerVersion();
 
-  getJavaHome(outputChannel)
+  getJavaHome()
     .then(javaHome => fetchAndLaunchMetals(context, javaHome))
     .catch(err => {
       const message =

--- a/src/getJavaHome.ts
+++ b/src/getJavaHome.ts
@@ -1,8 +1,8 @@
 import locateJavaHome from "locate-java-home";
-import { workspace, OutputChannel } from "vscode";
+import { workspace } from "vscode";
 import * as semver from "semver";
 
-export function getJavaHome(out: OutputChannel): Promise<string> {
+export function getJavaHome(): Promise<string> {
   const userJavaHome = workspace.getConfiguration("metals").get("javaHome");
   if (typeof userJavaHome === "string" && userJavaHome.trim() !== "") {
     return Promise.resolve(userJavaHome);

--- a/src/getJavaHome.ts
+++ b/src/getJavaHome.ts
@@ -1,30 +1,37 @@
 import locateJavaHome from "locate-java-home";
-import { workspace } from "vscode";
+import { workspace, OutputChannel } from "vscode";
+import * as semver from "semver";
 
-export function getJavaHome(): Promise<string> {
+export function getJavaHome(out: OutputChannel): Promise<string> {
   const userJavaHome = workspace.getConfiguration("metals").get("javaHome");
   if (typeof userJavaHome === "string" && userJavaHome.trim() !== "") {
     return Promise.resolve(userJavaHome);
   } else {
-    return new Promise((resolve, reject) => {
-      locateJavaHome({ version: "1.8" }, (err, javaHomes) => {
-        if (err) {
-          reject(err);
-        } else if (!javaHomes || javaHomes.length === 0) {
-          reject(new Error("No suitable Java version found"));
-        } else {
-          // Sort by reverse security number so the highest number comes first.
-          javaHomes.sort((a, b) => {
-            return b.security - a.security;
-          });
-          const jdkHome = javaHomes.find(j => j.isJDK);
-          if (jdkHome) {
-            resolve(jdkHome.path);
+    const JAVA_HOME = process.env["JAVA_HOME"];
+    if (JAVA_HOME) return Promise.resolve(JAVA_HOME);
+    else {
+      return new Promise((resolve, reject) => {
+        locateJavaHome({ version: ">=1.8 <=1.11" }, (err, javaHomes) => {
+          if (err) {
+            reject(err);
+          } else if (!javaHomes || javaHomes.length === 0) {
+            reject(new Error("No suitable Java version found"));
           } else {
-            resolve(javaHomes[0].path);
+            // Sort by reverse security number so the highest number comes first.
+            javaHomes.sort((a, b) => {
+              const byVersion = -semver.compare(a.version, b.version);
+              if (byVersion === 0) return b.security - a.security;
+              else return byVersion;
+            });
+            const jdkHome = javaHomes.find(j => j.isJDK);
+            if (jdkHome) {
+              resolve(jdkHome.path);
+            } else {
+              resolve(javaHomes[0].path);
+            }
           }
-        }
+        });
       });
-    });
+    }
   }
 }


### PR DESCRIPTION
First change: respect JAVA_HOME evironment variable, if defined.

The Metals website says that by default we try to use the `$JAVA_HOME`
environment variable while in reality we don't. This commit changes the
Java Home detection to work like it's explained in the documentation.

For people who start VS Code as a GUI application (not launched via
`code` command in the terminal) this change mostly likely won't have
an impact since environment variables that are defined in
`~/.bash_profile` and `~/.zshrc` are not set in GUI processes.

Second change: fallback to any Java 8 or Java 11 installation that's
available on the computer.  Previously, the VS Code extension failed to
launch on computers that only have Java 11 installed. Now, the VS Code
extension uses the most recent Java installation that's available that's
1.8 or higher and 1.11 or lower.

Sadly, the second fallback doesn't support Jabba installed JDKs but we
can maybe improve on that in the future.

Fixes https://github.com/scalameta/metals/issues/762