### PR TITLE
Add Symbol-search command

### DIFF
--- a/package.json
+++ b/package.json
@@ -381,6 +381,11 @@
         "command": "metals.test-current-target",
         "category": "Metals",
         "title": "Run all test in the current project"
+      },
+      {
+        "command": "metals.symbol-search",
+        "category": "Metals",
+        "title": "Search symbol in workspace"
       }
     ],
     "menus": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -74,6 +74,8 @@ import {
 import { clearTimeout } from "timers";
 import { increaseIndentPattern } from "./indentPattern";
 import { TastyResponse } from "./executeCommand";
+import { gotoLocation } from "./goToLocation";
+import { openSymbolSearch } from "./openSymbolSearch";
 
 const outputChannel = window.createOutputChannel("Metals");
 const openSettingsAction = "Open settings";
@@ -867,6 +869,9 @@ function launchMetals(
         });
       });
 
+      // NOTE: we offer a custom symbol search command to work around the limitations of the built-in one, see https://github.com/microsoft/vscode/issues/98125 for more details.
+      registerCommand(`metals.symbol-search`, () => openSymbolSearch(client));
+
       window.onDidChangeActiveTextEditor((editor) => {
         if (editor && isSupportedLanguage(editor.document.languageId)) {
           client.sendNotification(
@@ -1006,32 +1011,6 @@ function launchMetals(
         outputChannel.appendLine(reason.message);
       }
     }
-  );
-}
-
-function gotoLocation(location: Location, otherWindow: Boolean): void {
-  const range = new Range(
-    location.range.start.line,
-    location.range.start.character,
-    location.range.end.line,
-    location.range.end.character
-  );
-  var vs = ViewColumn.Active;
-  if (otherWindow) {
-    vs =
-      window.visibleTextEditors
-        .filter(
-          (vte) =>
-            window.activeTextEditor?.document.uri.scheme != "output" &&
-            vte.viewColumn
-        )
-        .pop()?.viewColumn || ViewColumn.Beside;
-  }
-  workspace.openTextDocument(Uri.parse(location.uri)).then((textDocument) =>
-    window.showTextDocument(textDocument, {
-      selection: range,
-      viewColumn: vs,
-    })
   );
 }
 

--- a/src/goToLocation.ts
+++ b/src/goToLocation.ts
@@ -1,0 +1,28 @@
+import { workspace, window, ViewColumn, Uri, Range } from "vscode";
+import { Location } from "vscode-languageclient/node";
+
+export function gotoLocation(location: Location, otherWindow: Boolean): void {
+  const range = new Range(
+    location.range.start.line,
+    location.range.start.character,
+    location.range.end.line,
+    location.range.end.character
+  );
+  var vs = ViewColumn.Active;
+  if (otherWindow) {
+    vs =
+      window.visibleTextEditors
+        .filter(
+          (vte) =>
+            window.activeTextEditor?.document.uri.scheme != "output" &&
+            vte.viewColumn
+        )
+        .pop()?.viewColumn || ViewColumn.Beside;
+  }
+  workspace.openTextDocument(Uri.parse(location.uri)).then((textDocument) =>
+    window.showTextDocument(textDocument, {
+      selection: range,
+      viewColumn: vs,
+    })
+  );
+}


### PR DESCRIPTION
Fixes scalameta/metals#2346.

The build-in symbols search in vscode doesn't work well as it filters out items which label doesn't match query. Beucase of that queries with `;` (include dependencies) and short forms like `j.n.f.Path` haven't worked.


![output](https://user-images.githubusercontent.com/5816952/133675550-c199e79a-55cc-4df6-871d-c8a3b1f0b3a3.gif)

