### PR TITLE
ci: search for `dependabot[bot]` in commit message rather than email 

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -10,8 +10,9 @@ jobs:
     if: |
       github.event.author.email != 'bot@scalameta.org' &&
       !contains(github.event.head_commit.message, 'scalameta/dependabot/') &&
-      !contains(github.event.author.email, 'dependabot[bot]@users.noreply.github.com') &&
-      !contains(github.event.head_commit.message, '[skip pre]')
+      !contains(github.event.head_commit.message, 'dependabot[bot]') &&
+      !contains(github.event.head_commit.message, '[skip pre]') &&
+      !contains(github.event.head_commit.message, '[skip-pre]')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/setup-node@v2


### PR DESCRIPTION
I've merged 2 PR's, one using the merge option, the second one using the squash option. 

PR merged by squash triggered pre-release workflow and it was unexpected. `!contains(github.event.head_commit.message, 'dependabot[bot]')` should prevent that.

In addition, I also added `!contains(github.event.head_commit.message, '[skip-pre]')` - I've already written this instead of `[skip pre]` once, there may be another tries :D