### PR TITLE
bugfix: Fix issue with * not being inserted automatically

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1138,17 +1138,6 @@ function enableScaladocIndentation() {
         action: { indentAction: IndentAction.Indent },
       },
       {
-        // stop vscode from indenting automatically to last known indentation
-        beforeText: /^\s*/,
-        /* we still want {} to be nicely split with two new lines into
-         *{
-         *  |
-         *}
-         */
-        afterText: /[^\]\}\)]+/,
-        action: { indentAction: IndentAction.None },
-      },
-      {
         // e.g. /** ...|
         beforeText: /^\s*\/\*\*(?!\/)([^\*]|\*(?!\/))*$/,
         action: { indentAction: IndentAction.None, appendText: " * " },
@@ -1172,6 +1161,17 @@ function enableScaladocIndentation() {
         // e.g.  *-----*/|
         beforeText: /^(\t|(\ \ ))*\ \*[^/]*\*\/\s*$/,
         action: { indentAction: IndentAction.None, removeText: 1 },
+      },
+      {
+        // stop vscode from indenting automatically to last known indentation
+        beforeText: /^\s*$/,
+        /* we still want {} to be nicely split with two new lines into
+         *{
+         *  |
+         *}
+         */
+        afterText: /[^\]\}\)]+/,
+        action: { indentAction: IndentAction.None },
       },
     ],
   });


### PR DESCRIPTION
Previously, the rule for automatically adjusting whitespace for Scala 3 (due to issues with optional braces) was catching almost all scaladoc rules. Now, I moved it last (only first rule is used) and also added $ at the end of the regex.

