### PR TITLE
Add deactivate to stop the client once the extension closes

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -73,6 +73,8 @@ const outputChannel = window.createOutputChannel("Metals");
 const openSettingsAction = "Open settings";
 const openSettingsCommand = "workbench.action.openSettings";
 let treeViews: MetalsTreeViews | undefined;
+let currentClient: LanguageClient | undefined;
+
 let decorationType: TextEditorDecorationType = window.createTextEditorDecorationType(
   {
     isWholeLine: true,
@@ -105,6 +107,10 @@ export async function activate(context: ExtensionContext) {
       }
     }
   );
+}
+
+export function deactivate(): Thenable<void> | undefined {
+  return currentClient?.stop();
 }
 
 function showMissingJavaMessage(): Thenable<void> {
@@ -311,6 +317,7 @@ function launchMetals(
     clientOptions
   );
 
+  currentClient = client;
   function registerCommand(command: string, callback: (...args: any[]) => any) {
     context.subscriptions.push(commands.registerCommand(command, callback));
   }


### PR DESCRIPTION
I've actually notice that we sometimes don't shutdown the server correctly and I did some digging and found that we don't actually have a deactivate function that closes the client explicitly. 

It seems to work most of the time, but maybe adding deactivate might help anyway? Perhaps client wouldn't shutdown properly due to some race condition?

@olafurpg What do you think? Is it just an omission or was it excluded on purpose?

CC @jvican I think this might cause the issue you were talking about.