### PR TITLE
ci(Mergify): configuration update

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,9 +1,13 @@
 pull_request_rules:
-  - name: CI passes and is @types package from dependabot
+  - name: CI passes and is dev-dependency package from dependabot
     conditions:
-      - "#status-success=6"
+      - check-success=Test
+      - check-success=Extension test
+      - check-success=Build
+      - check-success=Prettier
+      - check-success=Eslint
       - author~=^dependabot(|-preview)\[bot\]$
-      - title~=^Bump @types/(\w+) from .*$
+      - title~=^build\(deps-dev\).*$
       - base=main
     actions:
       merge:


### PR DESCRIPTION
This change has been made by @tanishiking from https://mergify.com config editor.

This PR updates mergify configuration to

- Specify CIs explicitly instead of checking the number of success
  - There is no such thing as "every status check" in GitHub. https://docs.mergify.com/conditions/#validating-all-status-checks
  - Mergify recommends us specify all CIs explicitly
- Enable to merge all `devDependencies` instead of `@types` only.