### PR TITLE
Update metals-languageserver and remove resolutions

### DIFF
--- a/package.json
+++ b/package.json
@@ -281,12 +281,9 @@
     "vsce": "1.74.0"
   },
   "dependencies": {
-    "metals-languageclient": "0.1.22",
+    "metals-languageclient": "0.1.23",
     "promisify-child-process": "3.1.4",
     "vscode-languageclient": "6.1.3"
-  },
-  "resolutions": {
-    "vscode-jsonrpc": "^5"
   },
   "extensionDependencies": [
     "scala-lang.scala"

--- a/yarn.lock
+++ b/yarn.lock
@@ -292,10 +292,10 @@ mdurl@^1.0.1:
   resolved "https://registry.yarnpkg.com/mdurl/-/mdurl-1.0.1.tgz#fe85b2ec75a59037f2adfec100fd6c601761152e"
   integrity sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4=
 
-metals-languageclient@0.1.22:
-  version "0.1.22"
-  resolved "https://registry.yarnpkg.com/metals-languageclient/-/metals-languageclient-0.1.22.tgz#dd5deb6c74b9f26c16b868d1f35b64e32be02979"
-  integrity sha512-IxrgkGE5Naip8evXrL9flBOTyBkIqXtePetdUIzbiuT7pk5W11n97iJvNPPBYUP5N5VtpQq8+VU2+7Gl4/TUZg==
+metals-languageclient@0.1.23:
+  version "0.1.23"
+  resolved "https://registry.yarnpkg.com/metals-languageclient/-/metals-languageclient-0.1.23.tgz#950cc13734a72bfbcd0c091f7fbf66a14e60c3b3"
+  integrity sha512-Gi/qomdchfurnRIiEH8RjLbYZ926zJDE/acOx8xCtAx7Ai9vA49ZyJnh/BP0BNqe8VXVvPHmadmqdM+4lC7hLQ==
   dependencies:
     fp-ts "^2.4.1"
     locate-java-home "^1.1.2"
@@ -304,7 +304,7 @@ metals-languageclient@0.1.22:
     promisify-child-process "^3.1.3"
     semver "^7.1.1"
     shell-quote "^1.7.2"
-    vscode-languageserver-protocol "3.15.0-next.6"
+    vscode-languageserver-protocol "3.15.3"
 
 mime@^1.3.4:
   version "1.6.0"
@@ -542,7 +542,7 @@ vsce@1.74.0:
     yauzl "^2.3.1"
     yazl "^2.2.2"
 
-vscode-jsonrpc@^4.1.0-next.2, vscode-jsonrpc@^5, vscode-jsonrpc@^5.0.1:
+vscode-jsonrpc@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/vscode-jsonrpc/-/vscode-jsonrpc-5.0.1.tgz#9bab9c330d89f43fc8c1e8702b5c36e058a01794"
   integrity sha512-JvONPptw3GAQGXlVV2utDcHx0BiY34FupW/kI6mZ5x06ER5DdPG/tXWMVHjTNULF5uKPOUUD0SaXg5QaubJL0A==
@@ -555,15 +555,7 @@ vscode-languageclient@6.1.3:
     semver "^6.3.0"
     vscode-languageserver-protocol "^3.15.3"
 
-vscode-languageserver-protocol@3.15.0-next.6:
-  version "3.15.0-next.6"
-  resolved "https://registry.yarnpkg.com/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.15.0-next.6.tgz#a8aeb7e7dd65da8216b386db59494cdfd3215d92"
-  integrity sha512-/yDpYlWyNs26mM23mT73xmOFsh1iRfgZfBdHmfAxwDKwpQKLoOSqVidtYfxlK/pD3IEKGcAVnT4WXTsguxxAMQ==
-  dependencies:
-    vscode-jsonrpc "^4.1.0-next.2"
-    vscode-languageserver-types "^3.15.0-next.2"
-
-vscode-languageserver-protocol@^3.15.3:
+vscode-languageserver-protocol@3.15.3, vscode-languageserver-protocol@^3.15.3:
   version "3.15.3"
   resolved "https://registry.yarnpkg.com/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.15.3.tgz#3fa9a0702d742cf7883cb6182a6212fcd0a1d8bb"
   integrity sha512-zrMuwHOAQRhjDSnflWdJG+O2ztMWss8GqUUB8dXLR/FPenwkiBNkMIJJYfSN6sgskvsF0rHAoBowNQfbyZnnvw==
@@ -571,7 +563,7 @@ vscode-languageserver-protocol@^3.15.3:
     vscode-jsonrpc "^5.0.1"
     vscode-languageserver-types "3.15.1"
 
-vscode-languageserver-types@3.15.1, vscode-languageserver-types@^3.15.0-next.2:
+vscode-languageserver-types@3.15.1:
   version "3.15.1"
   resolved "https://registry.yarnpkg.com/vscode-languageserver-types/-/vscode-languageserver-types-3.15.1.tgz#17be71d78d2f6236d414f0001ce1ef4d23e6b6de"
   integrity sha512-+a9MPUQrNGRrGU630OGbYVQ+11iOIovjCkqxajPa9w57Sd5ruK8WQNsslzpa0x/QJqC8kRc2DUxWjIFwoNm4ZQ==


### PR DESCRIPTION
This pr updates the metals-languageserver for the primary purpose of being able to remove resolutions (which I needed for coc-metals 😆 ). I've built and tested locally, and everything seems to be working fine, typechecking, etc.