### PR TITLE
Revert to previous Metals server version

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
       "properties": {
         "metals.serverVersion": {
           "type": "string",
-          "default": "0.9.9",
+          "default": "0.9.8",
           "markdownDescription": "The version of the Metals server artifact. Requires reloading the window.\n\n**Change only if you know what you're doing**"
         },
         "metals.serverProperties": {


### PR DESCRIPTION
Seems we are getting some errors, which I somehow missed while checking.

```
Exception in thread "pool-7-thread-2" java.lang.NoSuchMethodError: scala.meta.internal.pc.MetalsGlobal.reporter()Lscala/tools/nsc/reporters/Reporter;
	at scala.meta.internal.pc.ScalaCompilerWrapper.resetReporter(ScalaCompilerAccess.scala:17)
	at scala.meta.internal.pc.CompilerAccess.loadCompiler(CompilerAccess.scala:39)
	at scala.meta.internal.pc.CompilerAccess.withSharedCompiler(CompilerAccess.scala:137)
	at scala.meta.internal.pc.CompilerAccess.$anonfun$withNonInterruptableCompiler$1(CompilerAccess.scala:125)
	at scala.meta.internal.pc.CompilerAccess.$anonfun$onCompilerJobQueue$1(CompilerAccess.scala:197)
	at scala.meta.internal.pc.CompilerJobQueue$Job.run(CompilerJobQueue.scala:103)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
```