### PR TITLE
Fix homepage which is shown in marketplace

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "type": "git",
     "url": "https://github.com/scalameta/metals-vscode.git"
   },
-  "homepage": "http://metals.rocks",
+  "homepage": "https://scalameta.org/metals/",
   "engines": {
     "vscode": "^1.43.0"
   },


### PR DESCRIPTION
A colleague pointed this out to me today. When you are looking at the plugin in [Marketplace](https://marketplace.visualstudio.com/items?itemName=scalameta.metals) and click the homepage, it leads you to the old `metals.rocks` url.