### PR TITLE
Add options for import java.compiler module

### DIFF
--- a/packages/metals-languageclient/src/getJavaConfig.ts
+++ b/packages/metals-languageclient/src/getJavaConfig.ts
@@ -3,6 +3,7 @@ import * as path from "path";
 
 export interface JavaConfig {
   javaOptions: string[];
+  javaHome: string;
   javaPath: string;
   coursierPath: string;
   coursierMirrorFilePath: string | undefined;
@@ -37,6 +38,7 @@ export function getJavaConfig({
 
   return {
     javaOptions,
+    javaHome,
     javaPath,
     coursierPath,
     coursierMirrorFilePath,

--- a/packages/metals-languageclient/src/getServerOptions.ts
+++ b/packages/metals-languageclient/src/getServerOptions.ts
@@ -18,10 +18,7 @@ function parse(v: string): number | undefined {
   else return undefined;
 }
 
-function getJavaVersion(extraEnv: {
-  [k: string]: string | undefined;
-}): number | undefined {
-  const javaHome = extraEnv["JAVA_HOME"]!;
+function getJavaVersion(javaHome: string): number | undefined {
   const dirs = [
     path.join(javaHome, "release"),
     path.join(path.dirname(javaHome), "release"),
@@ -54,7 +51,7 @@ export function getServerOptions({
   metalsClasspath,
   serverProperties = [],
   clientName,
-  javaConfig: { javaOptions, javaPath, extraEnv },
+  javaConfig: { javaOptions, javaHome, javaPath, extraEnv },
 }: GetServerOptions): ServerOptions {
   const baseProperties = ["-Xss4m", "-Xms100m"];
 
@@ -64,7 +61,7 @@ export function getServerOptions({
 
   const mainArgs = ["-classpath", metalsClasspath, "scala.meta.metals.Main"];
 
-  const javaVersion = getJavaVersion(extraEnv);
+  const javaVersion = getJavaVersion(javaHome);
 
   const addOpens =
     javaVersion !== undefined && javaVersion >= 17

--- a/packages/metals-languageclient/src/getServerOptions.ts
+++ b/packages/metals-languageclient/src/getServerOptions.ts
@@ -1,11 +1,53 @@
 import { ServerOptions } from "./interfaces/ServerOptions";
 import { JavaConfig } from "./getJavaConfig";
+import * as fs from "fs";
+import * as path from "path";
 
 interface GetServerOptions {
   metalsClasspath: string;
   serverProperties: string[] | undefined;
   clientName?: string;
   javaConfig: JavaConfig;
+}
+
+function parse(v: string): number | undefined {
+  const numbers = v.split("-")[0].split(".").slice(0, 2);
+
+  if (numbers.length >= 2 && numbers[0] == "1") return parseInt(numbers[1]);
+  else if (numbers.length >= 1) return parseInt(numbers[0]);
+  else return undefined;
+}
+
+function getJavaVersion(extraEnv: {
+  [k: string]: string | undefined;
+}): number | undefined {
+  const javaHome = extraEnv["JAVA_HOME"]!;
+  const dirs = [
+    path.join(javaHome, "release"),
+    path.join(path.dirname(javaHome), "release"),
+  ];
+
+  const fromReleaseFile = dirs
+    .filter((d) => fs.existsSync(d))
+    .map((d) => {
+      const fileContents = fs.readFileSync(d, {
+        encoding: "utf-8",
+      });
+      const javaVersionString = fileContents
+        .toString()
+        .split(/\r?\n/)
+        .find((s) => s.startsWith("JAVA_VERSION"));
+      const regexp = /JAVA_VERSION="(.*)"/;
+      const versionNumber = regexp.exec(javaVersionString!)![1];
+
+      return parse(versionNumber);
+    });
+
+  if (fromReleaseFile.length > 0) {
+    return fromReleaseFile[0];
+  } else {
+    return undefined;
+  }
 }
 
 export function getServerOptions({
@@ -22,9 +64,21 @@ export function getServerOptions({
 
   const mainArgs = ["-classpath", metalsClasspath, "scala.meta.metals.Main"];
 
+  const javaVersion = getJavaVersion(extraEnv);
+
+  const addOpens =
+    javaVersion !== undefined && javaVersion >= 17
+      ? [
+          "--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED",
+          "--add-opens=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED",
+          "--add-opens=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED",
+        ]
+      : [];
+
   // let user properties override base properties
   const launchArgs = [
     ...baseProperties,
+    ...addOpens,
     ...javaOptions,
     ...serverProperties,
     ...mainArgs,


### PR DESCRIPTION
This changes related to [Java Hover](https://github.com/scalameta/metals/pull/5024) for Metals. It's required to export `java.compiler` module manually for Java version greater than 17. I've handled version of Java like it's made in [Metals](https://github.com/scalameta/metals/blob/45df705da236edfddcea7e358592fd3202bb9460/sbt-metals/src/main/scala/scala/meta/metals/MetalsPlugin.scala#L144).