### PR TITLE
Bump default version to the newest snapshot

### DIFF
--- a/package.json
+++ b/package.json
@@ -162,7 +162,7 @@
       "properties": {
         "metals.serverVersion": {
           "type": "string",
-          "default": "0.11.1",
+          "default": "0.11.1+74-558d667d-SNAPSHOT",
           "markdownDescription": "The version of the Metals server artifact. Requires reloading the window.\n\n**Change only if you know what you're doing**"
         },
         "metals.serverProperties": {


### PR DESCRIPTION
This is to make sure that users of prereleases don't have issues connected to older metals versions.

We could either:
- bump whenever something in metals-vscode shows up that needs changes from metals
- or we could get this automatic (we can do it later on)