### PR TITLE
chore: Bump default prerelease version to working one.

### DIFF
--- a/package.json
+++ b/package.json
@@ -220,7 +220,7 @@
       "properties": {
         "metals.serverVersion": {
           "type": "string",
-          "default": "0.11.10+21-a3a44da3-SNAPSHOT",
+          "default": "0.11.10+31-181ba661-SNAPSHOT",
           "markdownDescription": "The version of the Metals server artifact. Requires reloading the window.  \n\n**VS Code extension version is guaranteed to work only with the default version, change if you know what you're doing**"
         },
         "metals.serverProperties": {


### PR DESCRIPTION
Recently there has been some issues with snapshot, so bumping to the bugfixed one before announcing semantic highlight to test out..