### PR TITLE
Support StartRunSession command

### DIFF
--- a/src/client-commands.ts
+++ b/src/client-commands.ts
@@ -5,5 +5,6 @@ export const ClientCommands = {
   toggleLogs: "metals-logs-toggle",
   focusDiagnostics: "metals-diagnostics-focus",
   runDoctor: "metals-doctor-run",
-  startDebugSession: "metals-debug-session-start"
+  startDebugSession: "metals-debug-session-start",
+  startRunSession: "metals-run-session-start"
 };

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -353,12 +353,21 @@ function launchMetals(
           channelOpen = true;
         }
       },
-      startDebugSession: args => {
+      startDebugSession: (...args) => {
         if (!features.debuggingProvider) return;
 
-        scalaDebugger.start(args).then(wasStarted => {
+        scalaDebugger.start(true, ...args).then(wasStarted => {
           if (!wasStarted) {
             window.showErrorMessage("Debug session not started");
+          }
+        });
+      },
+      startRunSession: (...args) => {
+        if (!features.debuggingProvider) return;
+
+        scalaDebugger.start(false, ...args).then(wasStarted => {
+          if (!wasStarted) {
+            window.showErrorMessage("Run session not started");
           }
         });
       }

--- a/src/scalaDebugger.ts
+++ b/src/scalaDebugger.ts
@@ -20,9 +20,9 @@ export function initialize(outputChannel: vscode.OutputChannel): Disposable[] {
   ];
 }
 
-export async function start(parameters: any): Promise<Boolean> {
+export async function start(noDebug: Boolean, ...parameters: any[]): Promise<Boolean> {
   return vscode.commands
-    .executeCommand<DebugSession>(startAdapterCommand, parameters)
+    .executeCommand<DebugSession>(startAdapterCommand, ...parameters)
     .then(response => {
       if (response === undefined) return false;
 
@@ -33,6 +33,7 @@ export async function start(parameters: any): Promise<Boolean> {
       const configuration: vscode.DebugConfiguration = {
         type: configurationType,
         name: response.name,
+        noDebug: noDebug,
         request: "launch",
         debugServer: port // note: MUST be a number. vscode magic - automatically connects to the server
       };


### PR DESCRIPTION
Previously, there was no way to start a run session - only debug sessions were supported.
Now, StartRunSession (added in https://github.com/scalameta/metals/pull/1200) is also supported. 