### PR TITLE
Downgrade types/vscode to 1.43

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "homepage": "http://metals.rocks",
   "engines": {
-    "vscode": "^1.44.0"
+    "vscode": "^1.43.0"
   },
   "icon": "images/logo.png",
   "categories": [
@@ -337,7 +337,7 @@
   "devDependencies": {
     "@types/node": "13.11.1",
     "@types/shell-quote": "1.6.1",
-    "@types/vscode": "1.44.0",
+    "@types/vscode": "1.43.0",
     "prettier": "2.0.4",
     "typescript": "3.8.3",
     "vsce": "1.75.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -19,10 +19,10 @@
   resolved "https://registry.yarnpkg.com/@types/shell-quote/-/shell-quote-1.6.1.tgz#eed0cd93ac3628427d7b44c4550f854f9400e39f"
   integrity sha512-t0bxRLQ75MMF7EeICa1eYC//o1/6gPaUV7ELke4l4OkwpZ9apOzvv2oR5F2PmQJ3tM83Lo+MNKfAXn5gQRMcnA==
 
-"@types/vscode@1.44.0":
-  version "1.44.0"
-  resolved "https://registry.yarnpkg.com/@types/vscode/-/vscode-1.44.0.tgz#62ecfe3d0e38942fce556574da54ee1013c775b7"
-  integrity sha512-WJZtZlinE3meRdH+I7wTsIhpz/GLhqEQwmPGeh4s1irWLwMzCeTV8WZ+pgPTwrDXoafVUWwo1LiZ9HJVHFlJSQ==
+"@types/vscode@1.43.0":
+  version "1.43.0"
+  resolved "https://registry.yarnpkg.com/@types/vscode/-/vscode-1.43.0.tgz#22276e60034c693b33117f1068ffaac0e89522db"
+  integrity sha512-kIaR9qzd80rJOxePKpCB/mdy00mz8Apt2QA5Y6rdrKFn13QNFNeP3Hzmsf37Bwh/3cS7QjtAeGSK7wSqAU0sYQ==
 
 ansi-styles@^3.2.1:
   version "3.2.1"


### PR DESCRIPTION
I will downgrade to 1.43 for now, since it might be a bit too fast to upgrade to 1.44 - that just go released.