### PR TITLE
Make go to definition work with the newest languageclient

### DIFF
--- a/package.json
+++ b/package.json
@@ -848,7 +848,7 @@
   },
   "dependencies": {
     "ansicolor": "^1.1.95",
-    "metals-languageclient": "0.5.5",
+    "metals-languageclient": "0.5.6",
     "promisify-child-process": "4.1.1",
     "vscode-languageclient": "7.0.0"
   },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -363,6 +363,7 @@ function launchMetals(
     statusBarProvider: "on",
     treeViewProvider: true,
     testExplorerProvider: true,
+    commandInHtmlFormat: "vscode",
   };
 
   const clientOptions: LanguageClientOptions = {
@@ -836,16 +837,6 @@ function launchMetals(
         }
       );
 
-      registerCommand("metals.goto-path-uri", (...args) => {
-        const uri = args[0] as string;
-        const line = args[1] as number;
-        const otherWindow = args[2] as boolean;
-        const pos = new Position(line, 0);
-        const range = new Range(pos, pos);
-        const location = Location.create(uri, range);
-        gotoLocation(location, otherWindow);
-      });
-
       registerCommand(`metals.${ServerCommands.ResetChoice}`, (args = []) => {
         client.sendRequest(ExecuteCommandRequest.type, {
           command: ServerCommands.ResetChoice,
@@ -859,6 +850,13 @@ function launchMetals(
           arguments: args,
         });
       });
+
+      registerCommand(
+        `metals.${ServerCommands.GotoPosition}`,
+        (location: Location) => {
+          if (location) gotoLocation(location, false);
+        }
+      );
 
       registerCommand("metals.reveal-active-file", () => {
         if (treeViews) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -925,6 +925,14 @@
     "@typescript-eslint/types" "4.33.0"
     eslint-visitor-keys "^2.0.0"
 
+"@viperproject/locate-java-home@^1.1.5":
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/@viperproject/locate-java-home/-/locate-java-home-1.1.5.tgz#8f3f6fd7a90d036e885ccdce23ac1d5db37aca4a"
+  integrity sha512-lRc+WTN29viSGTMyWHxPQ/+jA0F9VgFwkvcJw2EFLrRnuHZgXirdYMT0zRTXtJiT6ObXvy7+raPE2TDTxrcwQA==
+  dependencies:
+    async "^3.2.2"
+    semver "^7.3.5"
+
 abab@^2.0.3, abab@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.5.tgz#c0b678fb32d60fc1219c784d6a826fe385aeb79a"
@@ -1069,12 +1077,10 @@ astral-regex@^2.0.0:
   resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-2.0.0.tgz#483143c567aeed4785759c0865786dc77d7d2e31"
   integrity sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==
 
-async@^2.6.1:
-  version "2.6.3"
-  resolved "https://registry.yarnpkg.com/async/-/async-2.6.3.tgz#d72625e2344a3656e3a3ad4fa749fa83299d82ff"
-  integrity sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==
-  dependencies:
-    lodash "^4.17.14"
+async@^3.2.2:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/async/-/async-3.2.2.tgz#2eb7671034bb2194d45d30e31e24ec7e7f9670cd"
+  integrity sha512-H0E+qZaDEfx/FY4t7iLRv1W2fFI6+pyCeTw1uN20AQPiwqwM6ojPxHxdLv4z8hi2DtnW9BOckSspLucW7pIE5g==
 
 asynckit@^0.4.0:
   version "0.4.0"
@@ -2865,14 +2871,6 @@ linkify-it@^2.0.0:
   dependencies:
     uc.micro "^1.0.1"
 
-locate-java-home@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/locate-java-home/-/locate-java-home-1.1.2.tgz#8cc6af243ad7ae4e53f0b8c3a671986750f69f36"
-  integrity sha512-cyylBBX0lBYYOpWGb5pJED40PZvFVru315HUaArT842bC5681AxOxbuQu0AlcNA+WCUBB+n0OQ21FaCKg9Jx5Q==
-  dependencies:
-    async "^2.6.1"
-    semver "^5.5.1"
-
 locate-path@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-5.0.0.tgz#1afba396afd676a6d42504d0a67a3a7eb9f62aa0"
@@ -2900,7 +2898,7 @@ lodash.truncate@^4.4.2:
   resolved "https://registry.yarnpkg.com/lodash.truncate/-/lodash.truncate-4.4.2.tgz#5a350da0b1113b837ecfffd5812cbe58d6eae193"
   integrity sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM=
 
-lodash@^4.17.14, lodash@^4.17.15, lodash@^4.7.0:
+lodash@^4.17.15, lodash@^4.7.0:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -2957,13 +2955,13 @@ merge2@^1.3.0:
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
   integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
 
-metals-languageclient@0.5.5:
-  version "0.5.5"
-  resolved "https://registry.yarnpkg.com/metals-languageclient/-/metals-languageclient-0.5.5.tgz#6a570dae0b8a3c3b7ee9f06c838555eefc8b193f"
-  integrity sha512-1CCmsvXH0OzTx9UEM4+L2mbJGMuVfKpUdUbwreS+1kwSL603z8/yvWQU7SMEqjIEVM5HQuJyt4zAHskR8cDsLA==
+metals-languageclient@0.5.6:
+  version "0.5.6"
+  resolved "https://registry.yarnpkg.com/metals-languageclient/-/metals-languageclient-0.5.6.tgz#7d9432fcc4cdedfb838a97e4f8ec599b8513a3c8"
+  integrity sha512-Sp9cX7++6lc8N+1E4N+nkueuGVwCs0hxVsVfwT1YZbXtanuvQ/Z5XLY8KmAfDCceGxwPZWIyAvP7HzMAGPQV4Q==
   dependencies:
+    "@viperproject/locate-java-home" "^1.1.5"
     fp-ts "^2.4.1"
-    locate-java-home "^1.1.2"
     mkdirp "^1.0.3"
     node-fetch "^2.6.0"
     promisify-child-process "^4.0.0"
@@ -3546,7 +3544,7 @@ semver@7.x, semver@^7.1.1, semver@^7.2.1, semver@^7.3.2, semver@^7.3.4, semver@^
   dependencies:
     lru-cache "^6.0.0"
 
-semver@^5.1.0, semver@^5.4.1, semver@^5.5.1:
+semver@^5.1.0, semver@^5.4.1:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==


### PR DESCRIPTION
`metals.goto-position` is needed for locally defined implicit decorations, but we can skip the step of sending it to the server.

I also updated the client configuration to declare the link format for command links.