### PR TITLE
Allow braces to be split with an added indentation

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1090,6 +1090,12 @@ function enableScaladocIndentation() {
       {
         // stop vscode from indenting automatically to last known indentation
         beforeText: /^\s*/,
+        /* we still want {} to be nicely split with two new lines into
+         *{
+         *  |
+         *}
+         */
+        afterText: /[^\]\}\)]+/,
         action: { indentAction: IndentAction.None },
       },
       {


### PR DESCRIPTION
Before the change:

![after](https://user-images.githubusercontent.com/3807253/133758983-ebccce95-cc4e-4fb5-ad61-80ff81192037.gif)

after:

![before](https://user-images.githubusercontent.com/3807253/133759016-88303997-68ca-4150-b820-51fb0fe22d2c.gif)


