### PR TITLE
feature: Run local coursier if available to avoid using bootstraped one

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
       - uses: actions/checkout@v2
+      - uses: coursier/setup-action@v1
       - uses: actions/setup-node@v2
         with:
           node-version: "16"

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,10 +7,11 @@
       "type": "extensionHost",
       "request": "launch",
       "runtimeExecutable": "${execPath}",
-      "args": ["--extensionDevelopmentPath=${workspaceRoot}"],
-      "stopOnEntry": false,
+      "args": [
+        "--extensionDevelopmentPath=${workspaceRoot}/packages/metals-vscode"
+      ],
       "sourceMaps": true,
-      "outFiles": ["${workspaceRoot}/out/**/*.js"],
+      "outFiles": ["${workspaceRoot}/packages/metals-vscode/out/**/*.js"],
       "preLaunchTask": "npm: watch"
     }
   ]

--- a/packages/metals-languageclient/src/__tests__/fetchMetals.test.ts
+++ b/packages/metals-languageclient/src/__tests__/fetchMetals.test.ts
@@ -1,4 +1,5 @@
 import { calcServerDependency } from "../fetchMetals";
+import { validateCoursier } from "../fetchMetals";
 
 describe("fetchMetals", () => {
   describe("calcServerDependency", () => {
@@ -33,5 +34,18 @@ describe("fetchMetals", () => {
       const customVersion = "com.acme:metals_1.2.3:3.2.1-foobar";
       expect(calcServerDependency(customVersion)).toBe(customVersion);
     });
+  });
+
+  it("should find coursier in PATH", async () => {
+    const pathEnv = process.env["PATH"];
+    if (pathEnv) {
+      expect(await validateCoursier(pathEnv)).toBeDefined();
+    } else {
+      fail("PATH environment variable is not defined");
+    }
+  });
+
+  it("should not find coursier if not present in PATH", async () => {
+    expect(await validateCoursier("path/fake")).toBeUndefined();
   });
 });

--- a/packages/metals-languageclient/src/fetchMetals.ts
+++ b/packages/metals-languageclient/src/fetchMetals.ts
@@ -1,6 +1,9 @@
 import * as semver from "semver";
+import path from "path";
+import fs from "fs";
 import { ChildProcessPromise, spawn } from "promisify-child-process";
 import { JavaConfig } from "./getJavaConfig";
+import { OutputChannel } from "./interfaces/OutputChannel";
 
 interface FetchMetalsOptions {
   serverVersion: string;
@@ -8,49 +11,112 @@ interface FetchMetalsOptions {
   javaConfig: JavaConfig;
 }
 
-export function fetchMetals({
-  serverVersion,
-  serverProperties,
-  javaConfig: { javaPath, javaOptions, extraEnv, coursierPath },
-}: FetchMetalsOptions): ChildProcessPromise {
+/**
+ * Without the additional object, the promises will be flattened and
+ * we will not be able to stream the output.
+ */
+interface PackedChildPromise {
+  promise: ChildProcessPromise;
+}
+
+export async function fetchMetals(
+  {
+    serverVersion,
+    serverProperties,
+    javaConfig: { javaPath, javaOptions, extraEnv, coursierPath },
+  }: FetchMetalsOptions,
+  output: OutputChannel
+): Promise<PackedChildPromise> {
   const fetchProperties = serverProperties.filter(
     (p) => !p.startsWith("-agentlib")
   );
-
   const serverDependency = calcServerDependency(serverVersion);
-  return spawn(
-    javaPath,
-    [
-      ...javaOptions,
-      ...fetchProperties,
-      "-Dfile.encoding=UTF-8",
-      "-jar",
-      coursierPath,
-      "fetch",
-      "-p",
-      "--ttl",
-      // Use infinite ttl to avoid redunant "Checking..." logs when using SNAPSHOT
-      // versions. Metals SNAPSHOT releases are effectively immutable since we
-      // never publish the same version twice.
-      "Inf",
-      serverDependency,
-      "-r",
-      "bintray:scalacenter/releases",
-      "-r",
-      "sonatype:public",
-      "-r",
-      "sonatype:snapshots",
-      "-p",
-    ],
-    {
-      env: {
-        COURSIER_NO_TERM: "true",
-        ...extraEnv,
-        ...process.env,
-      },
-      stdio: ["ignore"], // Due to Issue: #219
+
+  const coursierArgs = [
+    "fetch",
+    "-p",
+    "--ttl",
+    // Use infinite ttl to avoid redunant "Checking..." logs when using SNAPSHOT
+    // versions. Metals SNAPSHOT releases are effectively immutable since we
+    // never publish the same version twice.
+    "Inf",
+    serverDependency,
+    "-r",
+    "bintray:scalacenter/releases",
+    "-r",
+    "sonatype:public",
+    "-r",
+    "sonatype:snapshots",
+    "-p",
+  ];
+
+  const path = process.env["PATH"];
+  let possibleCoursier: string | undefined;
+  if (path) {
+    possibleCoursier = await validateCoursier(path);
+  }
+
+  function spawnDefault(): ChildProcessPromise {
+    return spawn(
+      javaPath,
+      [
+        ...javaOptions,
+        ...fetchProperties,
+        "-Dfile.encoding=UTF-8",
+        "-jar",
+        coursierPath,
+      ].concat(coursierArgs),
+      {
+        env: {
+          COURSIER_NO_TERM: "true",
+          ...extraEnv,
+          ...process.env,
+        },
+      }
+    );
+  }
+
+  if (possibleCoursier) {
+    const coursier: string = possibleCoursier;
+    output.appendLine(`Using coursier located at ${coursier}`);
+    return {
+      promise: spawn(coursier, coursierArgs),
+    };
+  } else {
+    return { promise: spawnDefault() };
+  }
+}
+
+export async function validateCoursier(
+  pathEnv: string
+): Promise<string | undefined> {
+  const isWindows = process.platform === "win32";
+  const possibleCoursier = pathEnv
+    .split(path.delimiter)
+    .flatMap((p) => {
+      try {
+        if (fs.statSync(p).isDirectory()) {
+          return fs.readdirSync(p).map((sub) => path.resolve(p, sub));
+        } else return [p];
+      } catch (e) {
+        return [];
+      }
+    })
+    .find(
+      (p) =>
+        (!isWindows && p.endsWith(path.sep + "cs")) ||
+        (!isWindows && p.endsWith(path.sep + "coursier")) ||
+        (isWindows && p.endsWith(path.sep + "cs.bat")) ||
+        (isWindows && p.endsWith(path.sep + "cs.exe"))
+    );
+  if (possibleCoursier) {
+    const coursierVersion = await spawn(possibleCoursier, ["version"]);
+    if (coursierVersion.code !== 0) {
+      return undefined;
+    } else {
+      return possibleCoursier;
     }
-  );
+  }
 }
 
 export function calcServerDependency(serverVersion: string): string {


### PR DESCRIPTION
This might help out in corporate environements since it will require installing coursier only once and Metals will be able to use it.

In later steps I will try to automatically download coursier or native image via metals if not available.

Continuation of https://github.com/scalameta/metals-languageclient/pull/524