### PR TITLE
refactor: extract commands from `extension.ts` to separate files

### DIFF
--- a/src/commands/client-commands.ts
+++ b/src/commands/client-commands.ts
@@ -1,0 +1,61 @@
+import { ClientCommands } from "metals-languageclient";
+import { commands, ExtensionContext, window } from "vscode";
+import { LanguageClient } from "vscode-languageclient/node";
+import { gotoLocation, WindowLocation } from "../goToLocation";
+import * as scalaDebugger from "../scalaDebugger";
+
+export function registerClientCommands(
+  context: ExtensionContext,
+  client: LanguageClient
+): void {
+  function registerCommand(
+    command: string,
+    callback: (...args: any[]) => unknown
+  ) {
+    context.subscriptions.push(commands.registerCommand(command, callback));
+  }
+  let channelOpen = false;
+
+  registerCommand(
+    `metals.${ClientCommands.GotoLocation}`,
+    (location: WindowLocation) => {
+      if (location) {
+        gotoLocation(location);
+      }
+    }
+  );
+
+  registerCommand(ClientCommands.FocusDiagnostics, () =>
+    commands.executeCommand("workbench.action.problems.focus")
+  );
+
+  registerCommand(ClientCommands.RunDoctor, () =>
+    commands.executeCommand(ClientCommands.RunDoctor)
+  );
+
+  registerCommand(ClientCommands.ToggleLogs, () => {
+    if (channelOpen) {
+      client.outputChannel.hide();
+      channelOpen = false;
+    } else {
+      client.outputChannel.show(true);
+      channelOpen = true;
+    }
+  });
+
+  registerCommand(ClientCommands.StartDebugSession, (...args: any[]) => {
+    scalaDebugger.start(false, ...args).then((wasStarted) => {
+      if (!wasStarted) {
+        window.showErrorMessage("Debug session not started");
+      }
+    });
+  });
+
+  registerCommand(ClientCommands.StartRunSession, (...args: any[]) => {
+    scalaDebugger.start(true, ...args).then((wasStarted) => {
+      if (!wasStarted) {
+        window.showErrorMessage("Run session not started");
+      }
+    });
+  });
+}

--- a/src/commands/client-commands.ts
+++ b/src/commands/client-commands.ts
@@ -3,18 +3,14 @@ import { commands, ExtensionContext, window } from "vscode";
 import { LanguageClient } from "vscode-languageclient/node";
 import { gotoLocation, WindowLocation } from "../goToLocation";
 import * as scalaDebugger from "../scalaDebugger";
+import { registerCommandWithin } from "../util";
 
 export function registerClientCommands(
   context: ExtensionContext,
   client: LanguageClient
 ): void {
-  function registerCommand(
-    command: string,
-    callback: (...args: any[]) => unknown
-  ) {
-    context.subscriptions.push(commands.registerCommand(command, callback));
-  }
   let channelOpen = false;
+  const registerCommand = registerCommandWithin(context);
 
   registerCommand(
     `metals.${ClientCommands.GotoLocation}`,

--- a/src/commands/client-commands.ts
+++ b/src/commands/client-commands.ts
@@ -1,6 +1,9 @@
 import { ClientCommands } from "metals-languageclient";
 import { commands, ExtensionContext, window } from "vscode";
-import { LanguageClient } from "vscode-languageclient/node";
+import {
+  ExecuteCommandRequest,
+  LanguageClient,
+} from "vscode-languageclient/node";
 import { gotoLocation, WindowLocation } from "../goToLocation";
 import * as scalaDebugger from "../scalaDebugger";
 import { registerCommandWithin } from "../util";
@@ -52,6 +55,12 @@ export function registerClientCommands(
       if (!wasStarted) {
         window.showErrorMessage("Run session not started");
       }
+    });
+  });
+
+  registerCommand(ClientCommands.EchoCommand, (arg: string) => {
+    client.sendRequest(ExecuteCommandRequest.type, {
+      command: arg,
     });
   });
 }

