### PR TITLE
Add a step to publish to Open VSX registry

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,12 @@ jobs:
         run: |
           URL=$(curl --silent "https://api.github.com/repos/scalameta/metals-vscode/releases/latest" | jq -r '.upload_url')
           echo ::set-output name=UPLOAD_URL::$URL
+      - name: Publish on Open VSX
+        id: open_vsx
+        env:
+          OVSX_PAT: ${{ secrets.OVSX_TOKEN }}
+        run: |
+          yarn ovsx:publish ./metals-${{ steps.get_version.outputs.NEW_VERSION }}.vsix
       - name: Upload VSIX package to release
         uses: actions/upload-release-asset@v1.0.1
         env:

--- a/package.json
+++ b/package.json
@@ -429,6 +429,7 @@
     "test": "yarn compile",
     "build": "vsce package --yarn",
     "vscode:publish": "vsce publish --yarn",
+    "ovsx:publish": "ovsx publish",
     "format": "prettier --write '**/*.{ts,js,json,yml}'",
     "format-check": "prettier --check '**/*.{ts,js,json,yml}'"
   },
@@ -438,7 +439,8 @@
     "@types/vscode": "1.43.0",
     "prettier": "2.0.5",
     "typescript": "3.9.6",
-    "vsce": "1.77.0"
+    "vsce": "1.77.0",
+    "ovsx": "0.1.0-next.dacd2fd"
   },
   "dependencies": {
     "metals-languageclient": "0.2.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -368,6 +368,13 @@ osenv@^0.1.3:
     os-homedir "^1.0.0"
     os-tmpdir "^1.0.0"
 
+ovsx@0.1.0-next.dacd2fd:
+  version "0.1.0-next.dacd2fd"
+  resolved "https://registry.yarnpkg.com/ovsx/-/ovsx-0.1.0-next.dacd2fd.tgz#319e3fb12bea82bc126d4e0f18eda2463ec0baf0"
+  integrity sha512-cdATv0t6HsLB7PmGe4Z0z8dMuQZBORiEf9wUq54tqy1Mq2UzWrUqBMvJXhHR8s0N1z7iES4mbCSf4s/uFFLeAA==
+  dependencies:
+    vsce "^1.75.0"
+
 parse-semver@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/parse-semver/-/parse-semver-1.1.1.tgz#9a4afd6df063dc4826f93fba4a99cf223f666cb8"
@@ -507,7 +514,7 @@ util-deprecate@^1.0.1:
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=
 
-vsce@1.77.0:
+vsce@1.77.0, vsce@^1.75.0:
   version "1.77.0"
   resolved "https://registry.yarnpkg.com/vsce/-/vsce-1.77.0.tgz#21364d3e63095b2f54e0f185445e8ff6ab614602"
   integrity sha512-8vOTCI3jGmOm0JJFu/BMAbqxpaSuka4S3hV9E6K5aWBUsDM1SGFExkIxHblnsI8sls43xP61DHorYT+K0F+GFA==


### PR DESCRIPTION
I added the OVSX_TOKEN to secrets and it should all work. I will test it out with the next release.

Fixes https://github.com/scalameta/metals-vscode/issues/360

A follow up from https://github.com/eclipse/open-vsx.org/issues/83