### PR TITLE
fix: use `||` instead of `??`

### DIFF
--- a/src/getServerVersion.ts
+++ b/src/getServerVersion.ts
@@ -21,7 +21,7 @@ export function getServerVersion(config: WorkspaceConfiguration): string {
   const serverVersionConfig = config.get<string>(serverVersionSection);
   const defaultServerVersion =
     config.inspect<string>(serverVersionSection)!.defaultValue!;
-  const serverVersion = serverVersionConfig?.trim() ?? defaultServerVersion;
+  const serverVersion = serverVersionConfig?.trim() || defaultServerVersion;
 
   validateCurrentVersion(serverVersion, config);
   return serverVersion;


### PR DESCRIPTION
For some reason an empty string was being taken as a Metals version.

`"" || 1` yields 1 where `"" ?? 1` yields "" and it's a reason why. `??` was my suggestion at review, guilty as charged.