### PR TITLE
Revert #717

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -27,8 +27,6 @@ import {
   TextEditorEdit,
   ConfigurationTarget,
   TextDocumentContentProvider,
-  CompletionList,
-  CompletionItem,
   ProviderResult,
   Hover,
   TextDocument,
@@ -370,37 +368,6 @@ function launchMetals(
     outputChannel: outputChannel,
     initializationOptions,
     middleware: {
-      // VSCode might reorder items in case if items were matched by fuzzySearch
-      // This workarond is taken from:
-      //   https://github.com/llvm/llvm-project/commit/c86f794bd555a272f0f74a0b0a48f158e84b26b4
-      provideCompletionItem: async (
-        document,
-        position,
-        context,
-        token,
-        next
-      ) => {
-        // Get the incomplete identifier before the cursor.
-        let word = document.getWordRangeAtPosition(position);
-        let prefix = word && document.getText(new Range(word.start, position));
-
-        let list = await next(document, position, context, token);
-
-        let isIncomplete = false;
-        let originalItems: CompletionItem[] = [];
-        if (Array.isArray(list)) {
-          originalItems = list;
-          isIncomplete = false;
-        } else if (list) {
-          originalItems = list.items;
-        }
-
-        let items = originalItems.map((item) => {
-          if (prefix) item.filterText = prefix + "_" + item.filterText;
-          return item;
-        });
-        return new CompletionList(items, isIncomplete);
-      },
       provideHover: hoverLinksMiddlewareHook,
     },
   };


### PR DESCRIPTION
As it turns out, we missed that in some cases Metals return incorrect
completions that were filtered out by VS Code.

For example:
```
// sample 1
for {
  x <- Some(1)
} y@@ // <- [Empty - scala.meta.internal.semanticdb.Tree, ..]

// sample 2
Input@@ // <- [InterruptedException]
```

Let's revert #717 it and do release as the original issue was less annoying
than current state.

We can return this hack back in next release once this will be fixed on
server side.