### PR TITLE
Fix issues with hovers in worksheets

### DIFF
--- a/src/decoration-protocol.ts
+++ b/src/decoration-protocol.ts
@@ -1,5 +1,9 @@
 import { NotificationType } from "vscode-jsonrpc";
-import { DecorationRenderOptions, DecorationOptions } from "vscode";
+import {
+  DecorationRenderOptions,
+  DecorationInstanceRenderOptions,
+  Range,
+} from "vscode";
 
 ("use strict");
 
@@ -15,10 +19,20 @@ export namespace DecorationTypeDidChange {
   );
 }
 
+export interface MetalsDecorationOptions {
+  range: Range;
+  hoverMessage: {
+    kind: string;
+    value: string;
+  };
+  renderOptions?: DecorationInstanceRenderOptions;
+}
+
 export interface PublishDecorationsParams {
   uri: string;
-  options: DecorationOptions[];
+  options: MetalsDecorationOptions[];
 }
+
 export namespace DecorationsRangesDidChange {
   export const type = new NotificationType<PublishDecorationsParams, void>(
     "metals/publishDecorations"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -815,7 +815,7 @@ function launchMetals(
               new Position(o.range.start.line, o.range.start.character),
               new Position(o.range.end.line, o.range.end.character)
             ),
-            hoverMessage: o.hoverMessage,
+            hoverMessage: o.hoverMessage.value,
             renderOptions: o.renderOptions,
           };
         });


### PR DESCRIPTION
Previously we would send MarkupContent with `value` and `kind` parameter specified and feed it to decorations.
It seems that this would not work as it would not fit the expected format, which can be string, {language, string} or MarkdownString.
This should probably not worked before, but probably it was only by chance and as the behaviour was not documented it could be expected to last.