### PR TITLE
ci: publish pre-release version to VS Code Marketplace

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -1,4 +1,4 @@
-name: Release
+name: Pre-release
 
 on:
   push:

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -16,7 +16,7 @@ jobs:
   pre-release:
     if: |
       !contains(github.event.head_commit.message, 'scalameta/dependabot/') &&
-      !contains(github.event.head_commit.message, 'Signed-off-by: dependabot[bot]') &&
+      !contains(github.event.author.email, 'dependabot[bot]@users.noreply.github.com') &&
       github.event.author.email != 'bot@scalameta.org'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -6,13 +6,6 @@ on:
       - main
 
 jobs:
-  logging:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Print event metadata
-        run: |
-          echo "${{toJSON(github.event.commits[0])}}"
-          echo "${{toJSON(github.event.head_commit)}}"
   pre-release:
     if: |
       !contains(github.event.head_commit.message, 'scalameta/dependabot/') &&

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -1,0 +1,44 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  logging:
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+        echo "${{toJSON(github.event.commits[0])}}"
+        echo "${{toJSON(github.event.head_commit)}}"
+  pre-release:
+    if: |
+      !contains(github.event.head_commit.message, 'scalameta/dependabot/') &&
+      !contains(github.event.head_commit.message, 'Signed-off-by: dependabot[bot]') &&
+      github.event.author.email != 'bot@scalameta.org'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-node@v2
+        with:
+          node-version: "16"
+      - uses: actions/checkout@v2
+      - name: Setup git env
+        run: |
+          git config --global user.email "bot@scalameta.org"
+          git config --global user.name "Scalameta bot"
+      - run: |
+          yarn install
+          yarn version --no-git-tag-version --patch
+      - name: Commit changes
+        run: |
+          git add .
+          git commit -m "Increase patch version for pre-release"
+      - name: Publish pre-release version to Visual Studio Marketplace
+        uses: HaaLeo/publish-vscode-extension@v1
+        with:
+          pat: ${{ secrets.VS_MARKETPLACE_TOKEN }}
+          registryUrl: https://marketplace.visualstudio.com
+          preRelease: true
+          yarn: true
+      # Don't publish for VSX, it doesn't support pre-release versions

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -9,9 +9,10 @@ jobs:
   logging:
     runs-on: ubuntu-latest
     steps:
-      - run: |
-        echo "${{toJSON(github.event.commits[0])}}"
-        echo "${{toJSON(github.event.head_commit)}}"
+      - name: Print event metadata
+        run: |
+          echo "${{toJSON(github.event.commits[0])}}"
+          echo "${{toJSON(github.event.head_commit)}}"
   pre-release:
     if: |
       !contains(github.event.head_commit.message, 'scalameta/dependabot/') &&

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,12 +6,11 @@ on:
 
 jobs:
   release:
-    runs-on: "ubuntu-18.04"
-
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/setup-node@v2
         with:
-          node-version: "14"
+          node-version: "16"
       - name: Setup git env
         run: |
           git config --global user.email "bot@scalameta.org"
@@ -22,8 +21,7 @@ jobs:
         run: echo ::set-output name=NEW_VERSION::${GITHUB_REF#refs/tags/v}
       - run: yarn install
       - run: |
-          yarn version --no-git-tag-version --new-version ${{ steps.get_version.outputs.NEW_VERSION
-          }}
+          yarn version --no-git-tag-version --new-version ${{ steps.get_version.outputs.NEW_VERSION }}
       - name: Generate changelog
         run: |
           npx github-changes -b main -o scalameta -r metals-vscode --no-merges -t "VSCode Extension Changelog" -k ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
From docs:
_VS Code Marketplace only support major.minor.patch for extension versions and semver pre-release tags are not supported. Support for this will arrive in the future. Because of this we recommend that extensions use major.EVEN_NUMBER.patch for release versions and major.ODD_NUMBER.patch for pre-release versions. For example: 0.2.* for release and 0.3.* for pre-release. VS Code will auto update extensions to the highest version available, so even if a user opted into a pre-release version and there is an extension release with a higher version, that user will be updated to the released version._

Since `semver pre-release tags are not supported` some workaround has to be created, docs advise using `ODD_NUMBER` and `EVEN_NUMBER` for minors to differentiate between release and pre-release versions. It seems a little bit counterintuitive, hence together with @tgodzik we concluded that this approach will be easier. 

Release versions will use `major.MINOR.0` and pre-release ones will use `major.minor.PATCH`.

The `pre-release` job was added which:
- `needs: [release]` because it should run sequentially (in case there is the release, we want to publish pre-release anyway with proper version - bumped both minor and patch)
- has `always()` - `Causes the step to always execute` - even when release was skipped
- doesn't publish pre-release for trivial actions such as bumping dependencies