### PR TITLE
Implement basics of test API

### DIFF
--- a/package.json
+++ b/package.json
@@ -250,6 +250,15 @@
           "default": false,
           "markdownDescription": "When this option is enabled, when user pastes any snippet into a Scala file, Metals will try to adjust the indentation to that of the current cursor."
         },
+        "metals.testUserInterface": {
+          "type": "string",
+          "default": "Test Explorer",
+          "enum": [
+            "Test Explorer",
+            "Code Lenses"
+          ],
+          "markdownDescription": "Specifies which UI should be used for tests. `Code lenses` shows virtual text above test class, just like it was previously. `Test explorer` is a new option which shows gutter icons on the left of the file in a less intrusive way. Moreover, this option comes with a new panel called `Testing` which lists all test suites in your codebase and allows you to browse tests and navigate to the file which contains them."
+        },
         "metals.fallbackScalaVersion": {
           "type": "string",
           "default": "automatic",
@@ -796,6 +805,7 @@
     "vsce": "2.5.1"
   },
   "dependencies": {
+    "ansicolor": "^1.1.95",
     "metals-languageclient": "0.5.5",
     "promisify-child-process": "4.1.1",
     "vscode-languageclient": "7.0.0"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -36,6 +36,7 @@ import {
   ExecuteCommandRequest,
   Location,
   CancellationToken,
+  CodeLensRefreshRequest,
 } from "vscode-languageclient/node";
 import { LazyProgress } from "./lazy-progress";
 import * as fs from "fs";
@@ -64,6 +65,7 @@ import {
   MetalsQuickPick,
   DebugDiscoveryParams,
   RunType,
+  TestUIKind,
 } from "metals-languageclient";
 import * as metalsLanguageClient from "metals-languageclient";
 import { startTreeView } from "./treeview";
@@ -83,7 +85,8 @@ import {
 } from "./findinfiles";
 import * as ext from "./hoverExtension";
 import { decodeAndShowFile, MetalsFileProvider } from "./metalsContentProvider";
-import { getTextDocumentPositionParams } from "./util";
+import { getTextDocumentPositionParams, getValueFromConfig } from "./util";
+import { createTestManager } from "./test-explorer/test-manager";
 const outputChannel = window.createOutputChannel("Metals");
 const openSettingsAction = "Open settings";
 const downloadJava = "Download Java";
@@ -359,6 +362,7 @@ function launchMetals(
     slowTaskProvider: true,
     statusBarProvider: "on",
     treeViewProvider: true,
+    testExplorerProvider: true,
   };
 
   const clientOptions: LanguageClientOptions = {
@@ -610,6 +614,33 @@ function launchMetals(
         { scheme: "file", language: "scala" },
         codeLensRefresher
       );
+
+      const getTestUI = () =>
+        getValueFromConfig<TestUIKind>(
+          config,
+          "testUserInterface",
+          "Test Explorer"
+        );
+
+      const istTestManagerDisabled = getTestUI() === "Code Lenses";
+      const testManager = createTestManager(client, istTestManagerDisabled);
+
+      const disableTestExplorer = workspace.onDidChangeConfiguration(() => {
+        const testUI = getTestUI();
+        if (testUI === "Code Lenses") {
+          testManager.disable();
+        } else {
+          testManager.enable();
+        }
+      });
+
+      const refreshTests = client.onRequest(CodeLensRefreshRequest.type, () => {
+        testManager.discoverTestSuites();
+      });
+
+      context.subscriptions.push(disableTestExplorer);
+      context.subscriptions.push(refreshTests);
+      context.subscriptions.push(testManager.testController);
 
       // Handle the metals/executeClientCommand extension notification.
       client.onNotification(ExecuteClientCommand.type, (params) => {

--- a/src/test-explorer/analyze-test-run.ts
+++ b/src/test-explorer/analyze-test-run.ts
@@ -1,0 +1,72 @@
+import * as vscode from "vscode";
+import {
+  Failed,
+  SingleTestResult,
+  SuiteName,
+  TestRunActions,
+  TestSuiteResult,
+} from "./types";
+import { ansicolor } from "ansicolor";
+
+/**
+ * Analyze results from TestRun and pass inform Test Controller about them.
+ *
+ * @param run Interface which corresponds to available actions in vscode.TestRun
+ * @param tests which should have been run in this TestRun
+ * @param testSuitesResult result which came back from DAP server
+ * @param teardown cleanup logic which has to be called at the end of function
+ */
+export const analyzeTestRun = (
+  run: TestRunActions,
+  tests: vscode.TestItem[],
+  testSuitesResults: TestSuiteResult[],
+  teardown?: () => void
+): void => {
+  const results = createResultsMap(testSuitesResults);
+  for (const test of tests) {
+    const suiteName = test.id as SuiteName;
+    const result = results.get(suiteName);
+    if (result != null) {
+      const duration = result.duration;
+      const failed = result.tests.filter(isFailed);
+      if (failed.length > 0) {
+        const msg = extractErrorMessages(failed);
+        run.failed?.(test, msg, duration);
+      } else {
+        run.passed?.(test, duration);
+      }
+    } else {
+      run.skipped?.(test);
+    }
+  }
+  teardown?.();
+};
+
+function isFailed(result: SingleTestResult): result is Failed {
+  return result.kind === "failed";
+}
+
+/**
+ * Transforms array of suite results into mapping between suite name and suite result
+ */
+function createResultsMap(
+  testSuitesResults: TestSuiteResult[]
+): Map<SuiteName, TestSuiteResult> {
+  const resultsTuples: [SuiteName, TestSuiteResult][] = testSuitesResults.map(
+    (result) => [result.suiteName, result]
+  );
+  const results = new Map(resultsTuples);
+  return results;
+}
+
+/**
+ * Extract error messages for array of failed tests and map them to the TestMessage.
+ * Messages can include ANSI escape sequences such as colors, but they have to be stripped
+ * because vscode test explorer doesn't support ANSI color codes.
+ */
+function extractErrorMessages(failed: Failed[]): vscode.TestMessage[] {
+  const msg = failed
+    .map((t) => ansicolor.strip(t.error))
+    .map((message) => ({ message }));
+  return msg;
+}

--- a/src/test-explorer/test-cache.ts
+++ b/src/test-explorer/test-cache.ts
@@ -1,0 +1,51 @@
+import * as vscode from "vscode";
+import { TestItemMetadata, TestSuiteResult } from "./types";
+
+class TestCache {
+  private readonly metadata = new WeakMap<vscode.TestItem, TestItemMetadata>();
+  private readonly suiteResults = new Map<string, TestSuiteResult[]>();
+
+  setMetadata(test: vscode.TestItem, data: TestItemMetadata): void {
+    this.metadata.set(test, data);
+  }
+
+  getMetadata(test: vscode.TestItem): TestItemMetadata | undefined {
+    return this.metadata.get(test);
+  }
+
+  /**
+   * Get all descendant suites of a given TestItem.
+   * For build target it returns all test suite within it, same for package.
+   * If is called with TestItem which is a suite, then returns itself
+   */
+  getTestItemChildren(test: vscode.TestItem): vscode.TestItem[] {
+    if (this.getMetadata(test)?.kind === "suite") {
+      return [test];
+    } else {
+      let children: vscode.TestItem[] = [];
+      test.children.forEach((child) => {
+        const descendants = this.getTestItemChildren(child);
+        children = [...children, ...descendants];
+      });
+      return children;
+    }
+  }
+
+  addSuiteResult(debugSession: string, result: TestSuiteResult): void {
+    this.suiteResults.get(debugSession)?.push(result);
+  }
+
+  getSuiteResultsFor(debugSession: string): TestSuiteResult[] | undefined {
+    return this.suiteResults.get(debugSession);
+  }
+
+  setEmptySuiteResultsFor(debugSession: string): void {
+    this.suiteResults.set(debugSession, []);
+  }
+
+  clearSuiteResultsFor(debugSession: string): void {
+    this.suiteResults.delete(debugSession);
+  }
+}
+
+export const testCache = new TestCache();

--- a/src/test-explorer/test-manager.ts
+++ b/src/test-explorer/test-manager.ts
@@ -1,0 +1,175 @@
+import * as vscode from "vscode";
+import { TestRunProfileKind, tests } from "vscode";
+import {
+  ExecuteCommandRequest,
+  LanguageClient,
+} from "vscode-languageclient/node";
+import { testCache } from "./test-cache";
+import { runHandler } from "./test-run-handler";
+import {
+  SuiteDiscovery,
+  TargetName,
+  TargetUri,
+  TestDiscoveryResult,
+  TestItemMetadata,
+} from "./types";
+import { toVscodeRange } from "./util";
+
+export function createTestManager(
+  client: LanguageClient,
+  isDisabled: boolean
+): TestManager {
+  return new TestManager(client, isDisabled);
+}
+
+class TestManager {
+  readonly testController = tests.createTestController(
+    "metalsTestController",
+    "Metals Test Explorer"
+  );
+
+  private isDisabled = false;
+  private isRunning = false;
+
+  constructor(private readonly client: LanguageClient, isDisabled: boolean) {
+    if (isDisabled) {
+      this.disable();
+    }
+    this.testController.resolveHandler = async (item?: vscode.TestItem) => {
+      if (item != null) {
+        return;
+      } else {
+        await this.discoverTestSuites();
+      }
+    };
+
+    const callback = () => (this.isRunning = false);
+
+    this.testController.createRunProfile(
+      "Run",
+      TestRunProfileKind.Run,
+      (request, token) => {
+        if (!this.isRunning) {
+          this.isRunning = true;
+          runHandler(this.testController, true, callback, request, token);
+        }
+      },
+      true
+    );
+
+    this.testController.createRunProfile(
+      "Debug",
+      TestRunProfileKind.Debug,
+      (request, token) => {
+        if (!this.isRunning) {
+          this.isRunning = true;
+          runHandler(this.testController, false, callback, request, token);
+        }
+      },
+      false
+    );
+  }
+
+  async enable(): Promise<void> {
+    this.isDisabled = false;
+    await this.discoverTestSuites();
+  }
+
+  /**
+   * Disables test manager, also it deletes all discovered test items in order to hide gutter icons.
+   */
+  disable(): void {
+    this.testController.items.forEach((item) =>
+      this.testController.items.delete(item.id)
+    );
+    this.isDisabled = true;
+  }
+
+  discoverTestSuites(): Promise<void> {
+    if (this.isDisabled) {
+      return Promise.resolve();
+    }
+
+    return this.client
+      .sendRequest(ExecuteCommandRequest.type, {
+        command: "discover-test-suites",
+      })
+      .then(
+        (value: SuiteDiscovery[]) => {
+          for (const { targetName, targetUri, discovered } of value) {
+            const rootNode = this.testController.createTestItem(
+              targetName,
+              targetName
+            );
+            createTestItems(
+              this.testController,
+              discovered,
+              rootNode,
+              targetName,
+              targetUri
+            );
+            const data: TestItemMetadata = {
+              kind: "project",
+              targetName,
+              targetUri,
+            };
+            testCache.setMetadata(rootNode, data);
+            this.testController.items.add(rootNode);
+          }
+        },
+        (err) => console.error(err)
+      );
+  }
+}
+
+/**
+ * Create TestItems from the given @param discoveredArray and add them to the @param parent
+ */
+function createTestItems(
+  testController: vscode.TestController,
+  discoveredArray: TestDiscoveryResult[],
+  parent: vscode.TestItem,
+  targetName: TargetName,
+  targetUri: TargetUri
+) {
+  for (const discovered of discoveredArray) {
+    if (discovered.kind === "suite") {
+      const { className, location, fullyQualifiedName } = discovered;
+      const parsedUri = vscode.Uri.parse(location.uri);
+      const parsedRange = toVscodeRange(location.range);
+      const testItem = testController.createTestItem(
+        fullyQualifiedName,
+        className,
+        parsedUri
+      );
+      testItem.range = parsedRange;
+      const data: TestItemMetadata = {
+        kind: "suite",
+        targetName,
+        targetUri,
+      };
+      testCache.setMetadata(testItem, data);
+      parent.children.add(testItem);
+    } else {
+      const data: TestItemMetadata = {
+        kind: "package",
+        targetName,
+        targetUri,
+      };
+
+      const packageNode = testController.createTestItem(
+        `${parent.id}.${discovered.prefix}`,
+        discovered.prefix
+      );
+      parent.children.add(packageNode);
+      testCache.setMetadata(packageNode, data);
+      createTestItems(
+        testController,
+        discovered.children,
+        packageNode,
+        targetName,
+        targetUri
+      );
+    }
+  }
+}

--- a/src/test-explorer/test-run-handler.ts
+++ b/src/test-explorer/test-run-handler.ts
@@ -1,0 +1,174 @@
+import { ServerCommands } from "metals-languageclient";
+import * as vscode from "vscode";
+import {
+  CancellationToken,
+  commands,
+  TestController,
+  TestRunRequest,
+} from "vscode";
+import { debugServerFromUri, DebugSession } from "../scalaDebugger";
+import { analyzeTestRun } from "./analyze-test-run";
+import { testCache } from "./test-cache";
+import { DapEvent, TargetUri, TestItemMetadata } from "./types";
+
+// this id is used to mark DAP sessions created by TestController
+// thanks to that debug tracker knows which requests it should track and gather results
+export const testRunnerId = "scala-dap-test-runner";
+
+/**
+ * Register tracker which tracks all DAP sessions which are started with @constant {testRunnerId} kind.
+ * Dap sends execution result for every suite included in TestRun in a special event of kind 'testResult'.
+ * Tracker has to capture these events and store them all in map under debug session id as a key.
+ */
+vscode.debug.registerDebugAdapterTrackerFactory("scala", {
+  createDebugAdapterTracker(session) {
+    if (session.configuration.kind === testRunnerId) {
+      return {
+        onWillStartSession: () => testCache.setEmptySuiteResultsFor(session.id),
+        onDidSendMessage: (msg: DapEvent) => {
+          if (
+            msg.event === "testResult" &&
+            msg.body.category === "testResult"
+          ) {
+            testCache.addSuiteResult(session.id, msg.body.data);
+          }
+        },
+      };
+    }
+  },
+});
+
+/**
+ * runHandler is a function which is called to start a TestRun. Depending on the run profile it may be ordinary run or a debug TestRun.
+ * It creates run queue which contains test supposed to be run and then for each entry it creates & run a debug session
+ */
+export async function runHandler(
+  testController: TestController,
+  noDebug: boolean,
+  callback: () => void,
+  request: TestRunRequest,
+  token: CancellationToken
+): Promise<void> {
+  const run = testController.createTestRun(request);
+  const queue = createRunQueue(request);
+
+  for (const { test, data } of queue) {
+    if (token.isCancellationRequested) {
+      run.skipped(test);
+    } else {
+      run.started(test);
+      const children = testCache.getTestItemChildren(test);
+      children.forEach((c) => run.enqueued(c));
+
+      try {
+        await commands.executeCommand("workbench.action.files.save");
+        const testsIds = children.map((t) => t.id);
+        const session = await createDebugSession(data.targetUri, testsIds);
+
+        if (!session) {
+          return;
+        }
+
+        const wasStarted = await startDebugging(session, noDebug);
+        if (!wasStarted) {
+          vscode.window.showErrorMessage("Debug session not started");
+          return run.failed(test, { message: "Debug session not started" });
+        }
+
+        await analyzeResults(run, children, callback);
+      } catch (error) {
+        console.error(error);
+      }
+    }
+  }
+  run.end();
+}
+
+/**
+ * Loop through all included tests in request and add them to our queue if they are not excluded explicitly
+ */
+function createRunQueue(
+  request: vscode.TestRunRequest
+): { test: vscode.TestItem; data: TestItemMetadata }[] {
+  const queue: { test: vscode.TestItem; data: TestItemMetadata }[] = [];
+
+  if (request.include) {
+    const excludes = new Set(request.exclude ?? []);
+    for (const test of request.include) {
+      if (!excludes.has(test)) {
+        const testData = testCache.getMetadata(test);
+        if (testData != null) {
+          queue.push({ test, data: testData });
+        }
+      }
+    }
+  }
+  return queue;
+}
+
+/**
+ * Creates a debug session via Metals DebugAdapterStart command.
+ * dataKind and data are determined by BSP debug request method.
+ */
+async function createDebugSession(
+  targetUri: TargetUri,
+  testsIds: string[]
+): Promise<DebugSession | undefined> {
+  return vscode.commands.executeCommand<DebugSession>(
+    ServerCommands.DebugAdapterStart,
+    {
+      targets: [{ uri: targetUri }],
+      dataKind: "scala-test-suites",
+      data: testsIds,
+    }
+  );
+}
+
+/**
+ * Starts interacting with created debug session.
+ * kind is set to the testRunnerId. It helps to differentiate debug session which were started by Test Explorer.
+ * These sessions are tracked by a vscode.debug.registerDebugAdapterTrackerFactory, which capture special event
+ * containing information about test suite execution.
+ */
+async function startDebugging(session: DebugSession, noDebug: boolean) {
+  const port = debugServerFromUri(session.uri).port;
+  const configuration: vscode.DebugConfiguration = {
+    type: "scala",
+    name: session.name,
+    noDebug,
+    request: "launch",
+    debugServer: port,
+    kind: testRunnerId,
+  };
+  return vscode.debug.startDebugging(undefined, configuration);
+}
+
+/**
+ * Analyze test results when debug session ends.
+ * Retrieves test suite results for current debus session gathered by DAP tracker and passes
+ * them to the analyzer function. After analysis ends, results are cleaned.
+ */
+async function analyzeResults(
+  run: vscode.TestRun,
+  children: vscode.TestItem[],
+  callback: () => void
+) {
+  return new Promise<void>((resolve) => {
+    const disposable = vscode.debug.onDidTerminateDebugSession(
+      (session: vscode.DebugSession) => {
+        const testSuitesResult = testCache.getSuiteResultsFor(session.id) ?? [];
+
+        // disposes current subscription and removes data from result map
+        const teardown = () => {
+          disposable.dispose();
+          testCache.clearSuiteResultsFor(session.id);
+          callback();
+        };
+
+        // analyze current TestRun
+        analyzeTestRun(run, children, testSuitesResult, teardown);
+        return resolve();
+      }
+    );
+  });
+}

--- a/src/test-explorer/types.ts
+++ b/src/test-explorer/types.ts
@@ -1,0 +1,102 @@
+import * as vscode from "vscode";
+import { Location } from "vscode-languageclient/node";
+import { newtype } from "../util";
+
+export type TargetName = newtype<string, "targetName">;
+export type TargetUri = newtype<string, "targetUri">;
+export type ClassName = newtype<string, "className">;
+export type FullyQualifiedName = newtype<string, "fullyQualifiedName">;
+export type TestName = newtype<string, "testName">;
+export type SuiteName = newtype<string, "suiteName">;
+
+/**
+ * Additional information about tests which is stored in map and retrieved when test is scheduled to run.
+ */
+export interface TestItemMetadata {
+  kind: "project" | "package" | "suite";
+  targetName: TargetName;
+  targetUri: TargetUri;
+}
+
+/**
+ * Information about test classes which is returned by Metals Language Server
+ */
+export interface SuiteDiscovery {
+  targetName: TargetName;
+  targetUri: TargetUri;
+  discovered: TestDiscoveryResult[];
+}
+
+export type TestDiscoveryResult = SuiteDiscovery | PackageDiscovery;
+
+export interface SuiteDiscovery {
+  kind: "suite";
+  className: ClassName;
+  fullyQualifiedName: FullyQualifiedName;
+  location: Location;
+}
+
+export interface PackageDiscovery {
+  kind: "package";
+  prefix: string;
+  children: TestDiscoveryResult[];
+}
+
+/**
+ * Subset of https://microsoft.github.io/debug-adapter-protocol/specification#Events_Output
+ * For our purposes we only care about testResult event which is used to pass information about test results from DAP server to the client.
+ **/
+export type DapEvent =
+  | {
+      event: "testResult";
+      body: {
+        category: "testResult";
+        data: TestSuiteResult;
+      };
+    }
+  | {
+      event: "output" | "exited" | "terminated";
+      body: {
+        category: "console" | "stdout" | "stderr" | string;
+        output: string;
+      };
+    };
+
+export interface TestSuiteResult {
+  suiteName: SuiteName;
+  duration: number;
+  tests: SingleTestResult[];
+}
+
+export type SingleTestResult = Passed | Failed | Skipped;
+
+interface Skipped {
+  kind: "skipped";
+  testName: TestName;
+}
+
+interface Passed {
+  kind: "passed";
+  testName: TestName;
+  duration: number;
+}
+
+export interface Failed {
+  kind: "failed";
+  testName: TestName;
+  duration: number;
+  error: string;
+}
+
+/**
+ * Describes actions from vscode.TestRun
+ */
+export interface TestRunActions {
+  failed?(
+    test: vscode.TestItem,
+    message: vscode.TestMessage | readonly vscode.TestMessage[],
+    duration?: number
+  ): void;
+  passed?(test: vscode.TestItem, duration?: number): void;
+  skipped?(test: vscode.TestItem): void;
+}

--- a/src/test-explorer/util.ts
+++ b/src/test-explorer/util.ts
@@ -1,0 +1,11 @@
+import { Range } from "vscode-languageclient/node";
+import * as vscode from "vscode";
+
+export function toVscodeRange(range: Range): vscode.Range {
+  return new vscode.Range(
+    range.start.line,
+    range.start.character,
+    range.end.line,
+    range.end.character
+  );
+}

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,9 +1,17 @@
-import { TextEditor } from "vscode";
+import { TextEditor, WorkspaceConfiguration } from "vscode";
 import {
   ExecuteCommandRequest,
   TextDocumentPositionParams,
 } from "vscode-languageclient";
 import { LanguageClient } from "vscode-languageclient/node";
+
+declare const sym: unique symbol;
+/**
+ * Creates a newtype without any runtime overhead. It's important for ID to be both unique and descriptive.
+ */
+export type newtype<A, ID extends string> = A & {
+  readonly [sym]: ID;
+};
 
 export function getTextDocumentPositionParams(
   editor: TextEditor
@@ -24,4 +32,17 @@ export function executeCommand<T>(
     command,
     arguments: args,
   });
+}
+
+export function getValueFromConfig<T>(
+  config: WorkspaceConfiguration,
+  key: string,
+  defaultValue: T
+): T {
+  const inspected = config.inspect<T>(key);
+  const fromConfig =
+    inspected?.workspaceValue ||
+    inspected?.globalValue ||
+    inspected?.defaultValue;
+  return fromConfig ?? defaultValue;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -854,6 +854,11 @@ ansi-styles@^5.0.0:
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-5.2.0.tgz#07449690ad45777d1924ac2abb2fc8895dba836b"
   integrity sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==
 
+ansicolor@^1.1.95:
+  version "1.1.95"
+  resolved "https://registry.yarnpkg.com/ansicolor/-/ansicolor-1.1.95.tgz#978c494f04793d6c58115ba13a50f56593f736c6"
+  integrity sha512-R4yTmrfQZ2H9Wr5TZoM2iOz0+T6TNHqztpld7ZToaN8EaUj/06NG4r5UHQfegA9/+K/OY3E+WumprcglbcTMRA==
+
 anymatch@^3.0.3:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-3.1.2.tgz#c0557c096af32f106198f4f4e2a383537e378716"


### PR DESCRIPTION
~There are some compilation errors which will be fixed in https://github.com/scalameta/metals-vscode/pull/754~ - done and merged

After the brainstorm, together with @tgodzik we concluded that using DAP Event to pass some structured data about test results (well-defined JSON) will be the best and the fastest approach. 
For now, mentioned data is passed through an OutputEvent, more specifically as a `testResult` event which contains all necessary information about the whole suite and at the same time about every single test.