### PR TITLE
Make sure the new project button doesn't show up in an empty workspace

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,8 @@
     "viewsWelcome": [
       {
         "view": "metalsPackages",
-        "contents": "No Scala project found.\n[New Scala project](command:metals.new-scala-project)"
+        "contents": "No Scala project found.\n[New Scala project](command:metals.new-scala-project)",
+        "when": "workbenchState != empty"
       }
     ],
     "views": {


### PR DESCRIPTION
Fixes https://github.com/scalameta/metals-vscode/issues/342