### PR TITLE
Add `isWholeLine` back in case of worksheets 

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -76,6 +76,13 @@ const openSettingsCommand = "workbench.action.openSettings";
 let treeViews: MetalsTreeViews | undefined;
 let currentClient: LanguageClient | undefined;
 
+let worksheetDecorationType: TextEditorDecorationType = window.createTextEditorDecorationType(
+  {
+    isWholeLine: true,
+    rangeBehavior: DecorationRangeBehavior.OpenClosed,
+  }
+);
+
 let decorationType: TextEditorDecorationType = window.createTextEditorDecorationType(
   {
     rangeBehavior: DecorationRangeBehavior.OpenClosed,
@@ -819,7 +826,9 @@ function launchMetals(
             renderOptions: o.renderOptions,
           };
         });
-        editor.setDecorations(decorationType, options);
+        if (params.uri.endsWith(".worksheet.sc"))
+          editor.setDecorations(worksheetDecorationType, options);
+        else editor.setDecorations(decorationType, options);
       } else {
         outputChannel.appendLine(
           `Ignoring decorations for non-active document '${params.uri}'.`


### PR DESCRIPTION
This fixes the behaviour when writting at an end of an evaluated worksheet:

![image](https://user-images.githubusercontent.com/3807253/100469822-4d6ca600-30d7-11eb-9c21-7232ede9db9b.png)

and now will move the whole decoration right:

![image](https://user-images.githubusercontent.com/3807253/100469939-89077000-30d7-11eb-9411-30a5f42ff9db.png)

If we ever support implicits inside worksheets we might need auto update the position to the end of line for worksheet decorations.