### PR TITLE
Increase default Xmx to 1G

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
             "type": "string"
           },
           "default": [
-            "-Xmx512m"
+            "-Xmx1G"
           ],
           "markdownDescription": "Optional list of properties to pass along to the Metals server. By default, the environment variable `JAVA_OPTS` and `.jvmopts` file are respected. Each property needs to be a separate item.\n\nExample: `-Dhttps.proxyHost=…`, `-Dhttps.proxyPort=…` or `-Dmetals.statistics=all`"
         },


### PR DESCRIPTION
Unfortunately, `512m` might be not enough for now because Scala3 PC requires much more memory that Scala 2.