### PR TITLE
Add an envFile parameter to debug launch configuration.

### DIFF
--- a/package.json
+++ b/package.json
@@ -409,6 +409,11 @@
                   "type": "string"
                 },
                 "default": []
+              },
+              "envFile": {
+                "type": "string",
+                "description": "Name of a .env file with additional environment variables",
+                "default": null
               }
             }
           }


### PR DESCRIPTION
Adds a new parameter to the debug launch configuration allowing you to specify an external `.env` file for loading additional environment variables.

Related to https://github.com/scalameta/metals/pull/2123