### PR TITLE
Add in clientExperimentalCapabilities from old property settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -252,7 +252,7 @@
     "vsce": "^1.54.0"
   },
   "dependencies": {
-    "metals-languageclient": "0.1.17",
+    "metals-languageclient": "0.1.19",
     "promisify-child-process": "3.1.3",
     "vscode": "^1.1.36",
     "vscode-languageclient": "^6.1.0"

--- a/src/MetalsFeatures.ts
+++ b/src/MetalsFeatures.ts
@@ -10,6 +10,7 @@ export interface DecorationProvider {}
 export interface InputBoxProvider {}
 export interface DidFocusProvider {}
 export interface SlowTaskProvider {}
+export interface ExecuteClientCommandProvider {}
 
 export class MetalsFeatures implements StaticFeature {
   treeViewProvider?: TreeViewProvider;
@@ -18,6 +19,7 @@ export class MetalsFeatures implements StaticFeature {
   inputBoxProvider?: InputBoxProvider;
   didFocusProvider?: DidFocusProvider;
   slowTaskProvider?: SlowTaskProvider;
+  executeClientCommandProvider?: ExecuteClientCommandProvider;
 
   fillInitializeParams(params: InitializeParams): void {
     if (!params.capabilities.experimental) {
@@ -29,6 +31,8 @@ export class MetalsFeatures implements StaticFeature {
     (params.capabilities.experimental as any).inputBoxProvider = true;
     (params.capabilities.experimental as any).didFocusProvider = true;
     (params.capabilities.experimental as any).slowTaskProvider = true;
+    (params.capabilities
+      .experimental as any).executeClientCommandProvider = true;
   }
   fillClientCapabilities(): void {}
   initialize(capabilities: ServerCapabilities): void {
@@ -39,6 +43,8 @@ export class MetalsFeatures implements StaticFeature {
       this.inputBoxProvider = capabilities.experimental.inputBoxProvider;
       this.didFocusProvider = capabilities.experimental.didFocusProvider;
       this.slowTaskProvider = capabilities.experimental.slowTaskProvider;
+      this.executeClientCommandProvider =
+        capabilities.experimental.executeClientCommandProvider;
     }
   }
 }

--- a/src/MetalsFeatures.ts
+++ b/src/MetalsFeatures.ts
@@ -9,6 +9,7 @@ export interface DebuggingProvider {}
 export interface DecorationProvider {}
 export interface InputBoxProvider {}
 export interface DidFocusProvider {}
+export interface SlowTaskProvider {}
 
 export class MetalsFeatures implements StaticFeature {
   treeViewProvider?: TreeViewProvider;
@@ -16,6 +17,7 @@ export class MetalsFeatures implements StaticFeature {
   decorationProvider?: DecorationProvider;
   inputBoxProvider?: InputBoxProvider;
   didFocusProvider?: DidFocusProvider;
+  slowTaskProvider?: SlowTaskProvider;
 
   fillInitializeParams(params: InitializeParams): void {
     if (!params.capabilities.experimental) {
@@ -26,6 +28,7 @@ export class MetalsFeatures implements StaticFeature {
     (params.capabilities.experimental as any).decorationProvider = true;
     (params.capabilities.experimental as any).inputBoxProvider = true;
     (params.capabilities.experimental as any).didFocusProvider = true;
+    (params.capabilities.experimental as any).slowTaskProvider = true;
   }
   fillClientCapabilities(): void {}
   initialize(capabilities: ServerCapabilities): void {
@@ -35,6 +38,7 @@ export class MetalsFeatures implements StaticFeature {
       this.decorationProvider = capabilities.experimental.decorationProvider;
       this.inputBoxProvider = capabilities.experimental.inputBoxProvider;
       this.didFocusProvider = capabilities.experimental.didFocusProvider;
+      this.slowTaskProvider = capabilities.experimental.slowTaskProvider;
     }
   }
 }

--- a/src/MetalsFeatures.ts
+++ b/src/MetalsFeatures.ts
@@ -12,6 +12,7 @@ export interface DidFocusProvider {}
 export interface SlowTaskProvider {}
 export interface ExecuteClientCommandProvider {}
 export interface DoctorProvider {}
+export interface StatusBarProvider {}
 
 export class MetalsFeatures implements StaticFeature {
   treeViewProvider?: TreeViewProvider;
@@ -22,6 +23,7 @@ export class MetalsFeatures implements StaticFeature {
   slowTaskProvider?: SlowTaskProvider;
   executeClientCommandProvider?: ExecuteClientCommandProvider;
   doctorProvider?: DoctorProvider;
+  statusBarProvider?: StatusBarProvider;
 
   fillInitializeParams(params: InitializeParams): void {
     if (!params.capabilities.experimental) {
@@ -36,6 +38,7 @@ export class MetalsFeatures implements StaticFeature {
     (params.capabilities
       .experimental as any).executeClientCommandProvider = true;
     (params.capabilities.experimental as any).doctorProvider = "html";
+    (params.capabilities.experimental as any).statusBarProvider = "on";
   }
   fillClientCapabilities(): void {}
   initialize(capabilities: ServerCapabilities): void {
@@ -49,6 +52,7 @@ export class MetalsFeatures implements StaticFeature {
       this.executeClientCommandProvider =
         capabilities.experimental.executeClientCommandProvider;
       this.doctorProvider = capabilities.experimental.doctorProvider;
+      this.statusBarProvider = capabilities.experimental.statusBarProvider;
     }
   }
 }

--- a/src/MetalsFeatures.ts
+++ b/src/MetalsFeatures.ts
@@ -11,6 +11,7 @@ export interface InputBoxProvider {}
 export interface DidFocusProvider {}
 export interface SlowTaskProvider {}
 export interface ExecuteClientCommandProvider {}
+export interface DoctorProvider {}
 
 export class MetalsFeatures implements StaticFeature {
   treeViewProvider?: TreeViewProvider;
@@ -20,6 +21,7 @@ export class MetalsFeatures implements StaticFeature {
   didFocusProvider?: DidFocusProvider;
   slowTaskProvider?: SlowTaskProvider;
   executeClientCommandProvider?: ExecuteClientCommandProvider;
+  doctorProvider?: DoctorProvider;
 
   fillInitializeParams(params: InitializeParams): void {
     if (!params.capabilities.experimental) {
@@ -33,6 +35,7 @@ export class MetalsFeatures implements StaticFeature {
     (params.capabilities.experimental as any).slowTaskProvider = true;
     (params.capabilities
       .experimental as any).executeClientCommandProvider = true;
+    (params.capabilities.experimental as any).doctorProvider = "html";
   }
   fillClientCapabilities(): void {}
   initialize(capabilities: ServerCapabilities): void {
@@ -45,6 +48,7 @@ export class MetalsFeatures implements StaticFeature {
       this.slowTaskProvider = capabilities.experimental.slowTaskProvider;
       this.executeClientCommandProvider =
         capabilities.experimental.executeClientCommandProvider;
+      this.doctorProvider = capabilities.experimental.doctorProvider;
     }
   }
 }

--- a/src/MetalsFeatures.ts
+++ b/src/MetalsFeatures.ts
@@ -7,11 +7,15 @@ import {
 export interface TreeViewProvider {}
 export interface DebuggingProvider {}
 export interface DecorationProvider {}
+export interface InputBoxProvider {}
+export interface DidFocusProvider {}
 
 export class MetalsFeatures implements StaticFeature {
   treeViewProvider?: TreeViewProvider;
   debuggingProvider?: DebuggingProvider;
   decorationProvider?: DecorationProvider;
+  inputBoxProvider?: InputBoxProvider;
+  didFocusProvider?: DidFocusProvider;
 
   fillInitializeParams(params: InitializeParams): void {
     if (!params.capabilities.experimental) {
@@ -20,6 +24,8 @@ export class MetalsFeatures implements StaticFeature {
     (params.capabilities.experimental as any).treeViewProvider = true;
     (params.capabilities.experimental as any).debuggingProvider = true;
     (params.capabilities.experimental as any).decorationProvider = true;
+    (params.capabilities.experimental as any).inputBoxProvider = true;
+    (params.capabilities.experimental as any).didFocusProvider = true;
   }
   fillClientCapabilities(): void {}
   initialize(capabilities: ServerCapabilities): void {
@@ -27,6 +33,8 @@ export class MetalsFeatures implements StaticFeature {
       this.treeViewProvider = capabilities.experimental.treeViewProvider;
       this.debuggingProvider = capabilities.experimental.debuggingProvider;
       this.decorationProvider = capabilities.experimental.decorationProvider;
+      this.inputBoxProvider = capabilities.experimental.inputBoxProvider;
+      this.didFocusProvider = capabilities.experimental.didFocusProvider;
     }
   }
 }

--- a/src/MetalsFeatures.ts
+++ b/src/MetalsFeatures.ts
@@ -13,6 +13,7 @@ export interface SlowTaskProvider {}
 export interface ExecuteClientCommandProvider {}
 export interface DoctorProvider {}
 export interface StatusBarProvider {}
+export interface OpenFilesOnRenameProvider {}
 
 export class MetalsFeatures implements StaticFeature {
   treeViewProvider?: TreeViewProvider;
@@ -24,6 +25,7 @@ export class MetalsFeatures implements StaticFeature {
   executeClientCommandProvider?: ExecuteClientCommandProvider;
   doctorProvider?: DoctorProvider;
   statusBarProvider?: StatusBarProvider;
+  openFilesOnRenameProvider?: OpenFilesOnRenameProvider;
 
   fillInitializeParams(params: InitializeParams): void {
     if (!params.capabilities.experimental) {
@@ -37,6 +39,7 @@ export class MetalsFeatures implements StaticFeature {
     (params.capabilities.experimental as any).slowTaskProvider = true;
     (params.capabilities
       .experimental as any).executeClientCommandProvider = true;
+    (params.capabilities.experimental as any).openFilesOnRenameProvider = true;
     (params.capabilities.experimental as any).doctorProvider = "html";
     (params.capabilities.experimental as any).statusBarProvider = "on";
   }
@@ -51,6 +54,8 @@ export class MetalsFeatures implements StaticFeature {
       this.slowTaskProvider = capabilities.experimental.slowTaskProvider;
       this.executeClientCommandProvider =
         capabilities.experimental.executeClientCommandProvider;
+      this.openFilesOnRenameProvider =
+        capabilities.experimental.openFilesOnRenameProvider;
       this.doctorProvider = capabilities.experimental.doctorProvider;
       this.statusBarProvider = capabilities.experimental.statusBarProvider;
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -254,8 +254,7 @@ function launchMetals(
     metalsClasspath,
     serverProperties,
     javaConfig,
-    clientName: "vscode",
-    doctorFormat: "html"
+    clientName: "vscode"
   });
 
   const clientOptions: LanguageClientOptions = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -524,10 +524,10 @@ mdurl@^1.0.1:
   resolved "https://registry.yarnpkg.com/mdurl/-/mdurl-1.0.1.tgz#fe85b2ec75a59037f2adfec100fd6c601761152e"
   integrity sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4=
 
-metals-languageclient@0.1.17:
-  version "0.1.17"
-  resolved "https://registry.yarnpkg.com/metals-languageclient/-/metals-languageclient-0.1.17.tgz#66340f991204d9d5d378014fc67224dfd4c05360"
-  integrity sha512-BsZFtWtEGSnEqlS9ICxII2CSsDBk3JreviwB5ejxF74nAlevEEuSTEyDjekRxEBBTbv6aDo/V+ac++hSbYT2dg==
+metals-languageclient@0.1.19:
+  version "0.1.19"
+  resolved "https://registry.yarnpkg.com/metals-languageclient/-/metals-languageclient-0.1.19.tgz#6eaae47103c438aec86d24e16e585c434e2d6829"
+  integrity sha512-1dWW9OLwUUSfVSHjDpsMUkuNp6dQuaBgRPJGV90Bq+6TGmZOHYK07RdCQFXCQh0Wk3HBWlTdc5wPl/Q9O3kZPw==
   dependencies:
     fp-ts "^2.4.1"
     locate-java-home "^1.1.2"


### PR DESCRIPTION
This pr will add the correct `clientExperimentalCapabilities` to the extension as we migrate certain properties away from being properties to being capabilities.

The related PR can be found here: https://github.com/scalameta/metals/pull/1414