### PR TITLE
fix: debug isn't working after compilation error

### DIFF
--- a/src/test-explorer/test-run-handler.ts
+++ b/src/test-explorer/test-run-handler.ts
@@ -77,6 +77,7 @@ export async function runHandler(
 
         await analyzeResults(run, children, callback);
       } catch (error) {
+        callback();
         console.error(error);
       }
     }


### PR DESCRIPTION
fixes https://github.com/scalameta/metals-vscode/issues/849

I was thinking about signaling the user what's going on. However, vscode notification mechanism, which is a surprise, doesn't provide an option to display a true "notification" - message which will disappear on its own after some time.

I was thinking about `vscode.window.showWarningMessage("Debug didn't start because of compiler errors");` but this message stays until explicitly dismissed.