### PR TITLE
Update metals-languageclient and vscode-languageclient

### DIFF
--- a/package.json
+++ b/package.json
@@ -909,9 +909,9 @@
   },
   "dependencies": {
     "ansicolor": "^1.1.100",
-    "metals-languageclient": "0.5.15",
+    "metals-languageclient": "0.5.16",
     "promisify-child-process": "4.1.1",
-    "vscode-languageclient": "7.0.0"
+    "vscode-languageclient": "8.0.1"
   },
   "extensionPack": [
     "scala-lang.scala"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -507,9 +507,7 @@ function launchMetals(
     )
   );
 
-  context.subscriptions.push(client.start());
-
-  return client.onReady().then(
+  return client.start().then(
     () => {
       const doctorProvider = new DoctorProvider(client);
       let stacktrace: WebviewPanel | undefined;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1350,10 +1350,10 @@ merge2@^1.3.0, merge2@^1.4.1:
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
   integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
 
-metals-languageclient@0.5.15:
-  version "0.5.15"
-  resolved "https://registry.yarnpkg.com/metals-languageclient/-/metals-languageclient-0.5.15.tgz#116f8d0cc1032f07b24777066965e5c12654dc6b"
-  integrity sha512-TOgU0rXI7FRE1ihvmhWu8lcCF6ECw/iNn/Qr1LRrGpb/a0LiqGcW8t4iXqguWniw5pfbk2BHht4fifN3EEHHqw==
+metals-languageclient@0.5.16:
+  version "0.5.16"
+  resolved "https://registry.yarnpkg.com/metals-languageclient/-/metals-languageclient-0.5.16.tgz#c368ea8f1802aa185623aa7859424cf4aca24609"
+  integrity sha512-npv7DssoWEKnZg3S/hZcTmcbHwhlrFWOqi07fxMwGPS3KHcrg601bnedWwps5t9xANxOKVV73mgpTcJ0KXRBfg==
   dependencies:
     "@viperproject/locate-java-home" "^1.1.5"
     fp-ts "^2.4.1"
@@ -1362,7 +1362,7 @@ metals-languageclient@0.5.15:
     promisify-child-process "^4.0.0"
     semver "^7.1.1"
     shell-quote "^1.7.2"
-    vscode-languageserver-protocol "3.16.0"
+    vscode-languageserver-protocol "3.17.1"
 
 micromatch@^4.0.4:
   version "4.0.4"
@@ -1814,7 +1814,7 @@ semver@^5.1.0, semver@^5.4.1:
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
 
-semver@^7.1.1, semver@^7.3.4, semver@^7.3.5, semver@^7.3.7:
+semver@^7.1.1, semver@^7.3.5, semver@^7.3.7:
   version "7.3.7"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.7.tgz#12c5b649afdbf9049707796e22a4028814ce523f"
   integrity sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==
@@ -2190,32 +2190,32 @@ vsce@2.9.1, vsce@^2.6.3:
     yauzl "^2.3.1"
     yazl "^2.2.2"
 
-vscode-jsonrpc@6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/vscode-jsonrpc/-/vscode-jsonrpc-6.0.0.tgz#108bdb09b4400705176b957ceca9e0880e9b6d4e"
-  integrity sha512-wnJA4BnEjOSyFMvjZdpiOwhSq9uDoK8e/kpRJDTaMYzwlkrhG1fwDIZI94CLsLzlCK5cIbMMtFlJlfR57Lavmg==
+vscode-jsonrpc@8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/vscode-jsonrpc/-/vscode-jsonrpc-8.0.1.tgz#f30b0625ebafa0fb3bc53e934ca47b706445e57e"
+  integrity sha512-N/WKvghIajmEvXpatSzvTvOIz61ZSmOSa4BRA4pTLi+1+jozquQKP/MkaylP9iB68k73Oua1feLQvH3xQuigiQ==
 
-vscode-languageclient@7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/vscode-languageclient/-/vscode-languageclient-7.0.0.tgz#b505c22c21ffcf96e167799757fca07a6bad0fb2"
-  integrity sha512-P9AXdAPlsCgslpP9pRxYPqkNYV7Xq8300/aZDpO35j1fJm/ncize8iGswzYlcvFw5DQUx4eVk+KvfXdL0rehNg==
+vscode-languageclient@8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/vscode-languageclient/-/vscode-languageclient-8.0.1.tgz#bf5535c4463a78daeaca0bcb4f5868aec86bb301"
+  integrity sha512-9XoE+HJfaWvu7Y75H3VmLo5WLCtsbxEgEhrLPqwt7eyoR49lUIyyrjb98Yfa50JCMqF2cePJAEVI6oe2o1sIhw==
   dependencies:
     minimatch "^3.0.4"
-    semver "^7.3.4"
-    vscode-languageserver-protocol "3.16.0"
+    semver "^7.3.5"
+    vscode-languageserver-protocol "3.17.1"
 
-vscode-languageserver-protocol@3.16.0:
-  version "3.16.0"
-  resolved "https://registry.yarnpkg.com/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.16.0.tgz#34135b61a9091db972188a07d337406a3cdbe821"
-  integrity sha512-sdeUoAawceQdgIfTI+sdcwkiK2KU+2cbEYA0agzM2uqaUy2UpnnGHtWTHVEtS0ES4zHU0eMFRGN+oQgDxlD66A==
+vscode-languageserver-protocol@3.17.1:
+  version "3.17.1"
+  resolved "https://registry.yarnpkg.com/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.1.tgz#e801762c304f740208b6c804a0cf21f2c87509ed"
+  integrity sha512-BNlAYgQoYwlSgDLJhSG+DeA8G1JyECqRzM2YO6tMmMji3Ad9Mw6AW7vnZMti90qlAKb0LqAlJfSVGEdqMMNzKg==
   dependencies:
-    vscode-jsonrpc "6.0.0"
-    vscode-languageserver-types "3.16.0"
+    vscode-jsonrpc "8.0.1"
+    vscode-languageserver-types "3.17.1"
 
-vscode-languageserver-types@3.16.0:
-  version "3.16.0"
-  resolved "https://registry.yarnpkg.com/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0.tgz#ecf393fc121ec6974b2da3efb3155644c514e247"
-  integrity sha512-k8luDIWJWyenLc5ToFQQMaSrqCHiLwyKPHKPQZ5zz21vM+vIVUSvsRpcbiECH4WR88K2XZqc4ScRcZ7nk/jbeA==
+vscode-languageserver-types@3.17.1:
+  version "3.17.1"
+  resolved "https://registry.yarnpkg.com/vscode-languageserver-types/-/vscode-languageserver-types-3.17.1.tgz#c2d87fa7784f8cac389deb3ff1e2d9a7bef07e16"
+  integrity sha512-K3HqVRPElLZVVPtMeKlsyL9aK0GxGQpvtAUTfX4k7+iJ4mc1M+JM+zQwkgGy2LzY0f0IAafe8MKqIkJrxfGGjQ==
 
 which@^2.0.1:
   version "2.0.2"


### PR DESCRIPTION
## Update metals-languageclient
To upgrade vscode-languageclient to 8.0.1, it was needed to remove
unused interface from metals-languageclient
see: https://github.com/scalameta/metals-languageclient/pull/459

Also, this version introduces some changes.

## Update vscode-languageclient
see: https://github.com/microsoft/vscode-languageserver-node/blob/95e411de3d10c0fa1e0371b84e88f482682a9170/README.md#3170-protocol-800-json-rpc-800-client-and-800-server

> cleanup of client start and stop methods. Both methods now return a promise since these methods are async. This is a breaking change since start returned a disposable before. Extensions should now implement a deactivate function in their extension main file and correctly return the stop promise from the deactivate call. As a consequence the onReady() got removed since extensions can await the start()

metals-vscode already implement `deactivate` method that returns promise from `stop()`, so it's all good