### PR TITLE
Fix issue when hover undefined or null

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -849,7 +849,7 @@ function launchMetals(
               new Position(o.range.start.line, o.range.start.character),
               new Position(o.range.end.line, o.range.end.character)
             ),
-            hoverMessage: o.hoverMessage.value,
+            hoverMessage: o.hoverMessage?.value,
             renderOptions: o.renderOptions,
           };
         });


### PR DESCRIPTION
When sending information about implicits to the client no hover message is passed, so it will be udnefined.
We should account for that when dealing with the message.

I haven't noticed before that it would break implicit info, fixing it quickly now to move on with the release.