### PR TITLE
Publish to ovsx with explicit --pat argument

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,12 +44,6 @@ jobs:
         run: |
           URL=$(curl --silent "https://api.github.com/repos/scalameta/metals-vscode/releases/latest" | jq -r '.upload_url')
           echo ::set-output name=UPLOAD_URL::$URL
-      - name: Publish on Open VSX
-        id: open_vsx
-        env:
-          OVSX_PAT: ${{ secrets.OVSX_TOKEN }}
-        run: |
-          yarn ovsx:publish ./metals-${{ steps.get_version.outputs.NEW_VERSION }}.vsix
       - name: Upload VSIX package to release
         uses: actions/upload-release-asset@v1.0.1
         env:
@@ -60,3 +54,9 @@ jobs:
           asset_name: |
             scalameta.metals-${{ steps.get_version.outputs.NEW_VERSION }}.vsix
           asset_content_type: application/octet-stream
+      - name: Publish on Open VSX
+        id: open_vsx
+        env:
+          OVSX_PAT: ${{ secrets.OVSX_TOKEN }}
+        run: |
+          yarn ovsx:publish --pat $OVSX_PAT ./metals-${{ steps.get_version.outputs.NEW_VERSION }}.vsix


### PR DESCRIPTION
I published 1.9.3 manually to test it out, but we will know for sure during the next release I guess.