### PR TITLE
Prefill symbol search with the word under cursor, if any

### DIFF
--- a/src/openSymbolSearch.ts
+++ b/src/openSymbolSearch.ts
@@ -33,6 +33,16 @@ export function openSymbolSearch(client: LanguageClient): void {
   inputBox.matchOnDetail = false;
   inputBox.matchOnDescription = false;
 
+  const activeTextEditor = window.activeTextEditor;
+  const wordRange = activeTextEditor?.document?.getWordRangeAtPosition(
+    activeTextEditor?.selection.active
+  );
+  const wordUnderCursor =
+    wordRange && activeTextEditor?.document?.getText(wordRange);
+  if (wordUnderCursor) {
+    inputBox.value = wordUnderCursor;
+  }
+
   let cancelToken: CancellationTokenSource | null = null;
 
   inputBox.onDidChangeValue(() => {


### PR DESCRIPTION
This mimics a behavior of the default symbol search which I've always found immensely useful.

When there's an active text editor, the quick pick is prefilled with the word under cursor (provided there's an active text editor and there's actually a word under the cursor).

Demo:

![2021-09-17 18 17 14](https://user-images.githubusercontent.com/691940/133821340-859fdc31-158d-4ca8-a01b-9ecde69e1dec.gif)