--- a/src/commands/execute-client-command.ts
+++ b/src/commands/execute-client-command.ts
@@ -1,0 +1,128 @@
+import {
+  ClientCommands,
+  ExecuteClientCommand,
+  MetalsOpenWindowParams,
+} from "metals-languageclient";
+import {
+  commands,
+  EventEmitter,
+  ExtensionContext,
+  OutputChannel,
+  Uri,
+  ViewColumn,
+  WebviewPanel,
+  window,
+} from "vscode";
+import { LanguageClient } from "vscode-languageclient/node";
+import { WindowLocation } from "../goToLocation";
+
+interface AdditionalParams {
+  outputChannel: OutputChannel;
+  compilationDoneEmitter: EventEmitter<void>;
+}
+
+export function registerExecuteClientCommands(
+  context: ExtensionContext,
+  client: LanguageClient,
+  additionalParams: AdditionalParams
+): void {
+  const { outputChannel, compilationDoneEmitter } = additionalParams;
+  let doctor: WebviewPanel | undefined;
+  let stacktrace: WebviewPanel | undefined;
+
+  function getDoctorPanel(isReload: boolean): WebviewPanel {
+    if (!doctor) {
+      doctor = window.createWebviewPanel(
+        "metals-doctor",
+        "Metals Doctor",
+        ViewColumn.Active,
+        { enableCommandUris: true }
+      );
+      context.subscriptions.push(doctor);
+      doctor.onDidDispose(() => {
+        doctor = undefined;
+      });
+    } else if (!isReload) {
+      doctor.reveal();
+    }
+    return doctor;
+  }
+
+  function getStacktracePanel(): WebviewPanel {
+    if (!stacktrace) {
+      stacktrace = window.createWebviewPanel(
+        "metals-stacktrace",
+        "Analyze Stacktrace",
+        ViewColumn.Beside,
+        { enableCommandUris: true }
+      );
+      context.subscriptions.push(stacktrace);
+      stacktrace.onDidDispose(() => {
+        stacktrace = undefined;
+      });
+    }
+    stacktrace.reveal();
+    return stacktrace;
+  }
+
+  // Handle the metals/executeClientCommand extension notification.
+  const disposable = client.onNotification(
+    ExecuteClientCommand.type,
+    (params) => {
+      switch (params.command) {
+        case ClientCommands.GotoLocation: {
+          const location = params.arguments?.[0] as WindowLocation;
+          commands.executeCommand(
+            `metals.${ClientCommands.GotoLocation}`,
+            location
+          );
+          break;
+        }
+        case ClientCommands.RefreshModel:
+          compilationDoneEmitter.fire();
+          break;
+        case ClientCommands.OpenFolder: {
+          const openWindowParams = params
+            .arguments?.[0] as MetalsOpenWindowParams;
+          if (openWindowParams) {
+            commands.executeCommand(
+              "vscode.openFolder",
+              Uri.parse(openWindowParams.uri),
+              openWindowParams.openNewWindow
+            );
+          }
+          break;
+        }
+        case "metals-show-stacktrace": {
+          const html = params.arguments && params.arguments[0];
+          if (typeof html === "string") {
+            const panel = getStacktracePanel();
+            panel.webview.html = html;
+          }
+          break;
+        }
+        case ClientCommands.RunDoctor:
+        case ClientCommands.ReloadDoctor: {
+          const isRun = params.command === ClientCommands.RunDoctor;
+          const isReload = params.command === ClientCommands.ReloadDoctor;
+          if (isRun || (doctor && isReload)) {
+            const html = params.arguments && params.arguments[0];
+            if (typeof html === "string") {
+              const panel = getDoctorPanel(isReload);
+              panel.webview.html = html;
+            }
+          }
+          break;
+        }
+        case ClientCommands.FocusDiagnostics:
+          commands.executeCommand(ClientCommands.FocusDiagnostics);
+          break;
+        default:
+          outputChannel.appendLine(`unknown command: ${params.command}`);
+      }
+
+      // Ignore other commands since they are less important.
+    }
+  );
+  context.subscriptions.push(disposable);
+}

