### PR TITLE
Set super method code lenses to true by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -183,7 +183,7 @@
         },
         "metals.superMethodLensesEnabled": {
           "type": "boolean",
-          "default": false,
+          "default": true,
           "description": "Enable/disable goto super method code lens."
         },
         "metals.enableStripMarginOnTypeFormatting": {


### PR DESCRIPTION
Thanks to https://github.com/scalameta/metals/pull/3045 we no longer need to calculate the super methods and just use the existing semanticdb information.

I don't think we need to confirm it since we already use a lot of different info from semanticdb and it doesn't cause any additional CPU usage.

CC @tanishiking 