### PR TITLE
bugfix: display tests in explorer per workspace folder

### DIFF
--- a/packages/metals-vscode/src/test/extension/suites/testExplorer/analyzeTestRun.test.ts
+++ b/packages/metals-vscode/src/test/extension/suites/testExplorer/analyzeTestRun.test.ts
@@ -7,7 +7,7 @@ import {
   TestRunActions,
   TestSuiteResult,
 } from "../../../../testExplorer/types";
-import { refineTestItem } from "../../../../testExplorer/util";
+import { refineRunnableTestItem } from "../../../../testExplorer/util";
 import { buildTarget } from "./util";
 
 const [targetName, targetUri] = buildTarget("app", "");
@@ -87,7 +87,7 @@ suite("Analyze tests results", () => {
   test("suite passed", () => {
     const [action, results] = getRunActions();
     const testItem = testController.createTestItem("TestSuite", "TestSuite");
-    const refined = refineTestItem(
+    const refined = refineRunnableTestItem(
       "suite",
       testItem,
       targetUri,
@@ -105,7 +105,7 @@ suite("Analyze tests results", () => {
   test("suite failed", () => {
     const [action, results] = getRunActions();
     const testItem = testController.createTestItem("TestSuite", "TestSuite");
-    const refined = refineTestItem(
+    const refined = refineRunnableTestItem(
       "suite",
       testItem,
       targetUri,
@@ -124,7 +124,7 @@ suite("Analyze tests results", () => {
   test("suite with testcases", () => {
     const [action, results] = getRunActions();
     const testItem = testController.createTestItem("TestSuite", "TestSuite");
-    const refined = refineTestItem(
+    const refined = refineRunnableTestItem(
       "suite",
       testItem,
       targetUri,
@@ -135,9 +135,27 @@ suite("Analyze tests results", () => {
     const child2 = testController.createTestItem("TestSuite.test2", "test2");
     const child3 = testController.createTestItem("TestSuite.test3", "test3");
     testItem.children.replace([
-      refineTestItem("testcase", child1, targetUri, targetName, refined),
-      refineTestItem("testcase", child2, targetUri, targetName, refined),
-      refineTestItem("testcase", child3, targetUri, targetName, refined),
+      refineRunnableTestItem(
+        "testcase",
+        child1,
+        targetUri,
+        targetName,
+        refined
+      ),
+      refineRunnableTestItem(
+        "testcase",
+        child2,
+        targetUri,
+        targetName,
+        refined
+      ),
+      refineRunnableTestItem(
+        "testcase",
+        child3,
+        targetUri,
+        targetName,
+        refined
+      ),
     ]);
 
     analyzeTestRun(action, [refined], failed);
@@ -155,7 +173,7 @@ suite("Analyze tests results", () => {
   test("testcase", () => {
     const [action, results] = getRunActions();
     const testItem = testController.createTestItem("TestSuite", "TestSuite");
-    const refined = refineTestItem(
+    const refined = refineRunnableTestItem(
       "suite",
       testItem,
       targetUri,
@@ -165,7 +183,7 @@ suite("Analyze tests results", () => {
     const child1 = testController.createTestItem("TestSuite.test1", "test1");
     const child2 = testController.createTestItem("TestSuite.test2", "test2");
     const child3 = testController.createTestItem("TestSuite.test3", "test3");
-    const refinedChild = refineTestItem(
+    const refinedChild = refineRunnableTestItem(
       "testcase",
       child1,
       targetUri,
@@ -174,8 +192,20 @@ suite("Analyze tests results", () => {
     );
     [
       refinedChild,
-      refineTestItem("testcase", child2, targetUri, targetName, refined),
-      refineTestItem("testcase", child3, targetUri, targetName, refined),
+      refineRunnableTestItem(
+        "testcase",
+        child2,
+        targetUri,
+        targetName,
+        refined
+      ),
+      refineRunnableTestItem(
+        "testcase",
+        child3,
+        targetUri,
+        targetName,
+        refined
+      ),
     ].forEach((c) => refined.children.add(c));
 
     analyzeTestRun(action, [refinedChild], failed);

--- a/packages/metals-vscode/src/test/extension/suites/testExplorer/testExplorerEvents.test.ts
+++ b/packages/metals-vscode/src/test/extension/suites/testExplorer/testExplorerEvents.test.ts
@@ -4,8 +4,9 @@ import { addTestCases } from "../../../../testExplorer/addTestCases";
 import { addTestSuite } from "../../../../testExplorer/addTestSuites";
 import { removeTestItem } from "../../../../testExplorer/removeTestItem";
 import { foo, fooBar, fooTestCases, noPackage } from "./data";
-import { buildTarget, prettyPrint, randomString } from "./util";
+import { buildFolder, buildTarget, prettyPrint, randomString } from "./util";
 
+const [folderName, folderUri] = buildFolder("root", "uri");
 const [targetName, targetUri] = buildTarget("app", "");
 
 interface TestItem {
@@ -60,41 +61,83 @@ suite("Test Explorer events", () => {
   const uri = vscode.Uri.parse("");
 
   test("add suite without package", () => {
-    addTestSuite(testController, targetName, targetUri, noPackage);
+    addTestSuite(
+      testController,
+      targetName,
+      targetUri,
+      folderName,
+      folderUri,
+      noPackage
+    );
 
     checkTestController(testController, {
-      id: targetName,
-      label: targetName,
-      children: [{ id: "NoPackage", label: "NoPackage", uri, children: [] }],
+      id: folderUri,
+      label: folderName,
+      children: [
+        {
+          id: targetName,
+          label: targetName,
+          children: [
+            { id: "NoPackage", label: "NoPackage", uri, children: [] },
+          ],
+        },
+      ],
     });
     cleanup();
   });
 
   test("add suites with packages", () => {
-    addTestSuite(testController, targetName, targetUri, noPackage);
-    addTestSuite(testController, targetName, targetUri, foo);
-    addTestSuite(testController, targetName, targetUri, fooBar);
+    addTestSuite(
+      testController,
+      targetName,
+      targetUri,
+      folderName,
+      folderUri,
+      noPackage
+    );
+    addTestSuite(
+      testController,
+      targetName,
+      targetUri,
+      folderName,
+      folderUri,
+      foo
+    );
+    addTestSuite(
+      testController,
+      targetName,
+      targetUri,
+      folderName,
+      folderUri,
+      fooBar
+    );
 
     checkTestController(testController, {
-      id: targetName,
-      label: targetName,
+      id: folderUri,
+      label: folderName,
       children: [
-        { id: "NoPackage", label: "NoPackage", uri, children: [] },
         {
-          id: "a",
-          label: "a",
+          id: targetName,
+          label: targetName,
           children: [
+            { id: "NoPackage", label: "NoPackage", uri, children: [] },
             {
-              id: "a.Foo",
-              label: "Foo",
-              uri,
-              children: [],
-            },
-            {
-              id: "a.b",
-              label: "b",
+              id: "a",
+              label: "a",
               children: [
-                { id: "a.b.FooBar", label: "FooBar", uri, children: [] },
+                {
+                  id: "a.Foo",
+                  label: "Foo",
+                  uri,
+                  children: [],
+                },
+                {
+                  id: "a.b",
+                  label: "b",
+                  children: [
+                    { id: "a.b.FooBar", label: "FooBar", uri, children: [] },
+                  ],
+                },
               ],
             },
           ],
@@ -105,39 +148,90 @@ suite("Test Explorer events", () => {
   });
 
   test("remove suite", () => {
-    addTestSuite(testController, targetName, targetUri, noPackage);
-    addTestSuite(testController, targetName, targetUri, foo);
-    removeTestItem(testController, targetName, { ...foo, kind: "removeSuite" });
+    addTestSuite(
+      testController,
+      targetName,
+      targetUri,
+      folderName,
+      folderUri,
+      noPackage
+    );
+    addTestSuite(
+      testController,
+      targetName,
+      targetUri,
+      folderName,
+      folderUri,
+      foo
+    );
+    removeTestItem(testController, targetName, folderUri, {
+      ...foo,
+      kind: "removeSuite",
+    });
 
     checkTestController(testController, {
-      id: targetName,
-      label: targetName,
-      children: [{ id: "NoPackage", label: "NoPackage", uri, children: [] }],
+      id: folderUri,
+      label: folderName,
+      children: [
+        {
+          id: targetName,
+          label: targetName,
+          children: [
+            { id: "NoPackage", label: "NoPackage", uri, children: [] },
+          ],
+        },
+      ],
     });
     cleanup();
   });
 
   test("add test cases", () => {
-    addTestSuite(testController, targetName, targetUri, noPackage);
-    addTestSuite(testController, targetName, targetUri, foo);
-    addTestCases(testController, targetName, targetUri, fooTestCases);
+    addTestSuite(
+      testController,
+      targetName,
+      targetUri,
+      folderName,
+      folderUri,
+      noPackage
+    );
+    addTestSuite(
+      testController,
+      targetName,
+      targetUri,
+      folderName,
+      folderUri,
+      foo
+    );
+    addTestCases(
+      testController,
+      targetName,
+      targetUri,
+      folderUri,
+      fooTestCases
+    );
 
     checkTestController(testController, {
-      id: targetName,
-      label: targetName,
+      id: folderUri,
+      label: folderName,
       children: [
-        { id: "NoPackage", label: "NoPackage", uri, children: [] },
         {
-          id: "a",
-          label: "a",
+          id: targetName,
+          label: targetName,
           children: [
+            { id: "NoPackage", label: "NoPackage", uri, children: [] },
             {
-              id: "a.Foo",
-              label: "Foo",
-              uri,
+              id: "a",
+              label: "a",
               children: [
-                { id: "a.Foo.test1", label: "test1", uri, children: [] },
-                { id: "a.Foo.test2", label: "test2", uri, children: [] },
+                {
+                  id: "a.Foo",
+                  label: "Foo",
+                  uri,
+                  children: [
+                    { id: "a.Foo.test1", label: "test1", uri, children: [] },
+                    { id: "a.Foo.test2", label: "test2", uri, children: [] },
+                  ],
+                },
               ],
             },
           ],

--- a/packages/metals-vscode/src/test/extension/suites/testExplorer/util.ts
+++ b/packages/metals-vscode/src/test/extension/suites/testExplorer/util.ts
@@ -1,9 +1,20 @@
 import * as vscode from "vscode";
-import { TargetName } from "../../../../testExplorer/types";
+import {
+  FolderName,
+  FolderUri,
+  TargetName,
+} from "../../../../testExplorer/types";
 import { TargetUri } from "../../../../types";
 
 export function randomString(): string {
   return Math.random().toString(36).substring(2, 15);
+}
+
+export function buildFolder(
+  folderName: string,
+  folderUri: string
+): [FolderName, FolderUri] {
+  return [folderName, folderUri] as [FolderName, FolderUri];
 }
 
 export function buildTarget(

--- a/packages/metals-vscode/src/testExplorer/removeTestItem.ts
+++ b/packages/metals-vscode/src/testExplorer/removeTestItem.ts
@@ -1,10 +1,11 @@
 import * as vscode from "vscode";
-import { RemoveTestSuite, TargetName } from "./types";
+import { RemoveTestSuite, TargetName, FolderUri } from "./types";
 import { prefixesOf, TestItemPath } from "./util";
 
 export function removeTestItem(
   testController: vscode.TestController,
   targetName: TargetName,
+  folderUri: FolderUri,
   event: RemoveTestSuite
 ): void {
   const { fullyQualifiedClassName } = event;
@@ -26,12 +27,18 @@ export function removeTestItem(
     }
   }
 
-  const buildTargetItem = testController.items.get(targetName);
-  if (buildTargetItem) {
-    const testPath = prefixesOf(event.fullyQualifiedClassName);
-    removeTestItemLoop(buildTargetItem, testPath);
-    if (buildTargetItem.children.size === 0) {
-      testController.items.delete(buildTargetItem.id);
+  const workspaceFolderItem = testController.items.get(folderUri);
+  if (workspaceFolderItem) {
+    const buildTargetItem = workspaceFolderItem.children.get(targetName);
+    if (buildTargetItem) {
+      const testPath = prefixesOf(event.fullyQualifiedClassName);
+      removeTestItemLoop(buildTargetItem, testPath);
+      if (buildTargetItem.children.size === 0) {
+        testController.items.delete(buildTargetItem.id);
+      }
+    }
+    if (workspaceFolderItem.children.size === 0) {
+      testController.items.delete(workspaceFolderItem.id);
     }
   }
 }

--- a/packages/metals-vscode/src/testExplorer/testManager.ts
+++ b/packages/metals-vscode/src/testExplorer/testManager.ts
@@ -8,7 +8,7 @@ import { addTestCases } from "./addTestCases";
 import { addTestSuite } from "./addTestSuites";
 import { removeTestItem } from "./removeTestItem";
 import { runHandler } from "./testRunHandler";
-import { BuildTargetUpdate } from "./types";
+import { BuildTargetUpdate, FolderName, FolderUri } from "./types";
 import { updateTestSuiteLocation } from "./updateTestSuiteLocation";
 
 export function createTestManager(
@@ -82,16 +82,42 @@ class TestManager {
   }
 
   updateTestExplorer(updates: BuildTargetUpdate[]) {
-    for (const { targetUri, targetName, events } of updates) {
+    for (const {
+      targetUri,
+      targetName,
+      folderUri,
+      folderName,
+      events,
+    } of updates) {
+      const folderUri_ = folderUri || ("root" as FolderUri);
+      const folderName_ = folderName || ("root" as FolderName);
       for (const event of events) {
         if (event.kind === "removeSuite") {
-          removeTestItem(this.testController, targetName, event);
+          removeTestItem(this.testController, targetName, folderUri_, event);
         } else if (event.kind === "addSuite") {
-          addTestSuite(this.testController, targetName, targetUri, event);
+          addTestSuite(
+            this.testController,
+            targetName,
+            targetUri,
+            folderName_,
+            folderUri_,
+            event
+          );
         } else if (event.kind === "updateSuiteLocation") {
-          updateTestSuiteLocation(this.testController, targetName, event);
+          updateTestSuiteLocation(
+            this.testController,
+            targetName,
+            folderUri_,
+            event
+          );
         } else if (event.kind === "addTestCases") {
-          addTestCases(this.testController, targetName, targetUri, event);
+          addTestCases(
+            this.testController,
+            targetName,
+            targetUri,
+            folderUri_,
+            event
+          );
         }
       }
     }

--- a/packages/metals-vscode/src/testExplorer/testRunHandler.ts
+++ b/packages/metals-vscode/src/testExplorer/testRunHandler.ts
@@ -67,13 +67,19 @@ export async function runHandler(
   const queue: RunnableMetalsTestItem[] = [];
 
   /**
-   * Loop through all included tests in request and add them to our queue if they are not excluded explicitly
+   * Loop through all included tests in request and add them to our queue if they are not excluded explicitly.
+   * The smallest runnable bit is a suite,
+   * for bigger groups (package, module, workspaceFolder) we collect and run all the included suites.
    */
   function createRunQueue(tests: Iterable<MetalsTestItem>): void {
     for (const test of tests) {
       if (!excludes.has(test)) {
         const kind = test._metalsKind;
-        if (kind === "project" || kind === "package") {
+        if (
+          kind === "workspaceFolder" ||
+          kind === "module" ||
+          kind === "package"
+        ) {
           createRunQueue(gatherTestItems(test.children));
         } else if (kind === "suite") {
           run.started(test);

--- a/packages/metals-vscode/src/testExplorer/updateTestSuiteLocation.ts
+++ b/packages/metals-vscode/src/testExplorer/updateTestSuiteLocation.ts
@@ -1,5 +1,5 @@
 import * as vscode from "vscode";
-import { TargetName, UpdateSuiteLocation } from "./types";
+import { TargetName, UpdateSuiteLocation, FolderUri } from "./types";
 import { prefixesOf, TestItemPath, toVscodeRange } from "./util";
 
 /**
@@ -12,6 +12,7 @@ import { prefixesOf, TestItemPath, toVscodeRange } from "./util";
 export function updateTestSuiteLocation(
   testController: vscode.TestController,
   targetName: TargetName,
+  folderUri: FolderUri,
   event: UpdateSuiteLocation
 ): void {
   function updateTestSuiteLocationLoop(
@@ -33,9 +34,12 @@ export function updateTestSuiteLocation(
     }
   }
 
-  const buildTargetItem = testController.items.get(targetName);
-  if (buildTargetItem) {
-    const testPath = prefixesOf(event.fullyQualifiedClassName, true);
-    updateTestSuiteLocationLoop(buildTargetItem, testPath);
+  const workspaceFolderItem = testController.items.get(folderUri);
+  if (workspaceFolderItem) {
+    const buildTargetItem = workspaceFolderItem.children.get(targetName);
+    if (buildTargetItem) {
+      const testPath = prefixesOf(event.fullyQualifiedClassName, true);
+      updateTestSuiteLocationLoop(buildTargetItem, testPath);
+    }
   }
 }


### PR DESCRIPTION
Previously: test suites were displayed per build target.
Now: we group them also per workspace folder

connected to: https://github.com/scalameta/metals/pull/5212
resolves: https://github.com/scalameta/metals/issues/5189