### PR TITLE
release: Bump versions for v0.11.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,11 +27,11 @@ The following table shows the status of various features.
 
 ## Requirements
 
-**Java 11 or 17 provided by OpenJDK or Oracle**. Eclipse OpenJ9 is not
+**Java 8, 11, 17 provided by OpenJDK or Oracle**. Eclipse OpenJ9 is not
 supported, please make sure the `JAVA_HOME` environment variable
 points to a valid Java 8, 11 or 17 installation.
 
-**macOS, Linux or Windows**. Metals is developed on many operating systems and
+**macOS, Linux or Windows**. Metals is developed on many operating systems and 
 every PR is tested on Ubuntu, Windows and MacOS.
 
 **Scala 2.13, 2.12, 2.11 and Scala 3**. Metals supports these Scala versions:
@@ -46,7 +46,7 @@ every PR is tested on Ubuntu, Windows and MacOS.
   2.11.12
 
 - **Scala 3**:
-  3.1.3-RC2, 3.1.2, 3.1.2-RC3, 3.1.2-RC2, 3.1.1, 3.1.0, 3.0.2, 3.0.1, 3.0.0
+  3.1.3-RC4, 3.1.3-RC3, 3.1.3-RC2, 3.1.2, 3.1.1, 3.1.0, 3.0.2, 3.0.1, 3.0.0
 
 Note that 2.11.x support is deprecated and it will be removed in future releases.
 It's recommended to upgrade to Scala 2.12 or Scala 2.13

--- a/package.json
+++ b/package.json
@@ -173,7 +173,7 @@
       "properties": {
         "metals.serverVersion": {
           "type": "string",
-          "default": "0.11.5",
+          "default": "0.11.6",
           "markdownDescription": "The version of the Metals server artifact. Requires reloading the window.  \n\n**VS Code extension version is guaranteed to work only with the default version, change if you know what you're doing**"
         },
         "metals.serverProperties": {


### PR DESCRIPTION
following https://scalameta.org/metals/docs/contributors/releasing

> check or update enum values of fallbackScalaVersion property in package.json. They should be the same as V.supportedScalaVersions in build.sbt

Should we do this? I just left it as is, since we didn't touch in the previous release?