### PR TITLE
chore: switch from `extensionDependencies` to `extensionPack` [skip pre]

### DIFF
--- a/package.json
+++ b/package.json
@@ -854,7 +854,7 @@
     "promisify-child-process": "4.1.1",
     "vscode-languageclient": "7.0.0"
   },
-  "extensionDependencies": [
+  "extensionPack": [
     "scala-lang.scala"
   ]
 }


### PR DESCRIPTION
It is a very subtle change. However, it's plays a huge role in extension tests where, for some reason, `scala-lang.scala` extension can't be found if it's specified in `extensionDependencies`. Because Metals doesn't depend on Scala Syntax API it's safe to make this change.

<img width="767" alt="Screenshot 2022-01-20 at 13 06 34" src="https://user-images.githubusercontent.com/37124721/150336195-b7bae104-ef6f-4603-a035-ee446cba172a.png">
