### PR TITLE
chore(prettier): fix prettier command in the npm scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -951,8 +951,8 @@
     "vscode:publish": "vsce publish --yarn",
     "ovsx:publish": "ovsx publish",
     "lint": "eslint . --ext .ts --fix && yarn format",
-    "format": "prettier --write '**/*.{ts,js,json,yml}'",
-    "format-check": "prettier --check '**/*.{ts,js,json,yml}'"
+    "format": "prettier --write **/*.{ts,js,json,yml}",
+    "format-check": "prettier --check **/*.{ts,js,json,yml}"
   },
   "devDependencies": {
     "@sourcegraph/scip-typescript": "^0.2.8",


### PR DESCRIPTION
## What is for this PR?

The current npm scripts command for prettier has error. This PR is fix them.

## Before & After

### before fix

```sh
$ yarn format
yarn run v1.22.11
warning metals@1.19.3: The engine "vscode" appears to be invalid.
$ prettier --write '**/*.{ts,js,json,yml}'
[error] No files matching the pattern were found: "'**/*.{ts,js,json,yml}'".
error Command failed with exit code 2.


$ yarn format-check
yarn run v1.22.11
warning metals@1.19.3: The engine "vscode" appears to be invalid.
$ prettier --check '**/*.{ts,js,json,yml}'
Checking formatting...
[error] No files matching the pattern were found: "'**/*.{ts,js,json,yml}'".
All matched files use Prettier code style!
error Command failed with exit code 2.
```


### after fix

```sh
$ yarn format       
yarn run v1.22.11
warning metals@1.19.3: The engine "vscode" appears to be invalid.
$ prettier --write **/*.{ts,js,json,yml}
.eslintrc.js 57ms
.github\dependabot.yml 30ms
.github\release-drafter.yml 9ms
...
update-version.js 7ms
Done in 2.38s.

$ yarn format-check
yarn run v1.22.11
warning metals@1.19.3: The engine "vscode" appears to be invalid.
$ prettier --check **/*.{ts,js,json,yml}
Checking formatting...
All matched files use Prettier code style!
Done in 2.08s.
```

Thank you :)