### PR TITLE
Handle `usernotification` event from debug session

### DIFF
--- a/packages/metals-vscode/src/consts.ts
+++ b/packages/metals-vscode/src/consts.ts
@@ -2,3 +2,6 @@ export const openSettingsAction = "Open settings";
 
 export const installJava11Action = "Install Java (JDK 11)";
 export const installJava17Action = "Install Java (JDK 17)";
+
+export const SCALA_LANGID = "scala";
+export const USER_NOTIFICATION_EVENT = "usernotification";

--- a/packages/metals-vscode/src/extension.ts
+++ b/packages/metals-vscode/src/extension.ts
@@ -1310,11 +1310,10 @@ function toggleBooleanWorkspaceSetting(setting: string) {
 function registerDebugEventListener(context: ExtensionContext) {
   context.subscriptions.push(
     debug.onDidReceiveDebugSessionCustomEvent((customEvent) => {
-      const t = customEvent.session ? customEvent.session.type : undefined;
-      if (t !== SCALA_LANGID) {
-        return;
-      }
-      if (customEvent.event === USER_NOTIFICATION_EVENT) {
+      if (
+        customEvent.session.type !== SCALA_LANGID &&
+        customEvent.event === USER_NOTIFICATION_EVENT
+      ) {
         handleUserNotification(customEvent);
       }
     })

--- a/packages/metals-vscode/src/extension.ts
+++ b/packages/metals-vscode/src/extension.ts
@@ -29,6 +29,8 @@ import {
   Hover,
   TextDocument,
   tests as vscodeTextExplorer,
+  debug,
+  DebugSessionCustomEvent,
 } from "vscode";
 import {
   LanguageClient,
@@ -96,7 +98,11 @@ import {
   showInstallJavaAction,
   showMissingJavaAction,
 } from "./installJavaAction";
-import { openSettingsAction } from "./consts";
+import {
+  openSettingsAction,
+  USER_NOTIFICATION_EVENT,
+  SCALA_LANGID,
+} from "./consts";
 import { ScalaCodeLensesParams } from "./debugger/types";
 
 const outputChannel = window.createOutputChannel("Metals");
@@ -123,6 +129,7 @@ export async function activate(context: ExtensionContext): Promise<void> {
   const serverVersion = getServerVersion(config, context);
   detectLaunchConfigurationChanges();
   configureSettingsDefaults();
+  registerDebugEventListener(context);
 
   await window.withProgress(
     {
@@ -1298,4 +1305,28 @@ function toggleBooleanWorkspaceSetting(setting: string) {
   const configProperty = config.inspect<boolean>(setting);
   const currentValues = configProperty?.workspaceValue ?? false;
   config.update(setting, !currentValues, ConfigurationTarget.Workspace);
+}
+
+function registerDebugEventListener(context: ExtensionContext) {
+  context.subscriptions.push(
+    debug.onDidReceiveDebugSessionCustomEvent((customEvent) => {
+      const t = customEvent.session ? customEvent.session.type : undefined;
+      if (t !== SCALA_LANGID) {
+        return;
+      }
+      if (customEvent.event === USER_NOTIFICATION_EVENT) {
+        handleUserNotification(customEvent);
+      }
+    })
+  );
+}
+
+function handleUserNotification(customEvent: DebugSessionCustomEvent) {
+  if (customEvent.body.notificationType === "ERROR") {
+    window.showErrorMessage(customEvent.body.message);
+  } else if (customEvent.body.notificationType === "WARNING") {
+    window.showWarningMessage(customEvent.body.message);
+  } else {
+    window.showInformationMessage(customEvent.body.message);
+  }
 }


### PR DESCRIPTION
Copied from [microsoft/vscode-java-debug](https://github.com/microsoft/vscode-java-debug)

The scala-debug-adapter can send `usernotification` events that should be shown to the user. For instance, it can contain the compilation errors of a conditional breakpoint.

Tested locally:
![usernotification](https://github.com/scalameta/metals-vscode/assets/13123162/8cff61b6-8439-49b5-a9a1-0ae76dbe67e4)

Fixes https://github.com/scalacenter/scala-debug-adapter/issues/455