### PR TITLE
Enable setting breakpoints in java and scala files

### DIFF
--- a/package.json
+++ b/package.json
@@ -214,6 +214,14 @@
         }
       ]
     },
+    "breakpoints": [
+      {
+        "language": "scala"
+      },
+      {
+        "language": "java"
+      }
+    ],
     "debuggers": [
       {
         "type": "scala",


### PR DESCRIPTION
Previously, metals didn't allow the user to set breakpoints in any file. Now, they can be set in any java or scala file.