### PR TITLE
Fix invoking focus on problems tab

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -729,9 +729,7 @@ function launchMetals(
           item.command = params.command;
           commands.getCommands().then((values) => {
             if (values.includes(command)) {
-              registerCommand(command, () => {
-                client.sendRequest(ExecuteCommandRequest.type, { command });
-              });
+              commands.executeCommand(command);
             }
           });
         } else {


### PR DESCRIPTION
Previously, each time an error was detected we would try to register a command indicated by `command` parameter if it was already registred. This would obviously fail as we explicitely checked for that. Now, whenever there is a problem in the workspace, the problem tab will be focused. Though the question is "should it?", wouldn't it be a bit annoying?