### PR TITLE
feat: show Metals' release notes if server version is updated

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -17,7 +17,10 @@ module.exports = {
           { ignoreRestArgs: true },
         ],
         "no-unused-vars": "off",
-        "@typescript-eslint/no-unused-vars": ["error"],
+        "@typescript-eslint/no-unused-vars": [
+          "error",
+          { varsIgnorePattern: "_" },
+        ],
         "@typescript-eslint/no-non-null-assertion": "error",
         "guard-for-in": "error",
         "no-var": "error",

--- a/media/styles.css
+++ b/media/styles.css
@@ -1,0 +1,8 @@
+h2,
+h3,
+h4,
+h5,
+h6 {
+	margin-top: 2em;
+	margin-bottom: 0em;
+}

--- a/package.json
+++ b/package.json
@@ -890,6 +890,8 @@
     "@types/glob": "^7.2.0",
     "@types/mocha": "^9.1.1",
     "@types/node": "17.0.27",
+    "@types/remarkable": "^2.0.3",
+    "@types/semver": "^7.3.9",
     "@types/vscode": "1.59.0",
     "@typescript-eslint/eslint-plugin": "^5.27.0",
     "@typescript-eslint/parser": "^5.27.0",
@@ -902,6 +904,7 @@
     "mocha": "^10.0.0",
     "ovsx": "0.3.0",
     "prettier": "2.6.2",
+    "remarkable": "^2.0.1",
     "rimraf": "^3.0.2",
     "ts-mocha": "^10.0.0",
     "typescript": "4.7.3",
@@ -911,6 +914,7 @@
     "ansicolor": "^1.1.100",
     "metals-languageclient": "0.5.15",
     "promisify-child-process": "4.1.1",
+    "semver": "^7.3.7",
     "vscode-languageclient": "7.0.0"
   },
   "extensionPack": [

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "ide",
     "scalameta"
   ],
