### PR TITLE
Add CopyWorksheetOutputProvider to enable worksheet code lenses

### DIFF
--- a/package.json
+++ b/package.json
@@ -566,7 +566,7 @@
     "vsce": "1.83.0"
   },
   "dependencies": {
-    "metals-languageclient": "0.4.0",
+    "metals-languageclient": "0.4.1",
     "promisify-child-process": "4.1.1",
     "vscode-languageclient": "6.1.3"
   },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -294,6 +294,7 @@ function launchMetals(
       overrideDefFormat: "unicode",
       parameterHintsCommand: "editor.action.triggerParameterHints",
     },
+    copyWorksheetOutputProvider: true,
     decorationProvider: true,
     inlineDecorationProvider: true,
     debuggingProvider: true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -300,10 +300,10 @@ mdurl@^1.0.1:
   resolved "https://registry.yarnpkg.com/mdurl/-/mdurl-1.0.1.tgz#fe85b2ec75a59037f2adfec100fd6c601761152e"
   integrity sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4=
 
-metals-languageclient@0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/metals-languageclient/-/metals-languageclient-0.4.0.tgz#99df12b3776ceb0ad0a05a67f628b1ea89cd8ba0"
-  integrity sha512-gvQ1NYkV7u0dbA59STd9Hleor23vztQY8WaIgDO1udb7tJM/NrS7ZLLxY9H6CDwoMiZhXaUvlpCjGwn/t8qTzg==
+metals-languageclient@0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/metals-languageclient/-/metals-languageclient-0.4.1.tgz#3f379d1073873993ad450e2630ad67510edd8d79"
+  integrity sha512-X1I0spZy0PQasLYW5FmzbojB5n3F+r8YpPr1fGDyWJGzVBH2WXJv+CwpUcY0VNKIJLrvat8aJRmKTd9PfRreHw==
   dependencies:
     fp-ts "^2.4.1"
     locate-java-home "^1.1.2"


### PR DESCRIPTION
This PR accompanies https://github.com/scalameta/metals/pull/2470 to provide code lensese to easily copy worksheet output.

Depends on new Metals and metals-languageclient releases.