### PR TITLE
Add Debuggers label

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
   },
   "icon": "images/logo.png",
   "categories": [
-    "Programming Languages"
+    "Programming Languages",
+    "Debuggers"
   ],
   "activationEvents": [
     "onCommand:metals.new-scala-project",


### PR DESCRIPTION
The label is basis for https://code.visualstudio.com/docs/editor/debugging where debuggers are dynamically queried.

It's probably never going to pop up there (I think it's the msot popular extensions), but it's better to add the label.