### PR TITLE
Reset popup choices support

### DIFF
--- a/package.json
+++ b/package.json
@@ -239,6 +239,11 @@
         "title": "Reveal super method hierachy"
       },
       {
+        "command": "metals.reset-choice-interactive",
+        "category": "Metals",
+        "title": "Reset Choice Interactive"
+      },
+      {
         "command": "metals.go-to-super-method",
         "category": "Metals",
         "title": "Go to super method"
@@ -317,6 +322,10 @@
         },
         {
           "command": "metals.go-to-super-method",
+          "when": "metals:enabled"
+        },
+        {
+          "command": "metals.reset-choice-interactive",
           "when": "metals:enabled"
         },
         {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -338,7 +338,8 @@ function launchMetals(
         doctor = window.createWebviewPanel(
           "metals-doctor",
           "Metals Doctor",
-          ViewColumn.Active
+          ViewColumn.Active,
+          { enableCommandUris: true }
         );
         context.subscriptions.push(doctor);
         doctor.onDidDispose(() => {
@@ -527,6 +528,20 @@ function launchMetals(
         });
       }
     );
+
+    registerCommand("metals.reset-choice-interactive", () => {
+      client.sendRequest(ExecuteCommandRequest.type, {
+        command: "reset-choice",
+        arguments: [],
+      });
+    });
+
+    registerCommand("metals.reset-choice", (args) => {
+      client.sendRequest(ExecuteCommandRequest.type, {
+        command: "reset-choice",
+        arguments: args,
+      });
+    });
 
     registerCommand("metals.goto", (args) => {
       client.sendRequest(ExecuteCommandRequest.type, {


### PR DESCRIPTION
This is work related to PR in metals (https://github.com/scalameta/metals/pull/1897)

Links will be displayed thanks to PR in metals, they will become functional when this PR will be merged.
![2020-07-09-110034_595x117_scrot](https://user-images.githubusercontent.com/10478402/87019874-709fc300-c1d3-11ea-924c-5583dcfca198.png)

Links execute LSP command e.g. `metals.reset-choice [import build]`

It also exposes `metals.reset-choice-interactive` that can be mapped to a keyboard shortcut that allows to reset available choices interactively:
![2020-07-09-110426_543x202_scrot](https://user-images.githubusercontent.com/10478402/87020432-20753080-c1d4-11ea-802f-ea74fda062f6.png)

Example binding:
![2020-07-09-110627_590x63_scrot](https://user-images.githubusercontent.com/10478402/87020530-43074980-c1d4-11ea-9c10-6d1e6a27c21e.png)

I have a feeling it could be good to document somewhere but I have no clue where would be best place.