### PR TITLE
Add missing bloop restart command and settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,6 +120,14 @@
           "type": "string",
           "markdownDescription": "Optional custom path to the .scalafmt.conf file.\n\nShould be relative to the workspace root directory and use forward slashes `/` for file separators (even on Windows)."
         },
+        "metals.bloopVersion": {
+          "type": "string",
+          "markdownDescription": "This version will be used for the Bloop build tool plugin, for any supported build tool,while importing in Metals as well as for running the embedded server"
+        },
+        "metals.bloopSbtAlreadyInstalled": {
+          "type": "boolean",
+          "markdownDescription": "If true, Metals will not generate a `project/metals.sbt` file under the assumption that sbt-bloop is already manually installed in the sbt build. Build import will fail with a 'not valid command bloopInstall' error in case Bloop is not manually installed in the build when using this option."
+        },
         "metals.customRepositories": {
           "type": "array",
           "items": {
@@ -143,6 +151,11 @@
         "command": "metals.restartServer",
         "category": "Metals",
         "title": "Restart server"
+      },
+      {
+        "command": "metals.build-restart",
+        "category": "Metals",
+        "title": "Restart Bloop server"
       },
       {
         "command": "metals.build-import",
@@ -190,6 +203,10 @@
         },
         {
           "command": "metals.build-import",
+          "when": "metals:enabled"
+        },
+        {
+          "command": "metals.build-restart",
           "when": "metals:enabled"
         },
         {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -159,7 +159,7 @@ function fetchAndLaunchMetals(context: ExtensionContext, javaHome: string) {
   if (dottyIde.enabled) {
     outputChannel.appendLine(
       `Metals will not start since Dotty is enabled for this workspace. ` +
-        `To enable Metals, remove the file ${dottyIde} and run 'Reload window'`
+        `To enable Metals, remove the file ${dottyIde.path} and run 'Reload window'`
     );
     return;
   }
@@ -308,6 +308,7 @@ function launchMetals(
     }
     [
       "build-import",
+      "build-restart",
       "build-connect",
       "sources-scan",
       "doctor-run",


### PR DESCRIPTION
Recently there was a new command added to restart the build server plus two new options for working with Bloop.