### PR TITLE
Show decorations for visible editors and not just for active one

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -838,11 +838,12 @@ function launchMetals(
       decorationType = window.createTextEditorDecorationType(options);
     });
     client.onNotification(DecorationsRangesDidChange.type, (params) => {
-      const editor = window.activeTextEditor;
-      if (
-        editor &&
-        Uri.parse(params.uri).toString() === editor.document.uri.toString()
-      ) {
+      const editors = window.visibleTextEditors;
+      const path = Uri.parse(params.uri).toString();
+      const editor = editors.find(
+        (editor) => editor.document.uri.toString() == path
+      );
+      if (editor) {
         const options = params.options.map<DecorationOptions>((o) => {
           return {
             range: new Range(


### PR DESCRIPTION
Previously, when an editor was visible but not active decorations would not show up, which was a problem especially in case of worksheets, where longer evaluating worksheets would not show if you started doing something for example in the terminal. Now, it should work for all visible editors.