### PR TITLE
Show file path for workspace symbols

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1004,10 +1004,7 @@ function launchMetals(
         });
       });
 
-      let workspaceUri: undefined | Uri;
-      if (workspace.workspaceFolders) {
-        workspaceUri = workspace.workspaceFolders[0].uri;
-      }
+      const workspaceUri = workspace.workspaceFolders?.[0].uri;
       // NOTE: we offer a custom symbol search command to work around the limitations of the built-in one, see https://github.com/microsoft/vscode/issues/98125 for more details.
       registerCommand(`metals.symbol-search`, () =>
         openSymbolSearch(client, metalsFileProvider, workspaceUri)

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1004,9 +1004,13 @@ function launchMetals(
         });
       });
 
+      let workspaceUri: undefined | Uri;
+      if (workspace.workspaceFolders) {
+        workspaceUri = workspace.workspaceFolders[0].uri;
+      }
       // NOTE: we offer a custom symbol search command to work around the limitations of the built-in one, see https://github.com/microsoft/vscode/issues/98125 for more details.
       registerCommand(`metals.symbol-search`, () =>
-        openSymbolSearch(client, metalsFileProvider)
+        openSymbolSearch(client, metalsFileProvider, workspaceUri)
       );
 
       window.onDidChangeActiveTextEditor((editor) => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1004,7 +1004,7 @@ function launchMetals(
         });
       });
 
-      const workspaceUri = workspace.workspaceFolders?.[0].uri;
+      const workspaceUri = workspace.workspaceFolders?.[0]?.uri;
       // NOTE: we offer a custom symbol search command to work around the limitations of the built-in one, see https://github.com/microsoft/vscode/issues/98125 for more details.
       registerCommand(`metals.symbol-search`, () =>
         openSymbolSearch(client, metalsFileProvider, workspaceUri)


### PR DESCRIPTION
Previously, we would not show the path to file containing the symbol, which would be problematic if we had the same name for different symbols. Now, we additionally show the path.

![image](https://user-images.githubusercontent.com/3807253/157937745-23e39ec0-c297-4697-a976-4d7954bde7ec.png)
