### PR TITLE
Bump version manually

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "ide",
     "scalameta"
   ],
-  "version": "1.12.15",
+  "version": "1.12.16",
   "publisher": "scalameta",
   "contributors": [
     {


### PR DESCRIPTION
Previously, release job didn't manage to update the version due to changes that were quickly done to the main branch. This should fix the next prereleases.