### PR TITLE
Add in missing `bsp-switch` command

### DIFF
--- a/package.json
+++ b/package.json
@@ -205,6 +205,11 @@
         "title": "Connect to build server"
       },
       {
+        "command": "metals.bsp-switch",
+        "category": "Metals",
+        "title": "Switch build server"
+      },
+      {
         "command": "metals.sources-scan",
         "category": "Metals",
         "title": "Rescan sources"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -394,6 +394,7 @@ function launchMetals(
       ServerCommands.BuildImport,
       ServerCommands.BuildRestart,
       ServerCommands.BuildConnect,
+      ServerCommands.BspSwitch,
       ServerCommands.SourcesScan,
       ServerCommands.DoctorRun,
       ServerCommands.CascadeCompile,


### PR DESCRIPTION
These ~two command~ command (I just removed the disconnect one) have been in Metals for a while, just not in the extension. So this won't break anything for users sticking on the stable Metals release, but will allow for users to more easily test the sbt BSP support.