--- a/src/commands/server-comands.ts
+++ b/src/commands/server-comands.ts
@@ -1,0 +1,136 @@
+import * as fs from "fs";
+import { ClientCommands, ServerCommands } from "metals-languageclient";
+import * as path from "path";
+import {
+  commands,
+  env,
+  ExtensionContext,
+  Uri,
+  window,
+  workspace,
+} from "vscode";
+import {
+  ExecuteCommandRequest,
+  LanguageClient,
+} from "vscode-languageclient/node";
+
+export function registerServerCommands(
+  context: ExtensionContext,
+  client: LanguageClient
+): void {
+  function registerCommand(
+    command: string,
+    callback: (...args: any[]) => unknown
+  ) {
+    context.subscriptions.push(commands.registerCommand(command, callback));
+  }
+
+  [
+    ServerCommands.BuildImport,
+    ServerCommands.BuildRestart,
+    ServerCommands.BuildConnect,
+    ServerCommands.BuildDisconnect,
+    ServerCommands.GenerateBspConfig,
+    ServerCommands.BspSwitch,
+    ServerCommands.SourcesScan,
+    ServerCommands.DoctorRun,
+    ServerCommands.CascadeCompile,
+    ServerCommands.CleanCompile,
+    ServerCommands.CancelCompilation,
+    ServerCommands.AmmoniteStart,
+    ServerCommands.AmmoniteStop,
+  ].forEach((command) => {
+    registerCommand("metals." + command, async () =>
+      client.sendRequest(ExecuteCommandRequest.type, { command: command })
+    );
+  });
+
+  registerCommand(ClientCommands.EchoCommand, (arg: string) => {
+    client.sendRequest(ExecuteCommandRequest.type, {
+      command: arg,
+    });
+  });
+
+  registerCommand(`metals.${ServerCommands.AnalyzeStacktrace}`, () => {
+    env.clipboard.readText().then((clip) => {
+      if (clip.trim().length < 1) {
+        window.showInformationMessage(
+          "Clipboard appears to be empty, copy stacktrace to clipboard and retry this command"
+        );
+      } else {
+        client.sendRequest(ExecuteCommandRequest.type, {
+          command: "analyze-stacktrace",
+          arguments: [clip],
+        });
+      }
+    });
+  });
+
+  registerCommand(`metals.${ServerCommands.ResetChoice}`, (args = []) => {
+    client.sendRequest(ExecuteCommandRequest.type, {
+      command: ServerCommands.ResetChoice,
+      arguments: args,
+    });
+  });
+
+  registerCommand(`metals.${ServerCommands.Goto}`, (args) => {
+    client.sendRequest(ExecuteCommandRequest.type, {
+      command: ServerCommands.Goto,
+      arguments: args,
+    });
+  });
+
+  registerCommand(`metals.${ServerCommands.NewScalaProject}`, async () => {
+    return client.sendRequest(ExecuteCommandRequest.type, {
+      command: ServerCommands.NewScalaProject,
+    });
+  });
+
+  registerCommand(
+    `metals.${ServerCommands.NewScalaFile}`,
+    async (directory: Uri) => {
+      return client.sendRequest(ExecuteCommandRequest.type, {
+        command: ServerCommands.NewScalaFile,
+        arguments: [directory?.toString()],
+      });
+    }
+  );
+
+  registerCommand(
+    `metals.${ServerCommands.NewJavaFile}`,
+    async (directory: Uri) => {
+      return client.sendRequest(ExecuteCommandRequest.type, {
+        command: ServerCommands.NewJavaFile,
+        arguments: [directory?.toString()],
+      });
+    }
+  );
+
+  registerCommand(`metals.new-scala-worksheet`, async () => {
+    const sendRequest = (args: Array<string | undefined>) => {
+      return client.sendRequest(ExecuteCommandRequest.type, {
+        command: ServerCommands.NewScalaFile,
+        arguments: args,
+      });
+    };
+    const currentUri = window.activeTextEditor?.document.uri;
+    if (currentUri != null) {
+      const parentUri = path.dirname(currentUri.toString());
+      const name = path.basename(parentUri);
+      const parentPath = Uri.parse(parentUri).fsPath;
+      const fullPath = path.join(parentPath, `${name}.worksheet.sc`);
+      if (fs.existsSync(fullPath)) {
+        window.showWarningMessage(
+          `A worksheet ${name}.worksheet.sc already exists, opening it instead`
+        );
+        return workspace
+          .openTextDocument(fullPath)
+          .then((textDocument) => window.showTextDocument(textDocument));
+      } else {
+        return sendRequest([parentUri, name, "scala-worksheet"]);
+      }
+    } else {
+      return sendRequest([undefined, undefined, "scala-worksheet"]);
+    }
+  });
+}

