### PR TITLE
Register the `metals.goto-position` command

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -822,6 +822,13 @@ function launchMetals(
         });
       });
 
+      registerCommand(`metals.goto-position`, (args) => {
+        client.sendRequest(ExecuteCommandRequest.type, {
+          command: "goto-position",
+          arguments: args,
+        });
+      });
+
       registerCommand("metals.reveal-active-file", () => {
         if (treeViews) {
           const editor = window.visibleTextEditors.find((e) =>


### PR DESCRIPTION
This is needed for go-to-definition for locally defined implicit decorations.

https://github.com/scalameta/metals/pull/3360

I will also need to update the metals-languageserver, but wanted to raise this in order not to forget.