### PR TITLE
Add formatOnPaste and formatOnType defaults for Scala files

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,9 @@
   "contributes": {
     "configurationDefaults": {
       "[scala]": {
-        "editor.suggestSelection": "first"
+        "editor.suggestSelection": "first",
+        "editor.formatOnPaste": true,
+        "editor.formatOnType": true
       }
     },
     "viewsContainers": {


### PR DESCRIPTION
Closes #163 

Previously, users had to manually enable `formatOnType` and `formatOnPaste` for the auto-insertion of `|` in multi-line strings to work. Now we automatically set those settings to `true` for the Scala language (this includes `.scala`, `.sc` and `.sbt` files currently)