### PR TITLE
ci: allow to skip prerelease workflow

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -8,9 +8,10 @@ on:
 jobs:
   pre-release:
     if: |
+      github.event.author.email != 'bot@scalameta.org' &&
       !contains(github.event.head_commit.message, 'scalameta/dependabot/') &&
       !contains(github.event.author.email, 'dependabot[bot]@users.noreply.github.com') &&
-      github.event.author.email != 'bot@scalameta.org'
+      !contains(github.event.head_commit.message, '[skip pre]')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/setup-node@v2


### PR DESCRIPTION
Sometimes changes don't bring any value to users and prerelase version doesn't need to be published. To avoid unnecessary versions and commits (scalameta bot bumping patch version) one can add `[skip pre]` to the commit message - prerelease workflow will be skipped. 

I think it's nice to have such a mechanism.