### PR TITLE
Replace config generation with automatic run of the current file

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1034,9 +1034,9 @@ function launchMetals(
       );
       treeViews = startTreeView(client, outputChannel, context, viewIds);
       context.subscriptions.concat(treeViews.disposables);
-      scalaDebugger
-        .initialize(outputChannel)
-        .forEach((disposable) => context.subscriptions.push(disposable));
+      scalaDebugger.initialize(outputChannel).forEach((disposable) => {
+        context.subscriptions.push(disposable);
+      });
       client.onNotification(DecorationTypeDidChange.type, (options) => {
         decorationType = window.createTextEditorDecorationType(options);
       });


### PR DESCRIPTION
Previously, when no launch.json was configured we would show a chain of quick picks so that the user would guided through configuring their entry. This however, would not be obvious to the users and would show up only once at the start. This was also not too obvious for the bginners and prompted https://github.com/scalameta/metals/issues/3272

Now, we remove the config generation and replace it by mechanism to detect if no launch.json is available and then run the command to run anything in the current file.

We might return partly to config generation when we have a mechanism to discover the the mains and tests, which can then be used to suggest new entries to launch.json.

Depends on https://github.com/scalameta/metals/pull/3311