### PR TITLE
Make debug console show up always when running or debugging

### DIFF
--- a/src/scalaDebugger.ts
+++ b/src/scalaDebugger.ts
@@ -1,5 +1,6 @@
 import * as vscode from "vscode";
 import {
+  commands,
   DebugConfiguration,
   Disposable,
   ProviderResult,
@@ -47,7 +48,7 @@ export async function start(
         request: "launch",
         debugServer: port, // note: MUST be a number. vscode magic - automatically connects to the server
       };
-
+      commands.executeCommand("workbench.panel.repl.view.focus");
       return vscode.debug.startDebugging(undefined, configuration);
     });
 }


### PR DESCRIPTION
I noticed recently, that the debug console will not show up always when users run or test their application, but turns we can force the view to appear whenever we are successfully starting a DAP session.