### PR TITLE
fix: update vscode version to support prelease

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -1,0 +1,47 @@
+name: Pre-release
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  pre-release:
+    if: |
+      !contains(github.event.head_commit.message, 'scalameta/dependabot/') &&
+      !contains(github.event.author.email, 'dependabot[bot]@users.noreply.github.com') &&
+      github.event.author.email != 'bot@scalameta.org'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-node@v2
+        with:
+          node-version: "16"
+      - uses: actions/checkout@v2
+      - name: Setup git env
+        run: |
+          git config --global user.email "bot@scalameta.org"
+          git config --global user.name "Scalameta bot"
+      - run: |
+          yarn install
+          yarn version --no-git-tag-version --patch
+      - name: Commit changes
+        run: |
+          git add .
+          git commit -m "Increase patch version for pre-release"
+      # Pre release version requires vscode ^1.63
+      # but we don't want to force normal users to update, modify it
+      - name: Update required vs code version
+        run: |
+          node ./update-version.js
+          yarn install
+      - name: Publish pre-release version to Visual Studio Marketplace
+        uses: HaaLeo/publish-vscode-extension@v1
+        with:
+          pat: ${{ secrets.VS_MARKETPLACE_TOKEN }}
+          registryUrl: https://marketplace.visualstudio.com
+          preRelease: true
+          yarn: true
+      # Don't publish for VSX, it doesn't support pre-release versions
+      # Push changes - increased patch version
+      - name: Push changes
+        run: git push origin HEAD:main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,12 +6,11 @@ on:
 
 jobs:
   release:
-    runs-on: "ubuntu-18.04"
-
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/setup-node@v2
         with:
-          node-version: "14"
+          node-version: "16"
       - name: Setup git env
         run: |
           git config --global user.email "bot@scalameta.org"
@@ -22,8 +21,7 @@ jobs:
         run: echo ::set-output name=NEW_VERSION::${GITHUB_REF#refs/tags/v}
       - run: yarn install
       - run: |
-          yarn version --no-git-tag-version --new-version ${{ steps.get_version.outputs.NEW_VERSION
-          }}
+          yarn version --no-git-tag-version --new-version ${{ steps.get_version.outputs.NEW_VERSION }}
       - name: Generate changelog
         run: |
           npx github-changes -b main -o scalameta -r metals-vscode --no-merges -t "VSCode Extension Changelog" -k ${{ secrets.GITHUB_TOKEN }}

--- a/update-version.js
+++ b/update-version.js
@@ -1,0 +1,8 @@
+const fs = require("fs");
+
+const path = "./package.json";
+
+const package = fs.readFileSync(path, { encoding: "utf8", flag: "r" });
+const updated = package.replaceAll("1.59.0", "1.63.0");
+
+fs.writeFileSync(path, updated);


### PR DESCRIPTION
I missed that prelease requires vscode `^1.63` but we don't want to force other users to update. Maybe what I propose is dirty, but it keeps status quo for release version and enables us to publish pre-release ones