### PR TITLE
Reword the build-restart description

### DIFF
--- a/package.json
+++ b/package.json
@@ -192,7 +192,7 @@
       {
         "command": "metals.build-restart",
         "category": "Metals",
-        "title": "Restart Bloop server"
+        "title": "Restart build server"
       },
       {
         "command": "metals.build-import",


### PR DESCRIPTION
Ugh, I should have done this before the release but didn't catch it. If a user is using sbt BSP and the trigger this, it does a `workspace/reload`, so it's not just for Bloop anymore. Probably best to update the description to reflect this.