--- a/src/commands/server-comands.ts
+++ b/src/commands/server-comands.ts
@@ -1,5 +1,5 @@
 import * as fs from "fs";
-import { ClientCommands, ServerCommands } from "metals-languageclient";
+import { ServerCommands } from "metals-languageclient";
 import * as path from "path";
 import { env, ExtensionContext, Uri, window, workspace } from "vscode";
 import {
@@ -32,12 +32,6 @@ export function registerServerCommands(
     registerCommand("metals." + command, async () =>
       client.sendRequest(ExecuteCommandRequest.type, { command: command })
     );
-  });
-
-  registerCommand(ClientCommands.EchoCommand, (arg: string) => {
-    client.sendRequest(ExecuteCommandRequest.type, {
-      command: arg,
-    });
   });
 
   registerCommand(`metals.${ServerCommands.AnalyzeStacktrace}`, () => {

--- a/src/commands/server-comands.ts
+++ b/src/commands/server-comands.ts
@@ -1,29 +1,18 @@
 import * as fs from "fs";
 import { ClientCommands, ServerCommands } from "metals-languageclient";
 import * as path from "path";
-import {
-  commands,
-  env,
-  ExtensionContext,
-  Uri,
-  window,
-  workspace,
-} from "vscode";
+import { env, ExtensionContext, Uri, window, workspace } from "vscode";
 import {
   ExecuteCommandRequest,
   LanguageClient,
 } from "vscode-languageclient/node";
+import { registerCommandWithin } from "../util";
 
 export function registerServerCommands(
   context: ExtensionContext,
   client: LanguageClient
 ): void {
-  function registerCommand(
-    command: string,
-    callback: (...args: any[]) => unknown
-  ) {
-    context.subscriptions.push(commands.registerCommand(command, callback));
-  }
+  const registerCommand = registerCommandWithin(context);
 
   [
     ServerCommands.BuildImport,

--- a/src/commands/text-editor-commands.ts
+++ b/src/commands/text-editor-commands.ts
@@ -22,9 +22,6 @@ type TextEditorCallback = (
   ...args: any[]
 ) => unknown;
 
-/**
- * Register text editor related commands
- */
 export function registerTextEditorCommands(
   context: ExtensionContext,
   client: LanguageClient

--- a/src/commands/text-editor-commands.ts
+++ b/src/commands/text-editor-commands.ts
@@ -1,0 +1,110 @@
+import {
+  DebugDiscoveryParams,
+  RunType,
+  ServerCommands,
+} from "metals-languageclient";
+import {
+  commands,
+  env,
+  ExtensionContext,
+  TextEditor,
+  TextEditorEdit,
+  window,
+} from "vscode";
+import { ExecuteCommandRequest } from "vscode-languageclient";
+import { LanguageClient } from "vscode-languageclient/node";
+import * as scalaDebugger from "../scalaDebugger";
+import { getTextDocumentPositionParams } from "../util";
+
+type TextEditorCallback = (
+  textEditor: TextEditor,
+  edit: TextEditorEdit,
+  ...args: any[]
+) => unknown;
+
+/**
+ * Register text editor related commands
+ */
+export function registerTextEditorCommands(
+  context: ExtensionContext,
+  client: LanguageClient
+): void {
+  function registerTextEditorCommand(
+    command: string,
+    callback: TextEditorCallback
+  ) {
+    const disposable = commands.registerTextEditorCommand(command, callback);
+    context.subscriptions.push(disposable);
+  }
+
+  registerTextEditorCommand(`metals.run-current-file`, (editor) => {
+    const args: DebugDiscoveryParams = {
+      path: editor.document.uri.toString(true),
+      runType: RunType.RunOrTestFile,
+    };
+    scalaDebugger.start(true, args).then((wasStarted) => {
+      if (!wasStarted) {
+        window.showErrorMessage("Debug session not started");
+      }
+    });
+  });
+
+  registerTextEditorCommand(`metals.test-current-target`, (editor) => {
+    const args: DebugDiscoveryParams = {
+      path: editor.document.uri.toString(true),
+      runType: RunType.TestTarget,
+    };
+    scalaDebugger.start(true, args).then((wasStarted) => {
+      if (!wasStarted) {
+        window.showErrorMessage("Debug session not started");
+      }
+    });
+  });
+
+  registerTextEditorCommand(
+    `metals.${ServerCommands.GotoSuperMethod}`,
+    (editor) => {
+      client.sendRequest(ExecuteCommandRequest.type, {
+        command: ServerCommands.GotoSuperMethod,
+        arguments: [getTextDocumentPositionParams(editor)],
+      });
+    }
+  );
+
+  registerTextEditorCommand(
+    `metals.${ServerCommands.SuperMethodHierarchy}`,
+    (editor) => {
+      client.sendRequest(ExecuteCommandRequest.type, {
+        command: ServerCommands.SuperMethodHierarchy,
+        arguments: [getTextDocumentPositionParams(editor)],
+      });
+    }
+  );
+
+  registerTextEditorCommand(
+    `metals.${ServerCommands.CopyWorksheetOutput}`,
+    (editor) => {
+      const uri = editor.document.uri;
+      if (uri.toString().endsWith("worksheet.sc")) {
+        client
+          .sendRequest(ExecuteCommandRequest.type, {
+            command: ServerCommands.CopyWorksheetOutput,
+            arguments: [uri.toString()],
+          })
+          .then((result) => {
+            window.showInformationMessage(result);
+            if (result.value) {
+              env.clipboard.writeText(result.value);
+              window.showInformationMessage(
+                "Copied worksheet evaluation to clipboard."
+              );
+            }
+          });
+      } else {
+        window.showWarningMessage(
+          "You must be in a worksheet to use this feature."
+        );
+      }
+    }
+  );
+}

--- a/src/decode-file/decode-file-commands.ts
+++ b/src/decode-file/decode-file-commands.ts
@@ -1,0 +1,81 @@
+import {
+  commands,
+  ExtensionContext,
+  TextDocumentContentProvider,
+  Uri,
+  workspace,
+} from "vscode";
+import { LanguageClient } from "vscode-languageclient/node";
+import {
+  decodeAndShowFile,
+  MetalsFileProvider,
+} from "./metals-content-provider";
+
+export function registerMetalsDecodeCommands(
+  context: ExtensionContext,
+  client: LanguageClient
+): void {
+  function registerTextDocumentContentProvider(
+    scheme: string,
+    provider: TextDocumentContentProvider
+  ) {
+    context.subscriptions.push(
+      workspace.registerTextDocumentContentProvider(scheme, provider)
+    );
+  }
+
+  function registerCommand(
+    command: string,
+    callback: (uri: Uri | undefined) => unknown
+  ) {
+    context.subscriptions.push(commands.registerCommand(command, callback));
+  }
+
+  const metalsFileProvider = new MetalsFileProvider(client);
+
+  registerTextDocumentContentProvider("metalsDecode", metalsFileProvider);
+  registerTextDocumentContentProvider("jar", metalsFileProvider);
+
+  registerCommand("metals.show-cfr", async (uri) => {
+    await decodeAndShowFile(client, metalsFileProvider, uri, "cfr");
+  });
+
+  registerCommand("metals.show-javap-verbose", async (uri) => {
+    await decodeAndShowFile(client, metalsFileProvider, uri, "javap-verbose");
+  });
+
+  registerCommand("metals.show-javap", async (uri) => {
+    await decodeAndShowFile(client, metalsFileProvider, uri, "javap");
+  });
+
+  registerCommand("metals.show-semanticdb-compact", async (uri) => {
+    await decodeAndShowFile(
+      client,
+      metalsFileProvider,
+      uri,
+      "semanticdb-compact"
+    );
+  });
+
+  registerCommand("metals.show-semanticdb-detailed", async (uri) => {
+    await decodeAndShowFile(
+      client,
+      metalsFileProvider,
+      uri,
+      "semanticdb-detailed"
+    );
+  });
+
+  registerCommand("metals.show-semanticdb-proto", async (uri) => {
+    await decodeAndShowFile(
+      client,
+      metalsFileProvider,
+      uri,
+      "semanticdb-proto"
+    );
+  });
+
+  registerCommand("metals.show-tasty", async (uri) => {
+    await decodeAndShowFile(client, metalsFileProvider, uri, "tasty-decoded");
+  });
+}

--- a/src/decode-file/metals-content-provider.ts
+++ b/src/decode-file/metals-content-provider.ts
@@ -9,7 +9,7 @@ import {
 } from "vscode";
 import { ExecuteCommandRequest } from "vscode-languageclient";
 import { LanguageClient } from "vscode-languageclient/node";
-import { executeCommand } from "./util";
+import { executeCommand } from "../util";
 
 export interface DecoderResponse {
   requestedUri: string;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -61,11 +61,7 @@ import { registerServerCommands } from "./commands/server-comands";
 import { registerTextEditorCommands } from "./commands/text-editor-commands";
 import { registerMetalsDecodeCommands } from "./decode-file/decode-file-commands";
 import { DecorationsRangesDidChange } from "./decoration-protocol";
-import {
-  createFindInFilesTreeView,
-  executeFindInFiles,
-  startFindInFilesProvider,
-} from "./findinfiles";
+import { registerFindInFilesProvider } from "./find-in-files/find-in-file-provider";
 import * as ext from "./hoverExtension";
 import { increaseIndentPattern } from "./indentPattern";
 import { LazyProgress } from "./lazy-progress";
@@ -517,6 +513,7 @@ function launchMetals(
         compilationDoneEmitter,
         outputChannel,
       });
+      registerFindInFilesProvider(context, client, outputChannel);
 
       registerCommand("metals.reveal-active-file", () => {
         if (treeViews) {
@@ -560,21 +557,6 @@ function launchMetals(
       registerCommand("metals.toggle-show-inferred-type", () => {
         toggleBooleanWorkspaceSetting("showInferredType");
       });
-
-      const findInFilesProvider = startFindInFilesProvider(context);
-      const findInFilesView = createFindInFilesTreeView(
-        findInFilesProvider,
-        context
-      );
-
-      registerCommand(`metals.find-text-in-dependency-jars`, async () =>
-        executeFindInFiles(
-          client,
-          findInFilesProvider,
-          findInFilesView,
-          outputChannel
-        )
-      );
 
       // NOTE: we offer a custom symbol search command to work around the limitations of the built-in one, see https://github.com/microsoft/vscode/issues/98125 for more details.
       registerCommand(`metals.symbol-search`, () => openSymbolSearch(client));

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -77,6 +77,7 @@ import {
   getJavaHomeFromConfig,
   getTextDocumentPositionParams,
   getValueFromConfig,
+  toggleBooleanWorkspaceSetting,
 } from "./util";
 const outputChannel = window.createOutputChannel("Metals");
 const openSettingsAction = "Open settings";
@@ -929,11 +930,4 @@ function configureSettingsDefaults() {
     },
     ConfigurationTarget.Workspace
   );
-}
-
-function toggleBooleanWorkspaceSetting(setting: string) {
-  const config = workspace.getConfiguration("metals");
-  const configProperty = config.inspect<boolean>(setting);
-  const currentValues = configProperty?.workspaceValue ?? false;
-  config.update(setting, !currentValues, ConfigurationTarget.Workspace);
 }

--- a/src/find-in-files/find-in-file-provider.ts
+++ b/src/find-in-files/find-in-file-provider.ts
@@ -15,6 +15,30 @@ import {
   workspace,
 } from "vscode";
 import { LanguageClient, Location } from "vscode-languageclient/node";
+import { registerCommandWithin } from "../util";
+
+export function registerFindInFilesProvider(
+  context: ExtensionContext,
+  client: LanguageClient,
+  outputChannel: OutputChannel
+): void {
+  const findInFilesProvider = startFindInFilesProvider(context);
+  const findInFilesView = createFindInFilesTreeView(
+    findInFilesProvider,
+    context
+  );
+
+  registerCommandWithin(context)(
+    `metals.find-text-in-dependency-jars`,
+    async () =>
+      executeFindInFiles(
+        client,
+        findInFilesProvider,
+        findInFilesView,
+        outputChannel
+      )
+  );
+}
 
 class TopLevel {
   constructor(

--- a/src/util.ts
+++ b/src/util.ts
@@ -4,6 +4,8 @@ import {
   TextEditor,
   WorkspaceConfiguration,
   ConfigurationTarget,
+  ExtensionContext,
+  commands,
 } from "vscode";
 import {
   ExecuteCommandRequest,
@@ -68,9 +70,15 @@ export function getJavaHomeFromConfig(): string | undefined {
   }
 }
 
-export function toggleBooleanWorkspaceSetting(setting: string) {
+export function toggleBooleanWorkspaceSetting(setting: string): void {
   const config = workspace.getConfiguration("metals");
   const configProperty = config.inspect<boolean>(setting);
   const currentValues = configProperty?.workspaceValue ?? false;
   config.update(setting, !currentValues, ConfigurationTarget.Workspace);
 }
+
+export const registerCommandWithin =
+  (context: ExtensionContext) =>
+  (command: string, callback: (...args: any[]) => unknown): void => {
+    context.subscriptions.push(commands.registerCommand(command, callback));
+  };

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,5 +1,10 @@
 import * as path from "path";
-import { workspace, TextEditor, WorkspaceConfiguration } from "vscode";
+import {
+  workspace,
+  TextEditor,
+  WorkspaceConfiguration,
+  ConfigurationTarget,
+} from "vscode";
 import {
   ExecuteCommandRequest,
   TextDocumentPositionParams,
@@ -61,4 +66,11 @@ export function getJavaHomeFromConfig(): string | undefined {
   } else {
     return javaHomePath;
   }
+}
+
+export function toggleBooleanWorkspaceSetting(setting: string) {
+  const config = workspace.getConfiguration("metals");
+  const configProperty = config.inspect<boolean>(setting);
+  const currentValues = configProperty?.workspaceValue ?? false;
+  config.update(setting, !currentValues, ConfigurationTarget.Workspace);
 }


### PR DESCRIPTION
`extension.ts` is an enormous file and I always struggle to find anything in it. As a first step, I decided to extract some commands registration to separate files. This is a quick poc, let me know what do you think.

cc: @tgodzik @gabro 