### PR TITLE
revert: workaround for empty completion list + `isIncomplete = true`

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -29,8 +29,6 @@ import {
   Hover,
   TextDocument,
   tests as vscodeTextExplorer,
-  CompletionItem,
-  CompletionList,
 } from "vscode";
 import {
   LanguageClient,
@@ -303,28 +301,6 @@ function launchMetals(
     outputChannel: outputChannel,
     initializationOptions,
     middleware: {
-      provideCompletionItem: async (
-        document,
-        position,
-        context,
-        token,
-        next
-      ) => {
-        const list = await next(document, position, context, token);
-        if (Array.isArray(list)) {
-          return list;
-        } else if (list) {
-          // workaround for https://github.com/scalameta/metals/issues/4756
-          // original vscode issue https://github.com/microsoft/vscode/issues/155738
-          if (list.isIncomplete && list.items.length == 0) {
-            // this item won't be rendered by vscode
-            const item = new CompletionItem("type more!!");
-            return new CompletionList([item], true);
-          } else {
-            return list;
-          }
-        }
-      },
       provideHover: hoverLinksMiddlewareHook,
     },
     markdown: {


### PR DESCRIPTION
Reverted #1278 

Unfortunately it seems that the message is rendered and we need a different workaround here.

![Screenshot from 2022-12-30 16-07-19](https://user-images.githubusercontent.com/3807253/210232314-0292fa10-6ee0-4f85-b961-6629e4113f22.png)

I think we should revert before the release and try to rework the approach later
