### PR TITLE
Add in metals.copy-worksheet-ouput command

### DIFF
--- a/package.json
+++ b/package.json
@@ -319,6 +319,11 @@
         "command": "metals.toggle-show-inferred-type",
         "category": "Metals",
         "title": "Toggle showing inferred type"
+      },
+      {
+        "command": "metals.copy-worksheet-output",
+        "category": "Metals",
+        "title": "Copy worksheet output"
       }
     ],
     "menus": {

--- a/package.json
+++ b/package.json
@@ -566,7 +566,7 @@
     "vsce": "1.81.1"
   },
   "dependencies": {
-    "metals-languageclient": "0.3.3",
+    "metals-languageclient": "0.4.0",
     "promisify-child-process": "4.1.1",
     "vscode-languageclient": "6.1.3"
   },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -598,6 +598,34 @@ function launchMetals(
       });
     });
 
+    // TODO replace with ServerCommand when done
+    registerTextEditorCommand(
+      `metals.copy-worksheet-output`,
+      (editor, _edit, _args) => {
+        const uri = editor.document.uri;
+        if (uri.toString().endsWith("worksheet.sc")) {
+          client
+            .sendRequest(ExecuteCommandRequest.type, {
+              command: "copy-worksheet-output",
+              arguments: [uri.toString()],
+            })
+            .then((result) => {
+              window.showInformationMessage(result);
+              if (result.value) {
+                env.clipboard.writeText(result.value);
+                window.showInformationMessage(
+                  "Copied worksheet evaluation to clipboard."
+                );
+              }
+            });
+        } else {
+          window.showWarningMessage(
+            "You must be in a worksheet to use this feature."
+          );
+        }
+      }
+    );
+
     registerCommand("metals.goto-path-uri", (...args) => {
       const uri = args[0] as string;
       const line = args[1] as number;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -600,13 +600,13 @@ function launchMetals(
 
     // TODO replace with ServerCommand when done
     registerTextEditorCommand(
-      `metals.copy-worksheet-output`,
+      `metals.${ServerCommands.CopyWorksheetOutput}`,
       (editor, _edit, _args) => {
         const uri = editor.document.uri;
         if (uri.toString().endsWith("worksheet.sc")) {
           client
             .sendRequest(ExecuteCommandRequest.type, {
-              command: "copy-worksheet-output",
+              command: ServerCommands.CopyWorksheetOutput,
               arguments: [uri.toString()],
             })
             .then((result) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -290,10 +290,10 @@ mdurl@^1.0.1:
   resolved "https://registry.yarnpkg.com/mdurl/-/mdurl-1.0.1.tgz#fe85b2ec75a59037f2adfec100fd6c601761152e"
   integrity sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4=
 
-metals-languageclient@0.3.3:
-  version "0.3.3"
-  resolved "https://registry.yarnpkg.com/metals-languageclient/-/metals-languageclient-0.3.3.tgz#0d435604440e855b6c7eedc30583593bbac9c6f6"
-  integrity sha512-lcYMlelg5pHFxFR1oz6vqZA9M6bi2IcCcPdkc/OAOg1KTkS5fGBrW8RXGnbKx/j+w0hQ3sUJsg16x5U/ikXVVA==
+metals-languageclient@0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/metals-languageclient/-/metals-languageclient-0.4.0.tgz#99df12b3776ceb0ad0a05a67f628b1ea89cd8ba0"
+  integrity sha512-gvQ1NYkV7u0dbA59STd9Hleor23vztQY8WaIgDO1udb7tJM/NrS7ZLLxY9H6CDwoMiZhXaUvlpCjGwn/t8qTzg==
   dependencies:
     fp-ts "^2.4.1"
     locate-java-home "^1.1.2"


### PR DESCRIPTION
This pr adds in the `metals.copy-worksheet-output` command that is needed for https://github.com/scalameta/metals/pull/2290.

![2020-12-14 09 58 08](https://user-images.githubusercontent.com/13974112/102060961-1eeb0c80-3df3-11eb-8917-6b94c060b12d.gif)