### PR TITLE
Make Java Home setting machine-scoped

### DIFF
--- a/package.json
+++ b/package.json
@@ -140,6 +140,7 @@
         },
         "metals.javaHome": {
           "type": "string",
+          "scope": "machine",
           "markdownDescription": "Optional path to the Java home directory. Requires reloading the window.\n\nDefaults to the most recent Java version between 8 and 11 (inclusive) computed by the `locate-java-home` npm package."
         },
         "metals.sbtScript": {


### PR DESCRIPTION
Recently, I started using VSCode(ium) on Windows, which necessitated manually specifying the Java home setting in the extension settings. This was all fine and dandy, until I turned back to my Linux box, only to find it being broken by the settings synchronization. To my great satisfaction, it turned out to be already a supported to restrict the effect of a setting to machine-local: https://code.visualstudio.com/updates/v1_34#_machinespecific-settings
I tested this with Codium 1.60 across 2 Linux (Artix) and 1 Windows (10) hosts, having satisfying results.