### PR TITLE
Add automatic JDK installation via Jabba

### DIFF
--- a/package.json
+++ b/package.json
@@ -243,14 +243,17 @@
     "vscode:publish": "vsce publish --yarn"
   },
   "devDependencies": {
+    "@types/mkdirp": "^0.5.2",
     "@types/node": "^8.10.25",
     "@types/semver": "^5.5.0",
+    "@types/request": "^2.48.3",
     "@types/shell-quote": "^1.6.1",
     "typescript": "^3.2.2",
     "vsce": "^1.54.0"
   },
   "dependencies": {
     "metals-languageclient": "^0.1.6",
+    "locate-java-home": "^1.1.2",
     "promisify-child-process": "3.1.0",
     "semver": "^5.6.0",
     "vscode": "^1.1.34",

--- a/src/jdkInstaller.ts
+++ b/src/jdkInstaller.ts
@@ -1,0 +1,97 @@
+import * as path from "path";
+import * as request from "request";
+import * as fs from "fs";
+import * as mkdirp from "mkdirp";
+import * as pcp from "promisify-child-process";
+import { OutputChannel } from "vscode";
+
+export class JdkInstaller {
+  out: OutputChannel;
+
+  homedir = require("os").homedir();
+  bin = path.join(this.homedir, "bin");
+
+  constructor(out: OutputChannel) {
+    this.out = out;
+  }
+
+  installJava(javaVersion: string, jabbaVersion: string) {
+    const jabbaUrl = `https://github.com/shyiko/jabba/releases/download/${jabbaVersion}/jabba-${jabbaVersion}-${this.jabbaUrlSuffix()}`;
+    const jabba = path.join(this.bin, this.jabbaName());
+    return new Promise<void>((res, rej) => {
+      mkdirp(this.bin, (err, made) => {
+        if (err) {
+          const msg = `${err} ${made}`;
+          console.log(msg);
+          this.out.appendLine(msg);
+          rej(err);
+        } else res();
+      });
+    }).then(() =>
+      this.curl(jabbaUrl, jabba, true)
+        .then(pth => pcp.exec(`${jabba} ls-remote`))
+        .then(out =>
+          this.outputToString(out.stdout)
+            .split("\n")
+            .filter((str, i, arr) => str.includes(javaVersion))[0]
+            .trim()
+        )
+        .then(java => {
+          this.out.appendLine(`Installing ${java}`);
+          const jabbaSpawn = pcp.spawn(`${jabba}`, ["install", java], {});
+          jabbaSpawn.stdout.on("data", this.out.append);
+          jabbaSpawn.stderr.on("data", this.out.append);
+
+          return jabbaSpawn
+            .then(() => this.out.appendLine(`${java} installed`))
+            .then(() => pcp.exec(`${jabba} which --home ${java}`))
+            .then((e: pcp.Output) => this.outputToString(e.stdout).trim());
+        })
+    );
+  }
+
+  private jabbaUrlSuffix(): string {
+    const runnerOs = process.platform;
+    switch (runnerOs.toLowerCase()) {
+      case "linux":
+        return "linux-amd64";
+      case "darwin":
+        return "darwin-amd64";
+      case "win32":
+        return "windows-amd64.exe";
+      default:
+        throw new Error(
+          `unknown runner OS: ${runnerOs}, expected one of Linux, macOS or Windows.`
+        );
+    }
+  }
+
+  private isWindows(): boolean {
+    return process.platform === "win32";
+  }
+
+  private jabbaName(): string {
+    if (this.isWindows()) return "jabba.exe";
+    else return "jabba";
+  }
+
+  private curl(url: string, outputFile: string, exec?: boolean) {
+    return new Promise<string>((res, rej) => {
+      request
+        .get(url)
+        .pipe(fs.createWriteStream(outputFile))
+        .on("close", () => {
+          if (exec) fs.chmodSync(outputFile, 755);
+          res(outputFile);
+        })
+        .on("error", err => rej(err));
+    });
+  }
+
+  private outputToString(
+    out: Buffer | string | null | undefined,
+    enc: string = "utf-8"
+  ) {
+    return out instanceof Buffer ? out.toString(enc) : out ? <string>out : "";
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -9,6 +9,18 @@
   dependencies:
     regenerator-runtime "^0.12.0"
 
+"@types/caseless@*":
+  version "0.12.2"
+  resolved "https://registry.yarnpkg.com/@types/caseless/-/caseless-0.12.2.tgz#f65d3d6389e01eeb458bd54dc8f52b95a9463bc8"
+  integrity sha512-6ckxMjBBD8URvjB6J3NcnuAn5Pkl7t3TizAg+xdlzzQGSPSmBcXf8KoIH0ua/i+tio+ZRUHEXp0HEmvaR4kt0w==
+
+"@types/mkdirp@^0.5.2":
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/@types/mkdirp/-/mkdirp-0.5.2.tgz#503aacfe5cc2703d5484326b1b27efa67a339c1f"
+  integrity sha512-U5icWpv7YnZYGsN4/cmh3WD2onMY0aJIiTE6+51TwJCttdHvtCYmkBNOobHlXwrJRL0nkH9jH4kD+1FAdMN4Tg==
+  dependencies:
+    "@types/node" "*"
+
 "@types/node@*":
   version "10.12.12"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.12.12.tgz#e15a9d034d9210f00320ef718a50c4a799417c47"
@@ -19,6 +31,16 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-8.10.38.tgz#e05c201a668492e534b48102aca0294898f449f6"
   integrity sha512-EibsnbJerd0hBFaDjJStFrVbVBAtOy4dgL8zZFw0uOvPqzBAX59Ci8cgjg3+RgJIWhsB5A4c+pi+D4P9tQQh/A==
 
+"@types/request@^2.48.3":
+  version "2.48.4"
+  resolved "https://registry.yarnpkg.com/@types/request/-/request-2.48.4.tgz#df3d43d7b9ed3550feaa1286c6eabf0738e6cf7e"
+  integrity sha512-W1t1MTKYR8PxICH+A4HgEIPuAC3sbljoEVfyZbeFJJDbr30guDspJri2XOaM2E+Un7ZjrihaDi7cf6fPa2tbgw==
+  dependencies:
+    "@types/caseless" "*"
+    "@types/node" "*"
+    "@types/tough-cookie" "*"
+    form-data "^2.5.0"
+
 "@types/semver@^5.5.0":
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/@types/semver/-/semver-5.5.0.tgz#146c2a29ee7d3bae4bf2fcb274636e264c813c45"
@@ -28,6 +50,11 @@
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/@types/shell-quote/-/shell-quote-1.6.1.tgz#eed0cd93ac3628427d7b44c4550f854f9400e39f"
   integrity sha512-t0bxRLQ75MMF7EeICa1eYC//o1/6gPaUV7ELke4l4OkwpZ9apOzvv2oR5F2PmQJ3tM83Lo+MNKfAXn5gQRMcnA==
+
+"@types/tough-cookie@*":
+  version "2.3.6"
+  resolved "https://registry.yarnpkg.com/@types/tough-cookie/-/tough-cookie-2.3.6.tgz#c880579e087d7a0db13777ff8af689f4ffc7b0d5"
+  integrity sha512-wHNBMnkoEBiRAd3s8KTKwIuO9biFtTf0LehITzBhSco+HQI0xkXZbLOD55SW3Aqw3oUkHstkm5SPv58yaAdFPQ==
 
 agent-base@4, agent-base@^4.1.0:
   version "4.3.0"
@@ -329,6 +356,15 @@ forever-agent@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
   integrity sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=
+
+form-data@^2.5.0:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.5.1.tgz#f2cbec57b5e59e23716e128fe44d4e5dd23895f4"
+  integrity sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.6"
+    mime-types "^2.1.12"
 
 form-data@~2.3.2:
   version "2.3.3"


### PR DESCRIPTION
Previously, the VS Code extension would fail with an error message when it was unable to find a valid Java installation on the computer. Now, the extension asks the user to automatically install Java version via Jabba (https://github.com/shyiko/jabba) when there is no valid Java installation on the computer or if there's only Java 9.