### PR TITLE
Fix README (find-java-home has replaced by locate-java-home as v1.1.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ configuration problems in your workspace.
 ## Configure Java version
 
 The VS Code plugin uses by default the `JAVA_HOME` environment variable (via
-[`find-java-home`](https://www.npmjs.com/package/find-java-home)) to locate the
+[`locate-java-home`](https://www.npmjs.com/package/locate-java-home)) to locate the
 `java` executable. To override the default Java home location, update the "Java
 Home" variable in the settings menu.
 


### PR DESCRIPTION
Just noticed, while `find-java-home` has replaced by `locate-java-home` as v1.1.0, README still mentions `find-java-home`.

https://github.com/scalameta/metals-vscode/blob/master/CHANGELOG.md#v110-20181214-1443-0000