### PR TITLE
bugfix: Make sure that if cs version fails we use the fallback

### DIFF
--- a/packages/metals-languageclient/src/fetchMetals.ts
+++ b/packages/metals-languageclient/src/fetchMetals.ts
@@ -110,11 +110,15 @@ export async function validateCoursier(
         (isWindows && p.endsWith(path.sep + "cs.exe"))
     );
   if (possibleCoursier) {
-    const coursierVersion = await spawn(possibleCoursier, ["version"]);
-    if (coursierVersion.code !== 0) {
+    try {
+      const coursierVersion = await spawn(possibleCoursier, ["version"]);
+      if (coursierVersion.code !== 0) {
+        return undefined;
+      } else {
+        return possibleCoursier;
+      }
+    } catch (e) {
       return undefined;
-    } else {
-      return possibleCoursier;
     }
   }
 }


### PR DESCRIPTION
Previously, spawning coursier process to check if it works could throw an exception, which would make the Metals not start. Now, we catch that exception and default to normal coursier fallback

I had some weird coursier binary, which broke Metals for me.