### PR TITLE
Fix inverted meaning of run/debug commands

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -356,7 +356,7 @@ function launchMetals(
       startDebugSession: (...args) => {
         if (!features.debuggingProvider) return;
 
-        scalaDebugger.start(true, ...args).then(wasStarted => {
+        scalaDebugger.start(false, ...args).then(wasStarted => {
           if (!wasStarted) {
             window.showErrorMessage("Debug session not started");
           }
@@ -365,7 +365,7 @@ function launchMetals(
       startRunSession: (...args) => {
         if (!features.debuggingProvider) return;
 
-        scalaDebugger.start(false, ...args).then(wasStarted => {
+        scalaDebugger.start(true, ...args).then(wasStarted => {
           if (!wasStarted) {
             window.showErrorMessage("Run session not started");
           }


### PR DESCRIPTION
Previously, the breakpoints were ignored when handling the `startDebugSession` and respected for the `startRunSession` while it should be the other way around.

The culprit is the negated parameter `noDebug` but that is how the DAP expects it to be so I think it should stay that way.

Originally reported in https://github.com/scalameta/metals/issues/1296