### PR TITLE
Make Java Home config scope machine-overridable

### DIFF
--- a/package.json
+++ b/package.json
@@ -201,7 +201,7 @@
         },
         "metals.javaHome": {
           "type": "string",
-          "scope": "machine",
+          "scope": "machine-overridable",
           "markdownDescription": "Optional path to the Java home directory. Requires reloading the window.\n\nDefaults to the most recent Java version between 8 and 11 (inclusive) computed by the `locate-java-home` npm package."
         },
         "metals.sbtScript": {


### PR DESCRIPTION
The previous change to the scope of `metals.javaHome` from #681 makes it so that users cannot override the configuration at a workspace level. For users that have multiple projects with specific Java versions it is useful to be able to set the path per project.
The VSCode configuration scope can be set as `machine-overridable` to allow for the setting to be explicitly configured for a workspace but still defaults to being configured on a machine level: https://code.visualstudio.com/api/references/contribution-points#Configuration-schema