### PR TITLE
feature: Add scalafix run command and scalafix dependencies setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -173,7 +173,7 @@
       "properties": {
         "metals.serverVersion": {
           "type": "string",
-          "default": "0.11.6",
+          "default": "0.11.6+67-926ec9a3-SNAPSHOT",
           "markdownDescription": "The version of the Metals server artifact. Requires reloading the window.  \n\n**VS Code extension version is guaranteed to work only with the default version, change if you know what you're doing**"
         },
         "metals.serverProperties": {
@@ -242,6 +242,14 @@
         "metals.scalafixConfigPath": {
           "type": "string",
           "markdownDescription": "Optional custom path to the .scalafix.conf file.\n\nShould be an absolute path and use forward slashes `/` for file separators (even on Windows)."
+        },
+        "metals.scalafixRulesDependencies": {
+          "type": "array",
+          "scope": "machine",
+          "items": {
+            "type": "string"
+          },
+          "markdownDescription": "List of Scalafix rules dependencies in case they are not available by default in Metals and running scalafix fails due to 'rule not found' exception. For example: `com.github.liancheng::organize-imports:0.6.0` which follows the [coursier](https://get-coursier.io/) convention."
         },
         "metals.bloopVersion": {
           "type": "string",
@@ -408,6 +416,11 @@
         "title": "Run doctor"
       },
       {
+        "command": "metals.scalafix-run",
+        "category": "Metals",
+        "title": "Run all Scalafix rules"
+      },
+      {
         "command": "metals.show-tasty",
         "category": "Metals",
         "title": "Show decoded TASTy"
@@ -550,6 +563,12 @@
         "mac": "cmd+t",
         "command": "metals.symbol-search",
         "when": "editorLangId == scala"
+      },
+      {
+        "key": "ctrl+alt+shift+o",
+        "mac": "cmd+alt+shift+o",
+        "command": "metals.scalafix-run",
+        "when": "editorLangId == scala"
       }
     ],
     "menus": {
@@ -639,6 +658,10 @@
         },
         {
           "command": "metals.doctor-run",
+          "when": "metals:enabled"
+        },
+        {
+          "command": "metals.scalafix-run",
           "when": "metals:enabled"
         },
         {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -786,6 +786,13 @@ function launchMetals(
         }
       );
 
+      registerTextEditorCommand(`metals.scalafix-run`, (editor) => {
+        client.sendRequest(ExecuteCommandRequest.type, {
+          command: "scalafix-run",
+          arguments: [getTextDocumentPositionParams(editor)],
+        });
+      });
+
       registerTextEditorCommand(
         `metals.${ServerCommands.SuperMethodHierarchy}`,
         (editor) => {


### PR DESCRIPTION
For running scalafix I decided on using `ctrl+alt+shift+o` shortcut since it's one step from organize imports and should be pretty intuitive (do more than organize import so I add shift)

As for the dependency settings I was thinking about using an object first, but that would require each rule to have it's dependency (but there might be multiple rules in a single dep) and it's easier to represent an Array in the settings UI.

Related to https://github.com/scalameta/metals/pull/3996