### PR TITLE
Revert automatic indentation for optional braces

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -72,7 +72,7 @@ import {
   DecorationsRangesDidChange,
 } from "./decoration-protocol";
 import { clearTimeout } from "timers";
-import { decreaseIndentPattern, increaseIndentPattern } from "./indentPattern";
+import { increaseIndentPattern } from "./indentPattern";
 
 const outputChannel = window.createOutputChannel("Metals");
 const openSettingsAction = "Open settings";
@@ -1030,9 +1030,9 @@ function enableScaladocIndentation() {
   languages.setLanguageConfiguration("scala", {
     indentationRules: {
       // ^(.*\*/)?\s*\}.*$
-      decreaseIndentPattern: decreaseIndentPattern(),
+      decreaseIndentPattern: /^(.*\*\/)?\s*\}.*$/,
       // ^.*\{[^}"']*$
-      increaseIndentPattern: increaseIndentPattern(),
+      increaseIndentPattern: /^.*\{[^}"']*$/,
     },
     wordPattern:
       /(-?\d*\.\d\w*)|([^\`\~\!\@\#\%\^\&\*\(\)\-\=\+\[\{\]\}\\\|\;\:\'\"\,\.\<\>\/\?\s]+)/g,
@@ -1042,6 +1042,16 @@ function enableScaladocIndentation() {
         beforeText: /^\s*\/\*\*(?!\/)([^\*]|\*(?!\/))*$/,
         afterText: /^\s*\*\/$/,
         action: { indentAction: IndentAction.IndentOutdent, appendText: " * " },
+      },
+      {
+        // indent in places with optional braces
+        beforeText: increaseIndentPattern(),
+        action: { indentAction: IndentAction.Indent },
+      },
+      {
+        // stop vscode from indenting automatically to last known indentation
+        beforeText: /^\s*/,
+        action: { indentAction: IndentAction.None },
       },
       {
         // e.g. /** ...|

--- a/src/indentPattern.ts
+++ b/src/indentPattern.ts
@@ -1,15 +1,11 @@
-export function decreaseIndentPattern() {
-  return /((^\s*end\b\s*)\b(if|while|for|match|try|\w+)$|(^(.*\*\/)?\s*\}.*)$)/;
-}
 export function increaseIndentPattern() {
   const old_if = /\b(if|while)\s+\([^\)]*?\)/;
   const keywords_not_ending = /((?<!\bend\b\s*?)\b(if|while|for|match|try))/;
 
   const keywords =
     /(\b(then|else|do|catch|finally|yield|return|throw))|=|=>|<-|=>>|:/;
-  const brackets = /(^.*\{[^}"']*$)/;
   const ending_spaces = /\s*?$/;
 
-  const regexp = `((${keywords_not_ending.source}|${old_if.source}|${keywords.source})${ending_spaces.source})|${brackets.source}`;
+  const regexp = `(${keywords_not_ending.source}|${old_if.source}|${keywords.source})${ending_spaces.source}`;
   return new RegExp(regexp);
 }

--- a/src/test/indentPattern.test.ts
+++ b/src/test/indentPattern.test.ts
@@ -1,4 +1,4 @@
-import { decreaseIndentPattern, increaseIndentPattern } from "../indentPattern";
+import { increaseIndentPattern } from "../indentPattern";
 
 function checkIndent(indentPattern: RegExp, result: Boolean) {
   return (text: string) => expect(indentPattern.test(text)).toEqual(result);
@@ -12,18 +12,6 @@ describe("IncreaseIndentPattern Test Suite", () => {
   const [checkIncrease, checkNotIncrease] = checkFunctions(
     increaseIndentPattern()
   );
-
-  test("Scala2", () => {
-    checkIncrease("object Main extends App {");
-    checkIncrease("{");
-    checkIncrease("def myFunc(): Unit = {");
-    checkIncrease("val myLambda = () => {");
-
-    checkNotIncrease('val a: String = "a"');
-    checkNotIncrease("def myFunc(): Unit = {}");
-    checkNotIncrease("val myLambda = () => {}");
-    checkNotIncrease("val a: String = \"blocks starts with '{'\"");
-  });
 
   test("Scala3", () => {
     // after the closing ) of a condition in an old-style if or while.
@@ -63,28 +51,5 @@ describe("IncreaseIndentPattern Test Suite", () => {
     checkIncrease("{some code} yield");
 
     checkNotIncrease("{some code} yield {some other code}");
-  });
-});
-
-describe("DecreaseIndentPattern Test Suite", () => {
-  const [checkDecrease, checkNotDecrease] = checkFunctions(
-    decreaseIndentPattern()
-  );
-
-  test("Scala2 ", () => {
-    checkDecrease("}");
-    checkDecrease("*/ }");
-
-    checkNotDecrease('val a = \'"ciao" }');
-    checkNotDecrease("object Main extends App {");
-  });
-
-  test("Scala3", () => {
-    checkDecrease("end if");
-    checkDecrease("end while");
-    checkDecrease("end for");
-    checkDecrease("end match");
-    checkDecrease("end try");
-    checkDecrease("end Class");
   });
 });


### PR DESCRIPTION
It turns out that we need to have the same number of indents as deindents, otherwise when we write `end m...` it will increase indentation n - 1, where n was the last indentation that was increased. In order to make it work properly we would also need to deindent without an end marker.

This changes the behaviour to only indent for onEnterRules, which does not work the same and does not require deindent.

I also added an additional rule so that no automatic indentation is made when we press enter before an expression.

The problem this is fixing is:
![scala3-example-project-1631218361758](https://user-images.githubusercontent.com/3807253/132755913-cb9d7efa-b6e2-42c6-8fcd-089c2269fd95.gif)
