### PR TITLE
Revert VS Code type bump and switch mergify rule to 6 jobs

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,7 +1,7 @@
 pull_request_rules:
   - name: CI passes and is @types package from dependabot
     conditions:
-      - "#status-success=5"
+      - "#status-success=6"
       - author~=^dependabot(|-preview)\[bot\]$
       - title~=^Bump @types/(\w+) from .*$
       - base=main

--- a/package.json
+++ b/package.json
@@ -845,7 +845,7 @@
     "@types/glob": "^7.2.0",
     "@types/mocha": "^9.1.0",
     "@types/node": "17.0.13",
-    "@types/vscode": "1.63.2",
+    "@types/vscode": "1.59.0",
     "@typescript-eslint/eslint-plugin": "^4.33.0",
     "@typescript-eslint/parser": "^4.33.0",
     "@vscode/test-electron": "^2.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -111,10 +111,10 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.13.tgz#5ed7ed7c662948335fcad6c412bb42d99ea754e3"
   integrity sha512-Y86MAxASe25hNzlDbsviXl8jQHb0RDvKt4c40ZJQ1Don0AAL0STLZSs4N+6gLEO55pedy7r2cLwS+ZDxPm/2Bw==
 
-"@types/vscode@1.63.2":
-  version "1.63.2"
-  resolved "https://registry.yarnpkg.com/@types/vscode/-/vscode-1.63.2.tgz#1ee18eb7b1c1075b28a08afeb0910db915271613"
-  integrity sha512-awvdx4vX7SkMKyvWIlRjycjb4blYRSQI3Bav0YMn+lJLGN6gJgb20urN/dQCv/2ejDu5S6ADEBt6O15DOpIAkg==
+"@types/vscode@1.59.0":
+  version "1.59.0"
+  resolved "https://registry.yarnpkg.com/@types/vscode/-/vscode-1.59.0.tgz#11c93f5016926126bf30b47b9ece3bd617eeef31"
+  integrity sha512-Zg38rusx2nU6gy6QdF7v4iqgxNfxzlBlDhrRCjOiPQp+sfaNrp3f9J6OHIhpGNN1oOAca4+9Hq0+8u3jwzPMlQ==
 
 "@typescript-eslint/eslint-plugin@^4.33.0":
   version "4.33.0"


### PR DESCRIPTION
We recently added a new job that we forgot to accomodate in the mergify config.