### PR TITLE
Bump metals-languageclient to 0.5.17 and vscode-languageclient to 8.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -956,11 +956,11 @@
   },
   "dependencies": {
     "ansicolor": "^1.1.100",
-    "metals-languageclient": "0.5.15",
+    "metals-languageclient": "0.5.17",
     "promisify-child-process": "4.1.1",
     "remarkable": "^2.0.1",
     "semver": "^7.3.7",
-    "vscode-languageclient": "7.0.0"
+    "vscode-languageclient": "8.0.2"
   },
   "extensionPack": [
     "scala-lang.scala"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -443,9 +443,7 @@ function launchMetals(
       )
   );
 
-  context.subscriptions.push(client.start());
-
-  return client.onReady().then(
+  return client.start().then(
     () => {
       const doctorProvider = new DoctorProvider(client);
       let stacktrace: WebviewPanel | undefined;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1408,10 +1408,10 @@ merge2@^1.3.0, merge2@^1.4.1:
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
   integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
 
-metals-languageclient@0.5.15:
-  version "0.5.15"
-  resolved "https://registry.yarnpkg.com/metals-languageclient/-/metals-languageclient-0.5.15.tgz#116f8d0cc1032f07b24777066965e5c12654dc6b"
-  integrity sha512-TOgU0rXI7FRE1ihvmhWu8lcCF6ECw/iNn/Qr1LRrGpb/a0LiqGcW8t4iXqguWniw5pfbk2BHht4fifN3EEHHqw==
+metals-languageclient@0.5.17:
+  version "0.5.17"
+  resolved "https://registry.yarnpkg.com/metals-languageclient/-/metals-languageclient-0.5.17.tgz#8539261e48ef848735664b2fd0a4333578909df7"
+  integrity sha512-Metfq37jQL9CqwnL22Ny6FtGuyoea0LhHxzD26Eo+X+mb8uZhubCu92Z4UTNYXlCDUjB1p2WKODn9fwM73GVdQ==
   dependencies:
     "@viperproject/locate-java-home" "^1.1.5"
     fp-ts "^2.4.1"
@@ -1420,7 +1420,7 @@ metals-languageclient@0.5.15:
     promisify-child-process "^4.0.0"
     semver "^7.1.1"
     shell-quote "^1.7.2"
-    vscode-languageserver-protocol "3.16.0"
+    vscode-languageserver-protocol "3.17.2"
 
 micromatch@^4.0.4:
   version "4.0.4"
@@ -1897,7 +1897,7 @@ semver@^5.1.0, semver@^5.4.1:
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
 
-semver@^7.1.1, semver@^7.3.4, semver@^7.3.5, semver@^7.3.7:
+semver@^7.1.1, semver@^7.3.5, semver@^7.3.7:
   version "7.3.7"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.7.tgz#12c5b649afdbf9049707796e22a4028814ce523f"
   integrity sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==
@@ -2283,32 +2283,32 @@ vsce@2.9.2, vsce@^2.6.3:
     yauzl "^2.3.1"
     yazl "^2.2.2"
 
-vscode-jsonrpc@6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/vscode-jsonrpc/-/vscode-jsonrpc-6.0.0.tgz#108bdb09b4400705176b957ceca9e0880e9b6d4e"
-  integrity sha512-wnJA4BnEjOSyFMvjZdpiOwhSq9uDoK8e/kpRJDTaMYzwlkrhG1fwDIZI94CLsLzlCK5cIbMMtFlJlfR57Lavmg==
+vscode-jsonrpc@8.0.2:
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/vscode-jsonrpc/-/vscode-jsonrpc-8.0.2.tgz#f239ed2cd6004021b6550af9fd9d3e47eee3cac9"
+  integrity sha512-RY7HwI/ydoC1Wwg4gJ3y6LpU9FJRZAUnTYMXthqhFXXu77ErDd/xkREpGuk4MyYkk4a+XDWAMqe0S3KkelYQEQ==
 
-vscode-languageclient@7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/vscode-languageclient/-/vscode-languageclient-7.0.0.tgz#b505c22c21ffcf96e167799757fca07a6bad0fb2"
-  integrity sha512-P9AXdAPlsCgslpP9pRxYPqkNYV7Xq8300/aZDpO35j1fJm/ncize8iGswzYlcvFw5DQUx4eVk+KvfXdL0rehNg==
+vscode-languageclient@8.0.2:
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/vscode-languageclient/-/vscode-languageclient-8.0.2.tgz#f1f23ce8c8484aa11e4b7dfb24437d3e59bb61c6"
+  integrity sha512-lHlthJtphG9gibGb/y72CKqQUxwPsMXijJVpHEC2bvbFqxmkj9LwQ3aGU9dwjBLqsX1S4KjShYppLvg1UJDF/Q==
   dependencies:
     minimatch "^3.0.4"
-    semver "^7.3.4"
-    vscode-languageserver-protocol "3.16.0"
+    semver "^7.3.5"
+    vscode-languageserver-protocol "3.17.2"
 
-vscode-languageserver-protocol@3.16.0:
-  version "3.16.0"
-  resolved "https://registry.yarnpkg.com/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.16.0.tgz#34135b61a9091db972188a07d337406a3cdbe821"
-  integrity sha512-sdeUoAawceQdgIfTI+sdcwkiK2KU+2cbEYA0agzM2uqaUy2UpnnGHtWTHVEtS0ES4zHU0eMFRGN+oQgDxlD66A==
+vscode-languageserver-protocol@3.17.2:
+  version "3.17.2"
+  resolved "https://registry.yarnpkg.com/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.2.tgz#beaa46aea06ed061576586c5e11368a9afc1d378"
+  integrity sha512-8kYisQ3z/SQ2kyjlNeQxbkkTNmVFoQCqkmGrzLH6A9ecPlgTbp3wDTnUNqaUxYr4vlAcloxx8zwy7G5WdguYNg==
   dependencies:
-    vscode-jsonrpc "6.0.0"
-    vscode-languageserver-types "3.16.0"
+    vscode-jsonrpc "8.0.2"
+    vscode-languageserver-types "3.17.2"
 
-vscode-languageserver-types@3.16.0:
-  version "3.16.0"
-  resolved "https://registry.yarnpkg.com/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0.tgz#ecf393fc121ec6974b2da3efb3155644c514e247"
-  integrity sha512-k8luDIWJWyenLc5ToFQQMaSrqCHiLwyKPHKPQZ5zz21vM+vIVUSvsRpcbiECH4WR88K2XZqc4ScRcZ7nk/jbeA==
+vscode-languageserver-types@3.17.2:
+  version "3.17.2"
+  resolved "https://registry.yarnpkg.com/vscode-languageserver-types/-/vscode-languageserver-types-3.17.2.tgz#b2c2e7de405ad3d73a883e91989b850170ffc4f2"
+  integrity sha512-zHhCWatviizPIq9B7Vh9uvrH6x3sK8itC84HkamnBWoDFJtzBf7SWlpLCZUit72b3os45h6RWQNC9xHRDF8dRA==
 
 which@^2.0.1:
   version "2.0.2"


### PR DESCRIPTION
Previously, we reverted the updates to those libraries in https://github.com/scalameta/metals-vscode/pull/1018 because of the [issue](https://github.com/scalameta/metals-vscode/issues/1016).

Now, the fix for the cause is in vscode-languageclient 8.0.2 and we should be able to safe to update those libraries.

- PR: https://github.com/microsoft/vscode-languageserver-node/pull/972
- release note: https://github.com/microsoft/vscode-languageserver-node#3172-protocol-802-json-rpc-802-client-and-802-server

I'm going to play around with this build for a while before merging this PR :)