### PR TITLE
test: Add test for "needCheckForUpdates"

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -19,7 +19,11 @@ module.exports = {
         "no-unused-vars": "off",
         "@typescript-eslint/no-unused-vars": [
           "error",
-          { varsIgnorePattern: "_" },
+          {
+            argsIgnorePattern: "^_",
+            varsIgnorePattern: "^_",
+            caughtErrorsIgnorePattern: "^_",
+          },
         ],
         "@typescript-eslint/no-non-null-assertion": "error",
         "guard-for-in": "error",

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,8 +50,17 @@ Code and under "More Actions..." choose to "Install from VSIX...". Then open a
 
 ## Testing
 
-The extension currently has no tests. When you are happy with the functionality
-of your change, feel free to open a PR without tests.
+```sh
+# run unit all tests
+$ yarn run test
+
+# run unit tests that matched with the given regex
+# e.g. `yarn run test -g needCheckForUpdates`
+$ yarn run test -g <test name regex>
+
+# run integration tests
+$ yarn run test-extension
+```
 
 ## Formatting
 

--- a/package.json
+++ b/package.json
@@ -978,7 +978,6 @@
     "compile": "tsc -p ./",
     "clean": "rimraf out/",
     "watch": "tsc -watch -p ./",
-    "test-unit": "ts-mocha src/*.test.ts",
     "test": "ts-mocha src/test/unit/*.test.ts",
     "test-extension": "rimraf out/ && tsc -p ./ && node out/test/extension/runTest.js",
     "build": "yarn clean && vsce package --yarn",
@@ -990,6 +989,7 @@
   },
   "devDependencies": {
     "@sourcegraph/scip-typescript": "^0.2.9",
+    "@types/chai": "^4.3.3",
     "@types/glob": "^8.0.0",
     "@types/mocha": "^9.1.1",
     "@types/node": "18.7.14",
@@ -1000,6 +1000,7 @@
     "@typescript-eslint/eslint-plugin": "^5.36.1",
     "@typescript-eslint/parser": "^5.36.1",
     "@vscode/test-electron": "^2.1.5",
+    "chai": "^4.3.6",
     "eslint": "^8.23.0",
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-mocha": "^10.1.0",

--- a/package.json
+++ b/package.json
@@ -978,6 +978,7 @@
     "compile": "tsc -p ./",
     "clean": "rimraf out/",
     "watch": "tsc -watch -p ./",
+    "test-unit": "ts-mocha src/*.test.ts",
     "test": "ts-mocha src/test/unit/*.test.ts",
     "test-extension": "rimraf out/ && tsc -p ./ && node out/test/extension/runTest.js",
     "build": "yarn clean && vsce package --yarn",
@@ -994,6 +995,7 @@
     "@types/node": "18.7.14",
     "@types/remarkable": "^2.0.3",
     "@types/semver": "^7.3.12",
+    "@types/sinon": "^10.0.13",
     "@types/vscode": "1.59.0",
     "@typescript-eslint/eslint-plugin": "^5.36.1",
     "@typescript-eslint/parser": "^5.36.1",
@@ -1007,6 +1009,7 @@
     "ovsx": "0.5.1",
     "prettier": "2.7.1",
     "rimraf": "^3.0.2",
+    "sinon": "^14.0.0",
     "ts-mocha": "^10.0.0",
     "typescript": "4.8.2",
     "vsce": "2.11.0"

--- a/src/ConfigurationTarget.ts
+++ b/src/ConfigurationTarget.ts
@@ -1,0 +1,4 @@
+export enum ConfigurationTarget {
+  Global,
+  Workspace,
+}

--- a/src/repository/CheckForUpdateRepo.ts
+++ b/src/repository/CheckForUpdateRepo.ts
@@ -1,0 +1,50 @@
+import { ExtensionContext, Memento } from "vscode";
+import { ConfigurationTarget } from "../ConfigurationTarget";
+
+type LastUpdated = {
+  prevVersion?: string;
+  lastUpdatedAt?: string;
+};
+
+export interface CheckForUpdateRepo {
+  getLastUpdated(target: ConfigurationTarget): LastUpdated;
+  saveLastUpdated(
+    serverVersion: string,
+    lastUpdatedAt: string,
+    target: ConfigurationTarget
+  ): void;
+}
+
+export class DefaultCheckForUpdateRepo implements CheckForUpdateRepo {
+  constructor(private context: ExtensionContext) {}
+
+  private CurrentVersionKey = "currentVersion";
+  private LastUpdatedAtKey = "lastUpdatedAt";
+
+  getLastUpdated(target: ConfigurationTarget): LastUpdated {
+    const state = this.storage(target);
+    const prevVersion = state.get<string>(this.CurrentVersionKey);
+    const lastUpdatedAt = state.get<string>(this.LastUpdatedAtKey);
+    return {
+      prevVersion,
+      lastUpdatedAt,
+    };
+  }
+
+  saveLastUpdated(
+    serverVersion: string,
+    lastUpdatedAt: string,
+    target: ConfigurationTarget
+  ): void {
+    const state = this.storage(target);
+    state.update(this.CurrentVersionKey, serverVersion);
+    state.update(this.LastUpdatedAtKey, lastUpdatedAt);
+    return;
+  }
+
+  private storage(target: ConfigurationTarget): Memento {
+    return target === ConfigurationTarget.Global
+      ? this.context.globalState
+      : this.context.workspaceState;
+  }
+}

--- a/src/service/checkForUpdate.ts
+++ b/src/service/checkForUpdate.ts
@@ -1,0 +1,23 @@
+import { ConfigurationTarget } from "../ConfigurationTarget";
+import { CheckForUpdateRepo } from "../repository/CheckForUpdateRepo";
+
+/**
+ * The logic is the following:
+ *  - if version was set more than a day ago - update is needed
+ *  - if version is seen for the first time (user changed version in config by it self) - the update will be delayed for a day
+ */
+export async function needCheckForUpdates(
+  currentVersion: string,
+  today: string,
+  target: ConfigurationTarget,
+  repo: CheckForUpdateRepo
+): Promise<boolean> {
+  const { prevVersion, lastUpdatedAt } = repo.getLastUpdated(target);
+
+  if (prevVersion !== currentVersion) {
+    repo.saveLastUpdated(currentVersion, today, target);
+    return false;
+  } else {
+    return lastUpdatedAt !== today;
+  }
+}

--- a/src/test/unit/checkForUpdate.test.ts
+++ b/src/test/unit/checkForUpdate.test.ts
@@ -1,0 +1,89 @@
+import assert from "assert";
+import { ConfigurationTarget } from "../../ConfigurationTarget";
+import { needCheckForUpdates } from "../../service/checkForUpdate";
+import { CheckForUpdateRepo } from "../../repository/CheckForUpdateRepo";
+import sinon from "sinon";
+
+class MockRepo implements CheckForUpdateRepo {
+  constructor(private prevVersion?: string, private lastUpdatedAt?: string) {}
+  getLastUpdated(_target: ConfigurationTarget): {
+    prevVersion?: string | undefined;
+    lastUpdatedAt?: string | undefined;
+  } {
+    return {
+      prevVersion: this.prevVersion,
+      lastUpdatedAt: this.lastUpdatedAt,
+    };
+  }
+  saveLastUpdated(
+    _serverVersion: string,
+    _lastUpdatedAt: string,
+    _target: ConfigurationTarget
+  ): void {
+    return;
+  }
+}
+
+describe("needCheckForUpdates", () => {
+  it("should false if nothing has saved / save current versions", async () => {
+    const currentVersion = "0.11.8";
+    const today = "2022-01-01";
+    const repo = new MockRepo(undefined, undefined);
+    const spy = sinon.spy(repo, "saveLastUpdated");
+    const actual = await needCheckForUpdates(
+      currentVersion,
+      today,
+      ConfigurationTarget.Global,
+      repo
+    );
+    assert(actual === false);
+    assert(spy.calledWith(currentVersion, today, ConfigurationTarget.Global));
+  });
+
+  it("should false if currentVersion was seen for the first time / save current versions", async () => {
+    const prevVersion = "0.11.8";
+    const currentVersion = "0.11.9";
+    const today = "2022-01-01";
+    const repo = new MockRepo(prevVersion, today);
+    const spy = sinon.spy(repo, "saveLastUpdated");
+    const actual = await needCheckForUpdates(
+      currentVersion,
+      today,
+      ConfigurationTarget.Global,
+      repo
+    );
+    assert(actual === false);
+    assert(spy.calledWith(currentVersion, today, ConfigurationTarget.Global));
+  });
+
+  it("should false if currentVersion is set today", async () => {
+    const currentVersion = "0.11.8";
+    const today = "2022-01-01";
+    const repo = new MockRepo(currentVersion, today);
+    const spy = sinon.spy(repo, "saveLastUpdated");
+    const actual = await needCheckForUpdates(
+      currentVersion,
+      today,
+      ConfigurationTarget.Global,
+      repo
+    );
+    assert(actual === false);
+    assert(spy.notCalled);
+  });
+
+  it("should true if currentVersion is set more than a day ago", async () => {
+    const currentVersion = "0.11.8";
+    const lastUpdatedAt = "2022-01-01";
+    const today = "2022-01-02";
+    const repo = new MockRepo(currentVersion, lastUpdatedAt);
+    const spy = sinon.spy(repo, "saveLastUpdated");
+    const actual = await needCheckForUpdates(
+      currentVersion,
+      today,
+      ConfigurationTarget.Global,
+      repo
+    );
+    assert(actual === true);
+    assert(spy.notCalled);
+  });
+});

--- a/src/test/unit/checkForUpdate.test.ts
+++ b/src/test/unit/checkForUpdate.test.ts
@@ -1,8 +1,8 @@
-import assert from "assert";
 import { ConfigurationTarget } from "../../ConfigurationTarget";
 import { needCheckForUpdates } from "../../service/checkForUpdate";
 import { CheckForUpdateRepo } from "../../repository/CheckForUpdateRepo";
 import sinon from "sinon";
+import { expect } from "chai";
 
 class MockRepo implements CheckForUpdateRepo {
   constructor(private prevVersion?: string, private lastUpdatedAt?: string) {}
@@ -36,8 +36,12 @@ describe("needCheckForUpdates", () => {
       ConfigurationTarget.Global,
       repo
     );
-    assert(actual === false);
-    assert(spy.calledWith(currentVersion, today, ConfigurationTarget.Global));
+    expect(actual).false;
+    expect(spy.getCall(0).args).to.eql([
+      currentVersion,
+      today,
+      ConfigurationTarget.Global,
+    ]);
   });
 
   it("should false if currentVersion was seen for the first time / save current versions", async () => {
@@ -52,8 +56,12 @@ describe("needCheckForUpdates", () => {
       ConfigurationTarget.Global,
       repo
     );
-    assert(actual === false);
-    assert(spy.calledWith(currentVersion, today, ConfigurationTarget.Global));
+    expect(actual).false;
+    expect(spy.getCall(0).args).to.eql([
+      currentVersion,
+      today,
+      ConfigurationTarget.Global,
+    ]);
   });
 
   it("should false if currentVersion is set today", async () => {
@@ -67,8 +75,8 @@ describe("needCheckForUpdates", () => {
       ConfigurationTarget.Global,
       repo
     );
-    assert(actual === false);
-    assert(spy.notCalled);
+    expect(actual).false;
+    expect(spy.notCalled).true;
   });
 
   it("should true if currentVersion is set more than a day ago", async () => {
@@ -83,7 +91,7 @@ describe("needCheckForUpdates", () => {
       ConfigurationTarget.Global,
       repo
     );
-    assert(actual === true);
-    assert(spy.notCalled);
+    expect(actual).true;
+    expect(spy.notCalled).true;
   });
 });

--- a/src/test/unit/indentPattern.test.ts
+++ b/src/test/unit/indentPattern.test.ts
@@ -1,8 +1,8 @@
-import assert from "assert";
+import { expect } from "chai";
 import { increaseIndentPattern } from "../../indentPattern";
 
 function checkIndent(indentPattern: RegExp, result: boolean) {
-  return (text: string) => assert(indentPattern.test(text) === result);
+  return (text: string) => expect(indentPattern.test(text)).to.equal(result);
 }
 
 function checkFunctions(indentPattern: RegExp) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -106,6 +106,11 @@
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"
   integrity sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==
 
+"@types/chai@^4.3.3":
+  version "4.3.3"
+  resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.3.3.tgz#3c90752792660c4b562ad73b3fbd68bf3bc7ae07"
+  integrity sha512-hC7OMnszpxhZPduX+m+nrx+uFoLkWOMiR4oa/AZF3MuSETYTZmFfJAHqZEM8MVlvfG7BEUcgvtwoCTxBp6hm3g==
+
 "@types/glob@^8.0.0":
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/@types/glob/-/glob-8.0.0.tgz#321607e9cbaec54f687a0792b2d1d370739455d2"
@@ -382,6 +387,11 @@ arrify@^1.0.0:
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
   integrity sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=
 
+assertion-error@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-1.1.0.tgz#e60b6b0e8f301bd97e5375215bda406c85118c0b"
+  integrity sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==
+
 async@^3.2.2:
   version "3.2.3"
   resolved "https://registry.yarnpkg.com/async/-/async-3.2.3.tgz#ac53dafd3f4720ee9e8a160628f18ea91df196c9"
@@ -522,6 +532,19 @@ camelcase@^6.0.0:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-6.3.0.tgz#5685b95eb209ac9c0c177467778c9c84df58ba9a"
   integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
 
+chai@^4.3.6:
+  version "4.3.6"
+  resolved "https://registry.yarnpkg.com/chai/-/chai-4.3.6.tgz#ffe4ba2d9fa9d6680cc0b370adae709ec9011e9c"
+  integrity sha512-bbcp3YfHCUzMOvKqsztczerVgBKSsEijCySNlHHbX3VG1nskvqjz5Rfso1gGwD6w6oOV3eI60pKuMOV5MV7p3Q==
+  dependencies:
+    assertion-error "^1.1.0"
+    check-error "^1.0.2"
+    deep-eql "^3.0.1"
+    get-func-name "^2.0.0"
+    loupe "^2.3.1"
+    pathval "^1.1.1"
+    type-detect "^4.0.5"
+
 chainsaw@~0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/chainsaw/-/chainsaw-0.1.0.tgz#5eab50b28afe58074d0d58291388828b5e5fbc98"
@@ -545,6 +568,11 @@ chalk@^4.0.0, chalk@^4.1.0:
   dependencies:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
+
+check-error@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/check-error/-/check-error-1.0.2.tgz#574d312edd88bb5dd8912e9286dd6c0aed4aac82"
+  integrity sha512-BrgHpW9NURQgzoNyjfq0Wu6VFO6D7IZEmJNdtgNqpzGG8RuNFHt2jQxWlAs4HMe119chBnv+34syEZtc6IhLtA==
 
 cheerio-select@^1.5.0:
   version "1.5.0"
@@ -701,6 +729,13 @@ decompress-response@^4.2.0:
   integrity sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==
   dependencies:
     mimic-response "^2.0.0"
+
+deep-eql@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/deep-eql/-/deep-eql-3.0.1.tgz#dfc9404400ad1c8fe023e7da1df1c147c4b444df"
+  integrity sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==
+  dependencies:
+    type-detect "^4.0.0"
 
 deep-extend@^0.6.0:
   version "0.6.0"
@@ -1103,6 +1138,11 @@ get-caller-file@^2.0.5:
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
 
+get-func-name@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/get-func-name/-/get-func-name-2.0.0.tgz#ead774abee72e20409433a066366023dd6887a41"
+  integrity sha512-Hm0ixYtaSZ/V7C8FJrtZIuBBI+iSgL+1Aq82zSu8VQNB4S3Gk8e7Qs3VwBDJAhmRZcFqkl3tQu36g/Foh5I5ig==
+
 get-intrinsic@^1.0.2:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.1.1.tgz#15f59f376f855c446963948f0d24cd3637b4abc6"
@@ -1455,6 +1495,13 @@ log-symbols@4.1.0:
     chalk "^4.1.0"
     is-unicode-supported "^0.1.0"
 
+loupe@^2.3.1:
+  version "2.3.4"
+  resolved "https://registry.yarnpkg.com/loupe/-/loupe-2.3.4.tgz#7e0b9bffc76f148f9be769cb1321d3dcf3cb25f3"
+  integrity sha512-OvKfgCC2Ndby6aSTREl5aCCPTNIzlDfQZvZxNUrBrihDhL3xcrYegTblhmEiCrg2kKQz4XsFIaemE5BF4ybSaQ==
+  dependencies:
+    get-func-name "^2.0.0"
+
 lru-cache@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-6.0.0.tgz#6d6fe6570ebd96aaf90fcad1dafa3b2566db3a94"
@@ -1781,6 +1828,11 @@ path-type@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-4.0.0.tgz#84ed01c0a7ba380afe09d90a8c180dcd9d03043b"
   integrity sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
+
+pathval@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/pathval/-/pathval-1.1.1.tgz#8534e77a77ce7ac5a2512ea21e0fdb8fcf6c3d8d"
+  integrity sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==
 
 pend@~1.2.0:
   version "1.2.0"
@@ -2300,7 +2352,7 @@ type-check@^0.4.0, type-check@~0.4.0:
   dependencies:
     prelude-ls "^1.2.1"
 
-type-detect@4.0.8, type-detect@^4.0.8:
+type-detect@4.0.8, type-detect@^4.0.0, type-detect@^4.0.5, type-detect@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
   integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==

--- a/yarn.lock
+++ b/yarn.lock
@@ -62,6 +62,34 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
+"@sinonjs/commons@^1.6.0", "@sinonjs/commons@^1.7.0", "@sinonjs/commons@^1.8.3":
+  version "1.8.3"
+  resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.8.3.tgz#3802ddd21a50a949b6721ddd72da36e67e7f1b2d"
+  integrity sha512-xkNcLAn/wZaX14RPlwizcKicDk9G3F8m2nU3L7Ukm5zBgTwiT0wsoFAHx9Jq56fJA1z/7uKGtCRu16sOUCLIHQ==
+  dependencies:
+    type-detect "4.0.8"
+
+"@sinonjs/fake-timers@>=5", "@sinonjs/fake-timers@^9.1.2":
+  version "9.1.2"
+  resolved "https://registry.yarnpkg.com/@sinonjs/fake-timers/-/fake-timers-9.1.2.tgz#4eaab737fab77332ab132d396a3c0d364bd0ea8c"
+  integrity sha512-BPS4ynJW/o92PUR4wgriz2Ud5gpST5vz6GQfMixEDK0Z8ZCUv2M7SkBLykH56T++Xs+8ln9zTGbOvNGIe02/jw==
+  dependencies:
+    "@sinonjs/commons" "^1.7.0"
+
+"@sinonjs/samsam@^6.1.1":
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/@sinonjs/samsam/-/samsam-6.1.1.tgz#627f7f4cbdb56e6419fa2c1a3e4751ce4f6a00b1"
+  integrity sha512-cZ7rKJTLiE7u7Wi/v9Hc2fs3Ucc3jrWeMgPHbbTCeVAB2S0wOBbYlkJVeNSL04i7fdhT8wIbDq1zhC/PXTD2SA==
+  dependencies:
+    "@sinonjs/commons" "^1.6.0"
+    lodash.get "^4.4.2"
+    type-detect "^4.0.8"
+
+"@sinonjs/text-encoding@^0.7.1":
+  version "0.7.2"
+  resolved "https://registry.yarnpkg.com/@sinonjs/text-encoding/-/text-encoding-0.7.2.tgz#5981a8db18b56ba38ef0efb7d995b12aa7b51918"
+  integrity sha512-sXXKG+uL9IrKqViTtao2Ws6dy0znu9sOaP1di/jKGW1M6VssO8vlpXCQcpZ+jisQ1tTFAC5Jo/EOzFbggBagFQ==
+
 "@sourcegraph/scip-typescript@^0.2.9":
   version "0.2.9"
   resolved "https://registry.yarnpkg.com/@sourcegraph/scip-typescript/-/scip-typescript-0.2.9.tgz#17365c803bcd9f68c3be570f13263955e277a9e9"
@@ -128,6 +156,18 @@
   version "7.3.12"
   resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.3.12.tgz#920447fdd78d76b19de0438b7f60df3c4a80bf1c"
   integrity sha512-WwA1MW0++RfXmCr12xeYOOC5baSC9mSb0ZqCquFzKhcoF4TvHu5MKOuXsncgZcpVFhB1pXd5hZmM0ryAoCp12A==
+
+"@types/sinon@^10.0.13":
+  version "10.0.13"
+  resolved "https://registry.yarnpkg.com/@types/sinon/-/sinon-10.0.13.tgz#60a7a87a70d9372d0b7b38cc03e825f46981fb83"
+  integrity sha512-UVjDqJblVNQYvVNUsj0PuYYw0ELRmgt1Nt5Vk0pT5f16ROGfcKJY8o1HVuMOJOpD727RrGB9EGvoaTQE5tgxZQ==
+  dependencies:
+    "@types/sinonjs__fake-timers" "*"
+
+"@types/sinonjs__fake-timers@*":
+  version "8.1.2"
+  resolved "https://registry.yarnpkg.com/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.2.tgz#bf2e02a3dbd4aecaf95942ecd99b7402e03fad5e"
+  integrity sha512-9GcLXF0/v3t80caGs5p2rRfkB+a8VBGLJZVih6CNFkx8IZ994wiKKLSRs9nuFwk1HevWs/1mnUmkApGrSGsShA==
 
 "@types/vscode@1.59.0":
   version "1.59.0"
@@ -691,6 +731,11 @@ diff@^3.1.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
   integrity sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==
+
+diff@^5.0.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-5.1.0.tgz#bc52d298c5ea8df9194800224445ed43ffc87e40"
+  integrity sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==
 
 dir-glob@^3.0.1:
   version "3.0.1"
@@ -1308,6 +1353,11 @@ is-unicode-supported@^0.1.0:
   resolved "https://registry.yarnpkg.com/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz#3f26c76a809593b52bfa2ecb5710ed2779b522a7"
   integrity sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==
 
+isarray@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
+  integrity sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==
+
 isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
@@ -1341,6 +1391,11 @@ json5@^1.0.1:
   integrity sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==
   dependencies:
     minimist "^1.2.0"
+
+just-extend@^4.0.2:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/just-extend/-/just-extend-4.2.1.tgz#ef5e589afb61e5d66b24eca749409a8939a8c744"
+  integrity sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==
 
 keytar@^7.7.0:
   version "7.7.0"
@@ -1381,6 +1436,11 @@ locate-path@^6.0.0:
   integrity sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==
   dependencies:
     p-locate "^5.0.0"
+
+lodash.get@^4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
+  integrity sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==
 
 lodash.merge@^4.6.2:
   version "4.6.2"
@@ -1554,6 +1614,17 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
 
+nise@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/nise/-/nise-5.1.1.tgz#ac4237e0d785ecfcb83e20f389185975da5c31f3"
+  integrity sha512-yr5kW2THW1AkxVmCnKEh4nbYkJdB3I7LUkiUgOvEkOp414mc2UMaHMA7pjq1nYowhdoJZGwEKGaQVbxfpWj10A==
+  dependencies:
+    "@sinonjs/commons" "^1.8.3"
+    "@sinonjs/fake-timers" ">=5"
+    "@sinonjs/text-encoding" "^0.7.1"
+    just-extend "^4.0.2"
+    path-to-regexp "^1.7.0"
+
 node-abi@^2.21.0:
   version "2.30.1"
   resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-2.30.1.tgz#c437d4b1fe0e285aaf290d45b45d4d7afedac4cf"
@@ -1698,6 +1769,13 @@ path-key@^3.1.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-3.1.1.tgz#581f6ade658cbba65a0d3380de7753295054f375"
   integrity sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==
+
+path-to-regexp@^1.7.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.8.0.tgz#887b3ba9d84393e87a0a0b9f4cb756198b53548a"
+  integrity sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==
+  dependencies:
+    isarray "0.0.1"
 
 path-type@^4.0.0:
   version "4.0.0"
@@ -1986,6 +2064,18 @@ simple-get@^3.0.3:
     once "^1.3.1"
     simple-concat "^1.0.0"
 
+sinon@^14.0.0:
+  version "14.0.0"
+  resolved "https://registry.yarnpkg.com/sinon/-/sinon-14.0.0.tgz#203731c116d3a2d58dc4e3cbe1f443ba9382a031"
+  integrity sha512-ugA6BFmE+WrJdh0owRZHToLd32Uw3Lxq6E6LtNRU+xTVBefx632h03Q7apXWRsRdZAJ41LB8aUfn2+O4jsDNMw==
+  dependencies:
+    "@sinonjs/commons" "^1.8.3"
+    "@sinonjs/fake-timers" "^9.1.2"
+    "@sinonjs/samsam" "^6.1.1"
+    diff "^5.0.0"
+    nise "^5.1.1"
+    supports-color "^7.2.0"
+
 slash@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
@@ -2084,7 +2174,7 @@ supports-color@^5.3.0:
   dependencies:
     has-flag "^3.0.0"
 
-supports-color@^7.1.0:
+supports-color@^7.1.0, supports-color@^7.2.0:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-7.2.0.tgz#1b7dcdcb32b8138801b3e478ba6a51caa89648da"
   integrity sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==
@@ -2209,6 +2299,11 @@ type-check@^0.4.0, type-check@~0.4.0:
   integrity sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==
   dependencies:
     prelude-ls "^1.2.1"
+
+type-detect@4.0.8, type-detect@^4.0.8:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
+  integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==
 
 type-fest@^0.20.2:
   version "0.20.2"


### PR DESCRIPTION
https://github.com/scalameta/metals-vscode/issues/1144

This commit adds a test for `needCheckForUpdates`.

For adding unit tests, this commit abstract away the logic that needs
access to vscode APIs, becuase we need to run an integration test for
accessing vscode APIs.
see: https://github.com/microsoft/vscode-wordcount/issues/5#issuecomment-171050759
https://github.com/microsoft/vscode/issues/82471#issuecomment-564731132