### PR TITLE
Revert to an older version of openvsx to fix release issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -560,7 +560,7 @@
     "@types/node": "14.14.14",
     "@types/shell-quote": "1.7.0",
     "@types/vscode": "1.43.0",
-    "ovsx": "0.1.0-next.9321255",
+    "ovsx": "0.1.0-next.980e5cf",
     "prettier": "2.2.1",
     "typescript": "4.1.3",
     "vsce": "1.83.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -104,6 +104,11 @@ color-name@1.1.3:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
   integrity sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
 
+commander@^2.8.1:
+  version "2.20.3"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
+  integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
+
 commander@^6.1.0:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-6.1.0.tgz#f8d722b78103141006b66f4c7ba1e97315ba75bc"
@@ -196,6 +201,11 @@ fd-slicer@~1.1.0:
   integrity sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=
   dependencies:
     pend "~1.2.0"
+
+follow-redirects@^1.13.0:
+  version "1.13.1"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.13.1.tgz#5f69b813376cee4fd0474a3aba835df04ab763b7"
+  integrity sha512-SSG5xmZh1mkPGyKzjZP8zLjltIfpW32Y5QpdNJyjcfGxK3qo3NDDkZOZSFiGn1A6SclQxY9GzEwAHQ3dmYRWpg==
 
 fp-ts@^2.4.1:
   version "2.4.4"
@@ -368,12 +378,13 @@ osenv@^0.1.3:
     os-homedir "^1.0.0"
     os-tmpdir "^1.0.0"
 
-ovsx@0.1.0-next.9321255:
-  version "0.1.0-next.9321255"
-  resolved "https://registry.yarnpkg.com/ovsx/-/ovsx-0.1.0-next.9321255.tgz#dbb679e2eacf28017cfd474487a94008426d024d"
-  integrity sha512-gGQRzQWHBT6VdjZZgGxQUN1oaRxBuKcTkhtkL9AMstLqIu+tVmbTjJIE/j/RQeSumsn+HPoXysjnR0fzKsHkdQ==
+ovsx@0.1.0-next.980e5cf:
+  version "0.1.0-next.980e5cf"
+  resolved "https://registry.yarnpkg.com/ovsx/-/ovsx-0.1.0-next.980e5cf.tgz#7644ae8be472f6251cce59155c91a198f6088c95"
+  integrity sha512-YTRJC4mpS5TVJzrIBMiPKgcVEzRAdbytQFy+MXEeNlRmRU3hlAKOqaDXUkalC9CAK+8Xpv4/mA46LVH9J5waSw==
   dependencies:
-    vsce "^1.73.0"
+    follow-redirects "^1.13.0"
+    vsce "~1.79.5"
 
 parse-semver@^1.1.1:
   version "1.1.1"
@@ -514,7 +525,7 @@ util-deprecate@^1.0.1:
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=
 
-vsce@1.83.0, vsce@^1.73.0:
+vsce@1.83.0:
   version "1.83.0"
   resolved "https://registry.yarnpkg.com/vsce/-/vsce-1.83.0.tgz#61774e5389a8654e307c65ec392cf61534f65bcb"
   integrity sha512-gyF/xtCOFcKO+EvC0FQu5jPECHz2XKMWcw62gqwJJ22lVvlj58t49sWe1IGl9S5NpxCek+QMm6V9i/cDwGWs/Q==
@@ -523,6 +534,32 @@ vsce@1.83.0, vsce@^1.73.0:
     chalk "^2.4.2"
     cheerio "^1.0.0-rc.1"
     commander "^6.1.0"
+    denodeify "^1.2.1"
+    glob "^7.0.6"
+    leven "^3.1.0"
+    lodash "^4.17.15"
+    markdown-it "^10.0.0"
+    mime "^1.3.4"
+    minimatch "^3.0.3"
+    osenv "^0.1.3"
+    parse-semver "^1.1.1"
+    read "^1.0.7"
+    semver "^5.1.0"
+    tmp "0.0.29"
+    typed-rest-client "1.2.0"
+    url-join "^1.1.0"
+    yauzl "^2.3.1"
+    yazl "^2.2.2"
+
+vsce@~1.79.5:
+  version "1.79.5"
+  resolved "https://registry.yarnpkg.com/vsce/-/vsce-1.79.5.tgz#622d947aed97632d460e68ec774eac41f550102d"
+  integrity sha512-KZFOthGwxWFwoGqwrkzfTfyCZGuniTofnJ1a/dCzQ2HP93u1UuCKrTQyGT+SuGHu8sNqdBYNe0hb9GC3qCN7fg==
+  dependencies:
+    azure-devops-node-api "^7.2.0"
+    chalk "^2.4.2"
+    cheerio "^1.0.0-rc.1"
+    commander "^2.8.1"
     denodeify "^1.2.1"
     glob "^7.0.6"
     leven "^3.1.0"


### PR DESCRIPTION
It seems that the recently updated version fails without a clear reason (https://github.com/scalameta/metals-vscode/actions/runs/432894310). Should be safe to just stay on this one for the time being.