### PR TITLE
Add in a trim to the server version the user provides

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -171,7 +171,7 @@ function fetchAndLaunchMetals(context: ExtensionContext, javaHome: string) {
   const defaultServerVersion = config.inspect<string>("serverVersion")!
     .defaultValue!;
   const serverVersion = serverVersionConfig
-    ? serverVersionConfig
+    ? serverVersionConfig.trim()
     : defaultServerVersion;
 
   const serverProperties = config.get<string[]>("serverProperties")!;


### PR DESCRIPTION
This pr adds in a trim to the server version provided by the user. I had a co-worker today mention that this fails if you accidentally copy in the version with a space for example. Looking at the logs, it's then hard to see what's actually happening. 

<img width="1056" alt="Screenshot 2020-04-18 at 13 15 55" src="https://user-images.githubusercontent.com/13974112/79636500-5deb9400-8178-11ea-9911-79e13b33bb89.png">
