### PR TITLE
fix: change bloop related settings scope to machine

### DIFF
--- a/package.json
+++ b/package.json
@@ -300,11 +300,12 @@
         },
         "metals.bloopVersion": {
           "type": "string",
+          "scope": "machine",
           "markdownDescription": "This version will be used for the Bloop build tool plugin, for any supported build tool,while importing in Metals as well as for running the embedded server"
         },
         "metals.bloopJvmProperties": {
           "type": "array",
-          "scope": "machine-overridable",
+          "scope": "machine",
           "items": {
             "type": "string"
           },


### PR DESCRIPTION
scope - a configuration setting can have one of the following possible scopes:

    application - Settings that apply to all instances of VS Code and can only be configured in user settings.

    machine - Machine specific settings that can be set only in user settings or only in remote settings. For example, an installation path which shouldn't be shared across machines.

    machine-overridable - Machine specific settings that can be overridden by workspace or folder settings.

    window - Windows (instance) specific settings which can be configured in user, workspace, or remote settings.

    resource - Resource settings, which apply to files and folders, and can be configured in all settings levels, even folder settings.

    language-overridable - Resource settings that can be overridable at a language level.


Looking at that `machine` looks like the best option, doesn't it?