-  "version": "1.17.2",
+  "version": "1.17.6",
   "publisher": "scalameta",
   "contributors": [
     {
@@ -876,10 +876,11 @@
   "scripts": {
     "vscode:prepublish": "yarn compile",
     "compile": "tsc -p ./",
+    "clean": "rimraf out/",
     "watch": "tsc -watch -p ./",
     "test": "ts-mocha src/test/unit/*.test.ts",
     "test-extension": "rimraf out/ && tsc -p ./ && node out/test/extension/runTest.js",
-    "build": "vsce package --yarn",
+    "build": "yarn clean && vsce package --yarn",
     "vscode:publish": "vsce publish --yarn",
     "ovsx:publish": "ovsx publish",
     "lint": "eslint . --ext .ts --fix && yarn format",
@@ -904,7 +905,6 @@
     "mocha": "^10.0.0",
     "ovsx": "0.5.1",
     "prettier": "2.6.2",
-    "remarkable": "^2.0.1",
     "rimraf": "^3.0.2",
     "ts-mocha": "^10.0.0",
     "typescript": "4.7.3",
@@ -915,6 +915,7 @@
     "metals-languageclient": "0.5.16",
     "promisify-child-process": "4.1.1",
     "semver": "^7.3.7",
+    "remarkable": "^2.0.1",
     "vscode-languageclient": "8.0.1"
   },
   "extensionPack": [

--- a/package.json
+++ b/package.json
@@ -408,6 +408,11 @@
         "title": "Run doctor"
       },
       {
+        "command": "metals.show-release-notes",
+        "category": "Metals",
+        "title": "Show release notes"
+      },
+      {
         "command": "metals.show-tasty",
         "category": "Metals",
         "title": "Show decoded TASTy"
@@ -639,6 +644,10 @@
         },
         {
           "command": "metals.doctor-run",
+          "when": "metals:enabled"
+        },
+        {
+          "command": "metals.show-release-notes",
           "when": "metals:enabled"
         },
         {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -90,6 +90,7 @@ import * as workbenchCommands from "./workbenchCommands";
 import { getServerVersion } from "./getServerVersion";
 import { getCoursierMirrorPath } from "./mirrors";
 import { DoctorProvider } from "./doctor";
+import { showReleaseNotesIfNeeded } from "./releaseNotesProvider";
 
 const outputChannel = window.createOutputChannel("Metals");
 const openSettingsAction = "Open settings";
@@ -130,7 +131,8 @@ export async function activate(context: ExtensionContext): Promise<void> {
       commands.executeCommand("setContext", "metals:enabled", true);
       try {
         const javaHome = await getJavaHome(getJavaHomeFromConfig());
-        return fetchAndLaunchMetals(context, javaHome, serverVersion);
+        await fetchAndLaunchMetals(context, javaHome, serverVersion);
+        await showReleaseNotesIfNeeded(context, serverVersion, outputChannel);
       } catch (err) {
         outputChannel.appendLine(`${err}`);
         showMissingJavaMessage();

--- a/src/releaseNotesProvider.ts
+++ b/src/releaseNotesProvider.ts
@@ -88,8 +88,7 @@ async function showReleaseNotes(
    * TODO: what about wsl?
    */
   function isRemote(): Either<string, void> {
-    // const isWsl = env.remoteName === "wsl";
-    return env.remoteName == null
+    return env.remoteName == null || env.remoteName !== "wsl"
       ? makeRight(undefined)
       : makeLeft(`is a remote environment ${env.remoteName}`);
   }

--- a/src/releaseNotesProvider.ts
+++ b/src/releaseNotesProvider.ts
@@ -23,7 +23,6 @@ export async function showReleaseNotes(
   outputChannel: vscode.OutputChannel
 ) {
   try {
-    // context.globalState.update(versionKey, "0.11.5");
     const result = await showReleaseNotesImpl(calledOn, context, serverVersion);
     if (result.kind === "left") {
       const msg = `Release notes was not shown: ${result.value}`;

--- a/src/releaseNotesProvider.ts
+++ b/src/releaseNotesProvider.ts
@@ -1,0 +1,180 @@
+import { env, ExtensionContext } from "vscode";
+import * as vscode from "vscode";
+import * as semver from "semver";
+import { Remarkable } from "remarkable";
+import http from "https";
+
+const versionKey = "metals-server-version";
+
+// prettier-ignore
+const releaseNotesMarkdownUrl: Record<string, string> = {
+  "0.11.5": "https://raw.githubusercontent.com/scalameta/metals/main/website/blog/2022-04-28-aluminium.md",
+  "0.11.6": "https://raw.githubusercontent.com/scalameta/metals/main/website/blog/2022-06-03-aluminium.md",
+};
+
+/**
+ * Show release notes if possible, swallow errors since its not a crucial feature.
+ * Treats snapshot versions like 0.11.6+67-926ec9a3-SNAPSHOT as a 0.11.6.
+ */
+export async function showReleaseNotesIfNeeded(
+  context: ExtensionContext,
+  serverVersion: string,
+  outputChannel: vscode.OutputChannel
+) {
+  try {
+    await showReleaseNotes(context, serverVersion);
+  } catch (error) {
+    outputChannel.appendLine(
+      `Couldn't show release notes for Metals ${serverVersion}`
+    );
+    outputChannel.appendLine(`${error}`);
+  }
+}
+
+async function showReleaseNotes(
+  context: ExtensionContext,
+  currentVersion: string
+): Promise<void> {
+  const state = context.globalState;
+
+  const version = getVersion();
+  const releaseNotesUrl = version
+    ? releaseNotesMarkdownUrl[version]
+    : undefined;
+  if (isNotRemote() && version && releaseNotesUrl) {
+    await showPanel(version, releaseNotesUrl);
+  }
+
+  async function showPanel(version: string, releaseNotesUrl: string) {
+    const releaseNotes = await getReleaseNotesMarkdown(releaseNotesUrl);
+
+    if (typeof releaseNotes === "string") {
+      const panel = vscode.window.createWebviewPanel(
+        `scalameta.metals.whatsNew`,
+        `Metals ${version} release notes`,
+        vscode.ViewColumn.One
+      );
+
+      panel.webview.html = releaseNotes;
+      panel.reveal();
+
+      // set wrong value for local development
+      // const newVersion = "0.11.5";
+
+      const newVersion = version;
+
+      // Update current device's latest server version when there's no value or it was a older one.
+      // Then sync this value across other devices.
+      state.update(versionKey, newVersion);
+      state.setKeysForSync([versionKey]);
+
+      context.subscriptions.push(panel);
+    }
+  }
+
+  /**
+   * Don't show panel for remote environment because it installs extension on every time.
+   * TODO: what about wsl?
+   */
+  function isNotRemote(): boolean {
+    const isNotRemote = env.remoteName == null;
+    // const isWsl = env.remoteName === "wsl";
+    return isNotRemote;
+  }
+
+  /**
+   *  Return version for which release notes should be displayed
+   *  or
+   *  undefined if notes shouldn't be displayed
+   */
+  function getVersion(): string | undefined {
+    const previousVersion: string | undefined = state.get(versionKey);
+    // strip version to 'major.minor.patch'
+    const cleanVersion = semver.clean(currentVersion);
+    if (cleanVersion) {
+      if (previousVersion) {
+        const compare = semver.compare(cleanVersion, previousVersion);
+        const diff = semver.diff(cleanVersion, previousVersion);
+
+        // take into account only major, minor and patch, ignore snapshot releases
+        const isNewerVersion =
+          compare === 1 &&
+          (diff === "major" || diff === "minor" || diff === "patch");
+
+        return isNewerVersion ? cleanVersion : undefined;
+      }
+
+      // if there was no previous version then show release notes for current cleaned version
+      return currentVersion;
+    }
+  }
+}
+
+async function getReleaseNotesMarkdown(
+  releaseNotesUrl: string
+): Promise<string | { error: unknown }> {
+  const ps = new Promise<string>((resolve, reject) => {
+    http.get(releaseNotesUrl, (resp) => {
+      let body = "";
+      resp.on("data", (chunk) => (body += chunk));
+      resp.on("end", () => resolve(body));
+      resp.on("error", (e) => reject(e));
+    });
+  });
+
+  const text = await ps;
+  // every release notes starts with that
+  const beginning = "We're happy to announce the release of";
+  const notesStartIdx = text.indexOf(beginning);
+  const releaseNotes = text.substring(notesStartIdx);
+
+  // cut metadata yaml from release notes, it start with --- and ends with ---
+  const metadata = text
+    .substring(0, notesStartIdx - 1)
+    .replace("---", "")
+    .replace("---", "")
+    .trim()
+    .split("\n");
+  const author = metadata[0].slice("author: ".length);
+  const title = metadata[1].slice("title: ".length);
+  const authorUrl = metadata[2].slice("authorURL: ".length);
+
+  const md = new Remarkable({ html: true });
+  const renderedNotes = md.render(releaseNotes);
+
+  const notes = getHtmlContent(renderedNotes, author, title, authorUrl);
+  return notes;
+}
+
+function getHtmlContent(
+  renderedNotes: string,
+  author: string,
+  title: string,
+  authorURL: string
+): string {
+  return `
+  <!DOCTYPE html>
+  <html lang="en" style="height: 100%; width: 100%;">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  </head>
+  <body>
+    <h1>${title}</h1>
+    <hr>
+    <p>
+      Showing Metals' release notes embedded in vscode is an experimental feature, in case of any issues report them at 
+      <a href="https://github.com/scalameta/metals-vscode">https://github.com/scalameta/metals-vscode</a>.
+    </p>
+    <hr>
+    <p>
+      <a href="${authorURL}" target="_blank" itemprop="url">
+        <span itemprop="name">${author}</span>
+      </a>
+    </p>
+    <hr>
+    ${renderedNotes}
+    </body>
+  </html>
+`;
+}

--- a/src/releaseNotesProvider.ts
+++ b/src/releaseNotesProvider.ts
@@ -228,6 +228,12 @@ async function getReleaseNotesMarkdown(
     <p>
       Showing Metals' release notes embedded in vscode is an experimental feature, in case of any issues report them at 
       <a href="https://github.com/scalameta/metals-vscode">https://github.com/scalameta/metals-vscode</a>.
+      <br/>
+      <br/>
+      Original blogpost can be viewed at 
+      <a href="https://scalameta.org/metals/blog/" target="_blank" itemprop="url">
+      <span itemprop="name">Metals blog</span>
+      </a>.
     </p>
     <hr>
     <p>

--- a/src/releaseNotesProvider.ts
+++ b/src/releaseNotesProvider.ts
@@ -88,7 +88,7 @@ async function showReleaseNotes(
    * TODO: what about wsl?
    */
   function isRemote(): Either<string, void> {
-    return env.remoteName == null || env.remoteName !== "wsl"
+    return env.remoteName == null || env.remoteName === "wsl"
       ? makeRight(undefined)
       : makeLeft(`is a remote environment ${env.remoteName}`);
   }

--- a/src/releaseNotesProvider.ts
+++ b/src/releaseNotesProvider.ts
@@ -36,6 +36,7 @@ async function showReleaseNotes(
   currentVersion: string
 ): Promise<Either<string, void>> {
   const state = context.globalState;
+  state.update(versionKey, "0.11.5");
 
   const remote = isRemote();
   if (remote.kind === "left") {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,11 @@
+export type Either<Left, Right> =
+  | { kind: "left"; value: Left }
+  | { kind: "right"; value: Right };
+
+export function makeLeft<T>(t: T): Either<T, never> {
+  return { kind: "left", value: t };
+}
+
+export function makeRight<T>(t: T): Either<never, T> {
+  return { kind: "right", value: t };
+}

--- a/src/util.ts
+++ b/src/util.ts
@@ -11,6 +11,7 @@ import {
   TextDocumentPositionParams,
 } from "vscode-languageclient";
 import { LanguageClient } from "vscode-languageclient/node";
+import http from "https";
 
 declare const sym: unique symbol;
 /**
@@ -102,4 +103,19 @@ export function getJavaHomeFromConfig(): string | undefined {
   } else {
     return javaHomePath;
   }
+}
+
+export async function fetchFrom(
+  url: string,
+  options?: http.RequestOptions
+): Promise<string> {
+  const promise = new Promise<string>((resolve, reject) => {
+    http.get(url, options || {}, (resp) => {
+      let body = "";
+      resp.on("data", (chunk) => (body += chunk));
+      resp.on("end", () => resolve(body));
+      resp.on("error", (e) => reject(e));
+    });
+  });
+  return await promise;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -65,6 +65,11 @@
     "@types/minimatch" "*"
     "@types/node" "*"
 
+"@types/highlight.js@^9.7.0":
+  version "9.12.4"
+  resolved "https://registry.yarnpkg.com/@types/highlight.js/-/highlight.js-9.12.4.tgz#8c3496bd1b50cc04aeefd691140aa571d4dbfa34"
+  integrity sha512-t2szdkwmg2JJyuCM20e8kR2X59WCE5Zkl4bzm1u1Oukjm79zpbiAv+QjnwLnuuV0WHEcX2NgUItu0pAMKuOPww==
+
 "@types/json-schema@^7.0.9":
   version "7.0.11"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.11.tgz#d421b6c527a3037f7c84433fd2c4229e016863d3"
@@ -89,6 +94,19 @@
   version "17.0.27"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.27.tgz#f4df3981ae8268c066e8f49995639f855469081e"
   integrity sha512-4/Ke7bbWOasuT3kceBZFGakP1dYN2XFd8v2l9bqF2LNWrmeU07JLpp56aEeG6+Q3olqO5TvXpW0yaiYnZJ5CXg==
+
+"@types/remarkable@^2.0.3":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/@types/remarkable/-/remarkable-2.0.3.tgz#ba2e5edada8f0fe64c658beb2127e06ac0b9c1c8"
+  integrity sha512-QQUBeYApuHCNl9Br6ZoI3PlKmwZ69JHrlJktJXnjxobia9liZgsI70fm8PnCqVFAcefYK+9PGzR5L/hzCslNYQ==
+  dependencies:
+    "@types/highlight.js" "^9.7.0"
+    highlight.js "^9.7.0"
+
+"@types/semver@^7.3.9":
+  version "7.3.9"
+  resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.3.9.tgz#152c6c20a7688c30b967ec1841d31ace569863fc"
+  integrity sha512-L/TMpyURfBkf+o/526Zb6kd/tchUP3iBDEPjqjb+U2MAJhVRxxrmr2fwpe08E7QsV7YLcpq0tUaQ9O9x97ZIxQ==
 
 "@types/vscode@1.59.0":
   version "1.59.0"
@@ -280,6 +298,13 @@ are-we-there-yet@~1.1.2:
     delegates "^1.0.0"
     readable-stream "^2.0.6"
 
+argparse@^1.0.10:
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/argparse/-/argparse-1.0.10.tgz#bcd6791ea5ae09725e17e5ad988134cd40b3d911"
+  integrity sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==
+  dependencies:
+    sprintf-js "~1.0.2"
+
 argparse@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
@@ -299,6 +324,13 @@ async@^3.2.2:
   version "3.2.3"
   resolved "https://registry.yarnpkg.com/async/-/async-3.2.3.tgz#ac53dafd3f4720ee9e8a160628f18ea91df196c9"
   integrity sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g==
+
+autolinker@^3.11.0:
+  version "3.15.0"
+  resolved "https://registry.yarnpkg.com/autolinker/-/autolinker-3.15.0.tgz#03956088648f236642a5783612f9ca16adbbed38"
+  integrity sha512-N/5Dk5AZnqL9k6kkHdFIGLm/0/rRuSnJwqYYhLCJjU7ZtiaJwCBzNTvjzy1zzJADngv/wvtHYcrPHytPnASeFA==
+  dependencies:
+    tslib "^2.3.0"
 
 azure-devops-node-api@^11.0.1:
   version "11.1.0"
@@ -1102,6 +1134,11 @@ he@1.2.0:
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
 
+highlight.js@^9.7.0:
+  version "9.18.5"
+  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-9.18.5.tgz#d18a359867f378c138d6819edfc2a8acd5f29825"
+  integrity sha512-a5bFyofd/BHCX52/8i8uJkjr9DYwXIPnM/plwI6W7ezItLGqzt7X2G2nXuYSfsIJdkwwj/g9DG1LkcGJI/dDoA==
+
 hosted-git-info@^4.0.2:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-4.1.0.tgz#827b82867e9ff1c8d0c4d9d53880397d2c86d224"
@@ -1758,6 +1795,14 @@ regexpp@^3.2.0:
   resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-3.2.0.tgz#0425a2768d8f23bad70ca4b90461fa2f1213e1b2"
   integrity sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==
 
+remarkable@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/remarkable/-/remarkable-2.0.1.tgz#280ae6627384dfb13d98ee3995627ca550a12f31"
+  integrity sha512-YJyMcOH5lrR+kZdmB0aJJ4+93bEojRZ1HGDn9Eagu6ibg7aVZhc3OWbbShRid+Q5eAfsEqWxpe+g5W5nYNfNiA==
+  dependencies:
+    argparse "^1.0.10"
+    autolinker "^3.11.0"
+
 require-directory@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
@@ -1900,6 +1945,11 @@ source-map@^0.6.0:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
+
+sprintf-js@~1.0.2:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
+  integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
 
 string-width@^1.0.1:
   version "1.0.2"
@@ -2070,6 +2120,11 @@ tslib@^2.2.0:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
   integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
+
+tslib@^2.3.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.0.tgz#7cecaa7f073ce680a05847aa77be941098f36dc3"
+  integrity sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==
 
 tsutils@^3.21.0:
   version "3.21.0"


### PR DESCRIPTION
### Motivation

Currently Metals updates are completely silent and I suspect that most of the users doesn't even know that update just happened. Not everyone has twitter account or is checking [Metals' blog](https://scalameta.org/metals/blog/) on regular basis and this kind of people (I suspect that most of the beginners?) can omit all of those juicy new features which are shipped with the new release. 

It is a goal of this PR to provide some mechanism to inform user about latest changes.

---

### Other solutions

Currently, as far as I know, there is no mechanism for showing extension updates in vscode - see https://github.com/microsoft/vscode/issues/102139. There are some ways to do it, for example I found https://github.com/alefragnani/vscode-whats-new but it seems like its use case is a bit different than what this PR needs (metals-vscode doesn't have any useful changes on its own).  

---

### Goals

Show some indicator that update happened, maybe show embedded release notes in the webview panel?  

No matter what indicator will be chosen it mechanism should:
- not show too often. Ideally only once, after first vscode window start with updated Metals extension
- not show when running metals e.g. on gitpod or other containers which install extension every time
- be able to be disabled in options

---

### Current state

![sbt-playground-1654627142733](https://user-images.githubusercontent.com/37124721/172457795-a3115d4a-e72e-43b6-9d9f-dcb1c8f2860f.gif)

---

