### PR TITLE
Add command to quickly create worksheet

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
       "properties": {
         "metals.serverVersion": {
           "type": "string",
-          "default": "0.9.3",
+          "default": "0.9.4",
           "markdownDescription": "The version of the Metals server artifact. Requires reloading the window.\n\n**Change only if you know what you're doing**"
         },
         "metals.serverProperties": {

--- a/package.json
+++ b/package.json
@@ -235,6 +235,11 @@
         "title": "New Scala File..."
       },
       {
+        "command": "metals.new-scala-worksheet",
+        "category": "Metals",
+        "title": "Create Worksheet"
+      },
+      {
         "command": "metals.super-method-hierarchy",
         "category": "Metals",
         "title": "Reveal super method hierachy"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -607,6 +607,34 @@ function launchMetals(
       }
     );
 
+    registerCommand(`metals.new-scala-worksheet`, async () => {
+      const sendRequest = (args: Array<string | undefined>) => {
+        return client.sendRequest(ExecuteCommandRequest.type, {
+          command: ServerCommands.NewScalaFile,
+          arguments: args,
+        });
+      };
+      const currentUri = window.activeTextEditor?.document.uri;
+      if (currentUri != null) {
+        const parentUri = path.dirname(currentUri.toString());
+        const name = path.basename(parentUri);
+        const parentPath = Uri.parse(parentUri).fsPath;
+        const fullPath = path.join(parentPath, `${name}.worksheet.sc`);
+        if (fs.existsSync(fullPath)) {
+          window.showWarningMessage(
+            `A worksheet ${name}.worksheet.sc already exists, opening it instead`
+          );
+          return workspace
+            .openTextDocument(fullPath)
+            .then((textDocument) => window.showTextDocument(textDocument));
+        } else {
+          return sendRequest([parentUri, name, "worksheet"]);
+        }
+      } else {
+        return sendRequest([undefined, undefined, "worksheet"]);
+      }
+    });
+
     registerCommand(`metals.${ServerCommands.NewScalaProject}`, async () => {
       return client.sendRequest(ExecuteCommandRequest.type, {
         command: ServerCommands.NewScalaProject,


### PR DESCRIPTION
Depends on https://github.com/scalameta/metals-languageclient/pull/183

It will still ask for name if run from command palette, since it doesn't know the directory. I wonder if we should suggest some default name, or maybe a random one? We are not sure where we are creating the new file, so we will not even be able to check if we can create a new worksheet with the specified file. 

Maybe, we should suggest a default name for worksheets inside Metals server? I think input box has an option for that.
