### PR TITLE
Add a link to show logs when running slow task 

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -597,19 +597,14 @@ function launchMetals(
     // bar with a "cancel" button.
     client.onRequest(MetalsSlowTask.type, (params, requestToken) => {
       return new Promise((requestResolve) => {
+        const showLogs = ` ([show logs](command:${ClientCommands.toggleLogs} "Show Metals logs"))`;
         window.withProgress(
           {
             location: ProgressLocation.Notification,
-            title: params.message,
+            title: params.message + showLogs,
             cancellable: true,
           },
           (progress, progressToken) => {
-            const showLogs = !params.quietLogs;
-            if (showLogs) {
-              // Open logs so user can keep track of progress.
-              client.outputChannel.show(true);
-            }
-
             // Update total running time every second.
             let seconds = params.secondsElapsed || 0;
             const interval = setInterval(() => {
@@ -620,7 +615,6 @@ function launchMetals(
             // Hide logs and clean up resources on completion.
             function onComplete() {
               clearInterval(interval);
-              client.outputChannel.hide();
             }
 
             // Client triggered cancelation from the progress notification.


### PR DESCRIPTION
Previously, we would always open Metals logs when running slow task, which could cause the side panel to be clsoed quite randomly. Now we offer a link to the logs within the notification.

It's not possible to add additional buttons to the notification unfortunately.

![show-logs](https://user-images.githubusercontent.com/3807253/85705513-914f1f80-b6e1-11ea-8955-f174ba13c9a4.gif)
