### PR TITLE
bugfix: Check if tests namespace is enabled

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -28,6 +28,7 @@ import {
   ProviderResult,
   Hover,
   TextDocument,
+  tests,
 } from "vscode";
 import {
   LanguageClient,
@@ -600,7 +601,7 @@ function launchMetals(
           "Test Explorer"
         );
 
-      const istTestManagerDisabled = getTestUI() === "Code Lenses";
+      const istTestManagerDisabled = !tests || getTestUI() === "Code Lenses";
       const testManager = createTestManager(client, istTestManagerDisabled);
 
       const disableTestExplorer = workspace.onDidChangeConfiguration(() => {


### PR DESCRIPTION
Eclipse Theia does not support test explorer currently.

Related to https://github.com/scalameta/metals-vscode/discussions/1244