### PR TITLE
serverProperties: Add default xmx value

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,6 +109,9 @@
           "items": {
             "type": "string"
           },
+          "default": [
+            "-Xmx512m"
+          ],
           "markdownDescription": "Optional list of properties to pass along to the Metals server. By default, the environment variable `JAVA_OPTS` and `.jvmopts` file are respected. Each property needs to be a separate item.\n\nExample: `-Dhttps.proxyHost=…`, `-Dhttps.proxyPort=…` or `-Dmetals.statistics=all`"
         },
         "metals.ammoniteJvmProperties": {


### PR DESCRIPTION
I'm not sure if it should be 512m or 1G (512 is enough for metals and scalameta) but I think it anyway should be specified.

Having multiply metals processes without `Xmx` setting  sometimes causes problems  because they use default value (25% of MaxRam) and they consume more memory than required.