### PR TITLE
chore: Update release version

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "ide",
     "scalameta"
   ],
-  "version": "1.19.0",
+  "version": "1.19.1",
   "publisher": "scalameta",
   "contributors": [
     {


### PR DESCRIPTION
Caused by multiple PRs merged at the same time. Usually not a problem, only if automatic merges and manual ones are done at the same time.