### PR TITLE
Update ovsx

### DIFF
--- a/package.json
+++ b/package.json
@@ -456,7 +456,7 @@
     "@types/node": "14.11.1",
     "@types/shell-quote": "1.7.0",
     "@types/vscode": "1.43.0",
-    "ovsx": "0.1.0-next.9321255",
+    "ovsx": "0.1.0-next.bcce4bc",
     "prettier": "2.1.2",
     "typescript": "4.0.3",
     "vsce": "1.79.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -368,12 +368,12 @@ osenv@^0.1.3:
     os-homedir "^1.0.0"
     os-tmpdir "^1.0.0"
 
-ovsx@0.1.0-next.9321255:
-  version "0.1.0-next.9321255"
-  resolved "https://registry.yarnpkg.com/ovsx/-/ovsx-0.1.0-next.9321255.tgz#dbb679e2eacf28017cfd474487a94008426d024d"
-  integrity sha512-gGQRzQWHBT6VdjZZgGxQUN1oaRxBuKcTkhtkL9AMstLqIu+tVmbTjJIE/j/RQeSumsn+HPoXysjnR0fzKsHkdQ==
+ovsx@0.1.0-next.bcce4bc:
+  version "0.1.0-next.bcce4bc"
+  resolved "https://registry.yarnpkg.com/ovsx/-/ovsx-0.1.0-next.bcce4bc.tgz#8da209efa2e634151a6437a4fdce23e8e947cca4"
+  integrity sha512-ArfM+MLP/JwxqKctM5UNyqyCgSMMvUPI7ADu5sVS7nSG2+uxGW+y9AyO5dh8g61MdjhsTSgZsJ4nl8f29cf/bQ==
   dependencies:
-    vsce "^1.73.0"
+    vsce "~1.77.0"
 
 parse-semver@^1.1.1:
   version "1.1.1"
@@ -514,10 +514,36 @@ util-deprecate@^1.0.1:
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=
 
-vsce@1.79.5, vsce@^1.73.0:
+vsce@1.79.5:
   version "1.79.5"
   resolved "https://registry.yarnpkg.com/vsce/-/vsce-1.79.5.tgz#622d947aed97632d460e68ec774eac41f550102d"
   integrity sha512-KZFOthGwxWFwoGqwrkzfTfyCZGuniTofnJ1a/dCzQ2HP93u1UuCKrTQyGT+SuGHu8sNqdBYNe0hb9GC3qCN7fg==
+  dependencies:
+    azure-devops-node-api "^7.2.0"
+    chalk "^2.4.2"
+    cheerio "^1.0.0-rc.1"
+    commander "^2.8.1"
+    denodeify "^1.2.1"
+    glob "^7.0.6"
+    leven "^3.1.0"
+    lodash "^4.17.15"
+    markdown-it "^10.0.0"
+    mime "^1.3.4"
+    minimatch "^3.0.3"
+    osenv "^0.1.3"
+    parse-semver "^1.1.1"
+    read "^1.0.7"
+    semver "^5.1.0"
+    tmp "0.0.29"
+    typed-rest-client "1.2.0"
+    url-join "^1.1.0"
+    yauzl "^2.3.1"
+    yazl "^2.2.2"
+
+vsce@~1.77.0:
+  version "1.77.0"
+  resolved "https://registry.yarnpkg.com/vsce/-/vsce-1.77.0.tgz#21364d3e63095b2f54e0f185445e8ff6ab614602"
+  integrity sha512-8vOTCI3jGmOm0JJFu/BMAbqxpaSuka4S3hV9E6K5aWBUsDM1SGFExkIxHblnsI8sls43xP61DHorYT+K0F+GFA==
   dependencies:
     azure-devops-node-api "^7.2.0"
     chalk "^2.4.2"


### PR DESCRIPTION
So it seems that without this module we don't even get an error message, but the exact same command seems to be passing locally.

Basically, during the next release we should at least get a real error.