### PR TITLE
use checkoutv2 push rather than github-push-action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,9 +34,7 @@ jobs:
           git add .
           git commit -m "v${{ steps.get_version.outputs.NEW_VERSION }}"
       - name: Push changes
-        uses: ad-m/github-push-action@master
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+        run: git push origin HEAD:master
       - name: Publish extension
         run: yarn vscode:publish -p ${{ secrets.VS_MARKETPLACE_TOKEN }}
       - name: Build VSIX package


### PR DESCRIPTION
Since we are using checkout/v2, we can just use `push` since it cache's the auth token allowing other authenticated git commands to work. I just put this in https://github.com/scalameta/coc-metals/pull/65 and also ran a dummy test [here in a sandbox](https://github.com/ckipp01/actions-sandbox/runs/427437512?check_suite_focus=true) to ensure that it indeed works.