### PR TITLE
Allow for relative paths in java home config

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -125,7 +125,6 @@ export async function activate(context: ExtensionContext): Promise<void> {
     },
     async () => {
       commands.executeCommand("setContext", "metals:enabled", true);
-
       try {
         const javaHome = await getJavaHome(getJavaHomeFromConfig());
         return fetchAndLaunchMetals(context, javaHome);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -121,10 +121,20 @@ export async function activate(context: ExtensionContext): Promise<void> {
     },
     async () => {
       commands.executeCommand("setContext", "metals:enabled", true);
+
+      const javaHomeConfig = ((jhPath) =>
+        jhPath?.trim() && !path.isAbsolute(jhPath)
+          ? path.resolve(
+              ...[workspace.workspaceFolders?.[0]?.uri.fsPath, jhPath].filter(
+                (s): s is string => !!s
+              )
+            )
+          : jhPath)(
+        workspace.getConfiguration("metals").get<string>("javaHome")
+      );
+
       try {
-        const javaHome = await getJavaHome(
-          workspace.getConfiguration("metals").get("javaHome")
-        );
+        const javaHome = await getJavaHome(javaHomeConfig);
         return fetchAndLaunchMetals(context, javaHome);
       } catch (err) {
         outputChannel.appendLine(`${err}`);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -84,7 +84,11 @@ import {
 } from "./findinfiles";
 import * as ext from "./hoverExtension";
 import { decodeAndShowFile, MetalsFileProvider } from "./metalsContentProvider";
-import { getTextDocumentPositionParams, getValueFromConfig } from "./util";
+import {
+  getJavaHomeFromConfig,
+  getTextDocumentPositionParams,
+  getValueFromConfig,
+} from "./util";
 import { createTestManager } from "./test-explorer/test-manager";
 const outputChannel = window.createOutputChannel("Metals");
 const openSettingsAction = "Open settings";
@@ -122,19 +126,8 @@ export async function activate(context: ExtensionContext): Promise<void> {
     async () => {
       commands.executeCommand("setContext", "metals:enabled", true);
 
-      const javaHomeConfig = ((jhPath) =>
-        jhPath?.trim() && !path.isAbsolute(jhPath)
-          ? path.resolve(
-              ...[workspace.workspaceFolders?.[0]?.uri.fsPath, jhPath].filter(
-                (s): s is string => !!s
-              )
-            )
-          : jhPath)(
-        workspace.getConfiguration("metals").get<string>("javaHome")
-      );
-
       try {
-        const javaHome = await getJavaHome(javaHomeConfig);
+        const javaHome = await getJavaHome(getJavaHomeFromConfig());
         return fetchAndLaunchMetals(context, javaHome);
       } catch (err) {
         outputChannel.appendLine(`${err}`);

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,4 +1,5 @@
-import { TextEditor, WorkspaceConfiguration } from "vscode";
+import * as path from "path";
+import { workspace, TextEditor, WorkspaceConfiguration } from "vscode";
 import {
   ExecuteCommandRequest,
   TextDocumentPositionParams,
@@ -45,4 +46,19 @@ export function getValueFromConfig<T>(
     inspected?.globalValue ||
     inspected?.defaultValue;
   return fromConfig ?? defaultValue;
+}
+
+export function getJavaHomeFromConfig(): string | undefined {
+  const javaHomePath = workspace
+    .getConfiguration("metals")
+    .get<string>("javaHome");
+  if (javaHomePath?.trim() && !path.isAbsolute(javaHomePath)) {
+    const pathSegments = [
+      workspace.workspaceFolders?.[0]?.uri.fsPath,
+      javaHomePath,
+    ].filter((s): s is string => s != null);
+    return path.resolve(...pathSegments);
+  } else {
+    return javaHomePath;
+  }
 }


### PR DESCRIPTION
This change is an implementation to allow for the path provided in `metals.javaHome` to be a relative path from the root directory of the workspace. 

The current behaviour when calling `getJavaHome` is that the path must be an absolute path or is resolved to a path relative to the system root `/`. If a user has a JDK located in their project directory, for example by using a nix profile to install a JDK in the same directory, it would be convenient to allow for the Metals configuration to use a path relative to the workspace. 