### PR TITLE
Renamed "Import build" to "Import or reload build"

### DIFF
--- a/package.json
+++ b/package.json
@@ -213,7 +213,7 @@
       {
         "command": "metals.build-import",
         "category": "Metals",
-        "title": "Import build"
+        "title": "Import or reload build"
       },
       {
         "command": "metals.build-connect",


### PR DESCRIPTION
Since "command": "metals.build-import" is used for both **importing** the build into bloop and **reloading** the build when using BSP, it might as well reflect this in the command's title.

I opened a [discussion](https://github.com/scalameta/metals/discussions/2344) about this to gather some thoughts.