### PR TITLE
Revert "Bump vscode-languageclient from 6.1.1 to 6.1.2"

### DIFF
--- a/package.json
+++ b/package.json
@@ -284,7 +284,7 @@
     "metals-languageclient": "0.1.20",
     "promisify-child-process": "3.1.4",
     "vscode": "^1.1.36",
-    "vscode-languageclient": "^6.1.2"
+    "vscode-languageclient": "^6.1.1"
   },
   "resolutions": {
     "vscode-jsonrpc": "^5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -975,10 +975,10 @@ vscode-jsonrpc@^4.1.0-next.2, vscode-jsonrpc@^5, vscode-jsonrpc@^5.0.1:
   resolved "https://registry.yarnpkg.com/vscode-jsonrpc/-/vscode-jsonrpc-5.0.1.tgz#9bab9c330d89f43fc8c1e8702b5c36e058a01794"
   integrity sha512-JvONPptw3GAQGXlVV2utDcHx0BiY34FupW/kI6mZ5x06ER5DdPG/tXWMVHjTNULF5uKPOUUD0SaXg5QaubJL0A==
 
-vscode-languageclient@^6.1.2:
-  version "6.1.2"
-  resolved "https://registry.yarnpkg.com/vscode-languageclient/-/vscode-languageclient-6.1.2.tgz#e12a211fbb76ffb7b3a7431e9a06eea0b743b0c5"
-  integrity sha512-jbasqsg+btvhB8AmGUyycmwZhM6ZESns5yKixffJfCVO5E5Mf++0Bl8xsGjLLpEi7fjN0NPaJY9EyiGX5ZF2zA==
+vscode-languageclient@^6.1.1:
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/vscode-languageclient/-/vscode-languageclient-6.1.1.tgz#91b62e416c5abbf2013ae3726f314a19c22a8457"
+  integrity sha512-mB6d8Tg+82l8EFUfR+SBu0+lCshyKVgC5E5+MQ0/BJa+9AgeBjtG5npoGaCo4/VvWzK0ZRGm85zU5iRp1RYPIA==
   dependencies:
     semver "^6.3.0"
     vscode-languageserver-protocol "^3.15.3"


### PR DESCRIPTION
This reverts commit 05007891ba25a753e0c3923545250597f7f39496.