### PR TITLE
Bump metals-languageclient.

### DIFF
--- a/package.json
+++ b/package.json
@@ -432,7 +432,7 @@
     "vsce": "1.77.0"
   },
   "dependencies": {
-    "metals-languageclient": "0.2.7",
+    "metals-languageclient": "0.2.8",
     "promisify-child-process": "4.1.1",
     "vscode-languageclient": "6.1.3"
   },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -59,6 +59,7 @@ import {
   installJava,
   MetalsTreeViews,
   MetalsTreeViewReveal,
+  MetalsInitializationOptions,
 } from "metals-languageclient";
 import * as metalsLanguageClient from "metals-languageclient";
 import { startTreeView } from "./treeview";
@@ -271,6 +272,28 @@ function launchMetals(
     clientName: "vscode",
   });
 
+  const initializationOptions: MetalsInitializationOptions = {
+    compilerOptions: {
+      completionCommand: "editor.action.triggerSuggest",
+      overrideDefFormat: "unicode",
+      parameterHintsCommand: "editor.action.triggerParameterHints",
+    },
+    decorationProvider: true,
+    debuggingProvider: true,
+    doctorProvider: "html",
+    didFocusProvider: true,
+    executeClientCommandProvider: true,
+    globSyntax: "vscode",
+    icons: "vscode",
+    inputBoxProvider: true,
+    openFilesOnRenameProvider: true,
+    openNewWindowProvider: true,
+    quickPickProvider: true,
+    slowTaskProvider: true,
+    statusBarProvider: "on",
+    treeViewProvider: true,
+  };
+
   const clientOptions: LanguageClientOptions = {
     documentSelector: [{ scheme: "file", language: "scala" }],
     synchronize: {
@@ -278,20 +301,7 @@ function launchMetals(
     },
     revealOutputChannelOn: RevealOutputChannelOn.Never,
     outputChannel: outputChannel,
-    initializationOptions: {
-      decorationProvider: true,
-      debuggingProvider: true,
-      doctorProvider: "html",
-      didFocusProvider: true,
-      executeClientCommandProvider: true,
-      inputBoxProvider: true,
-      openFilesOnRenameProvider: true,
-      quickPickProvider: true,
-      slowTaskProvider: true,
-      statusBarProvider: "on",
-      treeViewProvider: true,
-      openNewWindowProvider: true,
-    },
+    initializationOptions,
   };
 
   const client = new LanguageClient(

--- a/yarn.lock
+++ b/yarn.lock
@@ -290,10 +290,10 @@ mdurl@^1.0.1:
   resolved "https://registry.yarnpkg.com/mdurl/-/mdurl-1.0.1.tgz#fe85b2ec75a59037f2adfec100fd6c601761152e"
   integrity sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4=
 
-metals-languageclient@0.2.7:
-  version "0.2.7"
-  resolved "https://registry.yarnpkg.com/metals-languageclient/-/metals-languageclient-0.2.7.tgz#b83be9ad41b26ef492c8ce437256c520b05ea28c"
-  integrity sha512-iZfEI/gAzAmzuc8M+ALBbWGHgk3VjwWaEKkgJChHdl2Ase/DSkNvnCkJwfG3JD4aksS9YA1C0nSf+pLIU7r6kA==
+metals-languageclient@0.2.8:
+  version "0.2.8"
+  resolved "https://registry.yarnpkg.com/metals-languageclient/-/metals-languageclient-0.2.8.tgz#82687c65bc386a50c6c3dfc2d1c7192629f98527"
+  integrity sha512-RGy28w9iYwGt3im5Da6YjD9eF6GTKtrRvluWy8StfwbHvI/KsobF1zmyVX/fD0wvNUCY0am867rImkjs1paTzA==
   dependencies:
     fp-ts "^2.4.1"
     locate-java-home "^1.1.2"


### PR DESCRIPTION
This adds in the ability to set the rest of the `InitializationOptions` that
vs code needs to be set. For now, both will be set to ensure a smooth transition,
but after this next release, we'll remove the client setting.

Relates to https://github.com/scalameta/metals/issues/1895