### PR TITLE
chore: exclude unnecessary files when publish the package

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,14 +1,12 @@
 .vscode/**
 .vscode-test/**
 out/test/**
-out/testExplorer/**
 out/**/*.map
 src/**
 .gitignore
 tsconfig.json
 vsc-extension-quickstart.md
 .github
-node_modules
 .mergify.yml
 .eslintrc.js
 .prettierignore

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,8 +1,14 @@
 .vscode/**
 .vscode-test/**
 out/test/**
+out/testExplorer/**
 out/**/*.map
 src/**
 .gitignore
 tsconfig.json
 vsc-extension-quickstart.md
+.github
+node_modules
+.mergify.yml
+.eslintrc.js
+.prettierignore

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -10,3 +10,4 @@ vsc-extension-quickstart.md
 .mergify.yml
 .eslintrc.js
 .prettierignore
+.update-version.js


### PR DESCRIPTION
Hello.
Thank you for awesome extension :)

## Description

The current published extension includes some unnecessary files.
I updated `.vscodeignore` and exclude them.

## Before

```sh
This extension consists of 1295 files, out of which 603 are JavaScript files. For performance reasons, you should bundle your extension: https://aka.ms/vscode-bundle-extension . You should also exclude unnecessary files by adding them to your .vscodeignore: https://aka.ms/vscode-vscodeignore
DONE  Packaged: C:\Users\username\development\metals-vscode-dev\metals-vscode\metals-1.13.10.vsix (1295 files, 2.92MB)
```

## After

```sh
DONE  Packaged: C:\Users\username\development\metals-vscode-dev\metals-vscode\metals-1.13.10.vsix (73 files, 1.27MB)
```

Thank you :)