### PR TITLE
feature: When using run discovery use shell command to run in task terminal

### DIFF
--- a/package.json
+++ b/package.json
@@ -220,7 +220,7 @@
       "properties": {
         "metals.serverVersion": {
           "type": "string",
-          "default": "0.11.10+31-181ba661-SNAPSHOT",
+          "default": "0.11.10+138-254db453-SNAPSHOT",
           "markdownDescription": "The version of the Metals server artifact. Requires reloading the window.  \n\n**VS Code extension version is guaranteed to work only with the default version, change if you know what you're doing**"
         },
         "metals.serverProperties": {

--- a/src/debugger/scalaDebugger.ts
+++ b/src/debugger/scalaDebugger.ts
@@ -95,7 +95,26 @@ export async function startDiscovery(
   noDebug: boolean,
   debugParams: DebugDiscoveryParams
 ): Promise<boolean> {
-  return debug(noDebug, debugParams);
+  if (
+    noDebug &&
+    debugParams.runType != RunType.TestFile &&
+    debugParams.runType != RunType.TestTarget
+  ) {
+    return vscode.commands
+      .executeCommand<ScalaCodeLensesParams>(
+        "discover-jvm-run-command",
+        debugParams
+      )
+      .then((response) => {
+        if (response && isExtendedScalaRunMain(response)) {
+          return runMain(response);
+        } else {
+          return debug(noDebug, debugParams);
+        }
+      });
+  } else {
+    return debug(noDebug, debugParams);
+  }
 }
 
 export async function start(


### PR DESCRIPTION
Previously, only when run from code lenses we would use the task terminal for running. Now, also when running the discovery commands (including when using F5 with no configurations) we will by default run within that terminal.