### PR TITLE
Run release on publish so that files are properly uploaded

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,8 @@
 name: Release
 
 on:
-  push:
-    tags:
-      - "v*.*.*"
+  release:
+    types: [published]
 
 jobs:
   release:


### PR DESCRIPTION
When we publish a release the push tag event is not matched, so trying out a different event.