### PR TITLE
Add a feature to create a new Project

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "Programming Languages"
   ],
   "activationEvents": [
+    "onCommand:metals.new-scala-project-activate",
     "onLanguage:scala",
     "workspaceContains:build.sbt",
     "workspaceContains:build.sc",
@@ -65,6 +66,18 @@
         }
       ]
     },
+    "viewsWelcome": [
+      {
+        "view": "metalsPackages",
+        "contents": "No Scala project found.\n[New Scala project](command:metals.new-scala-project-activate)",
+        "when": "!metals:enabled"
+      },
+      {
+        "view": "metalsPackages",
+        "contents": "No Scala project found.\n[New Scala project](command:metals.new-scala-project)",
+        "when": "metals:enabled && metals:no-build-tool"
+      }
+    ],
     "views": {
       "metals-explorer": [
         {
@@ -202,6 +215,11 @@
         "title": "Run doctor"
       },
       {
+        "command": "metals.new-scala-project",
+        "category": "Metals",
+        "title": "New Scala Project"
+      },
+      {
         "command": "metals.new-scala-file",
         "category": "Metals",
         "title": "New Scala File..."
@@ -268,6 +286,10 @@
         },
         {
           "command": "metals.new-scala-file",
+          "when": "metals:enabled"
+        },
+        {
+          "command": "metals.new-scala-project",
           "when": "metals:enabled"
         },
         {

--- a/package.json
+++ b/package.json
@@ -42,12 +42,15 @@
     "Programming Languages"
   ],
   "activationEvents": [
-    "onCommand:metals.new-scala-project-activate",
+    "onCommand:metals.new-scala-project",
+    "onDebugResolve:scala",
     "onLanguage:scala",
     "workspaceContains:build.sbt",
     "workspaceContains:build.sc",
     "workspaceContains:project/build.properties",
-    "workspaceContains:**/scala/**"
+    "workspaceContains:src/main/scala",
+    "workspaceContains:*/src/main/scala",
+    "workspaceContains:*/*/src/main/scala"
   ],
   "contributes": {
     "configurationDefaults": {
@@ -69,13 +72,7 @@
     "viewsWelcome": [
       {
         "view": "metalsPackages",
-        "contents": "No Scala project found.\n[New Scala project](command:metals.new-scala-project-activate)",
-        "when": "!metals:enabled"
-      },
-      {
-        "view": "metalsPackages",
-        "contents": "No Scala project found.\n[New Scala project](command:metals.new-scala-project)",
-        "when": "metals:enabled && metals:no-build-tool"
+        "contents": "No Scala project found.\n[New Scala project](command:metals.new-scala-project)"
       }
     ],
     "views": {

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -99,3 +99,8 @@ export namespace MetalsWindowStateDidChange {
 export interface MetalsWindowStateDidChangeParams {
   focused: boolean;
 }
+
+export interface MetalsOpenWindowParams {
+  uri: string;
+  openNewWindow: boolean;
+}


### PR DESCRIPTION
This is a follow up of https://github.com/scalameta/metals/pull/1728

In particular this adds:
- a welcome view with the new project button - it requires to have an additional activation command, since the normal "New Scala Project" command will only be added after the client is ready. 
- new extension to open a new window automatically (without it, there will only be a message saying that the new project got create)
