### PR TITLE
Revert "Add options for import java.compiler module (#1395)"

### DIFF
--- a/packages/metals-languageclient/src/getJavaConfig.ts
+++ b/packages/metals-languageclient/src/getJavaConfig.ts
@@ -3,7 +3,6 @@ import * as path from "path";
 
 export interface JavaConfig {
   javaOptions: string[];
-  javaHome: string;
   javaPath: string;
   coursierPath: string;
   coursierMirrorFilePath: string | undefined;
@@ -38,7 +37,6 @@ export function getJavaConfig({
 
   return {
     javaOptions,
-    javaHome,
     javaPath,
     coursierPath,
     coursierMirrorFilePath,

--- a/packages/metals-languageclient/src/getServerOptions.ts
+++ b/packages/metals-languageclient/src/getServerOptions.ts
@@ -1,7 +1,5 @@
 import { ServerOptions } from "./interfaces/ServerOptions";
 import { JavaConfig } from "./getJavaConfig";
-import * as fs from "fs";
-import * as path from "path";
 
 interface GetServerOptions {
   metalsClasspath: string;
@@ -10,48 +8,11 @@ interface GetServerOptions {
   javaConfig: JavaConfig;
 }
 
-function parse(v: string): number | undefined {
-  const numbers = v.split("-")[0].split(".").slice(0, 2);
-
-  if (numbers.length >= 2 && numbers[0] == "1") return parseInt(numbers[1]);
-  else if (numbers.length >= 1) return parseInt(numbers[0]);
-  else return undefined;
-}
-
-function getJavaVersion(javaHome: string): number | undefined {
-  const dirs = [
-    path.join(javaHome, "release"),
-    path.join(path.dirname(javaHome), "release"),
-  ];
-
-  const fromReleaseFile = dirs
-    .filter((d) => fs.existsSync(d))
-    .map((d) => {
-      const fileContents = fs.readFileSync(d, {
-        encoding: "utf-8",
-      });
-      const javaVersionString = fileContents
-        .toString()
-        .split(/\r?\n/)
-        .find((s) => s.startsWith("JAVA_VERSION"));
-      const regexp = /JAVA_VERSION="(.*)"/;
-      const versionNumber = regexp.exec(javaVersionString!)![1];
-
-      return parse(versionNumber);
-    });
-
-  if (fromReleaseFile.length > 0) {
-    return fromReleaseFile[0];
-  } else {
-    return undefined;
-  }
-}
-
 export function getServerOptions({
   metalsClasspath,
   serverProperties = [],
   clientName,
-  javaConfig: { javaOptions, javaHome, javaPath, extraEnv },
+  javaConfig: { javaOptions, javaPath, extraEnv },
 }: GetServerOptions): ServerOptions {
   const baseProperties = ["-Xss4m", "-Xms100m"];
 
@@ -61,21 +22,9 @@ export function getServerOptions({
 
   const mainArgs = ["-classpath", metalsClasspath, "scala.meta.metals.Main"];
 
-  const javaVersion = getJavaVersion(javaHome);
-
-  const addOpens =
-    javaVersion !== undefined && javaVersion >= 17
-      ? [
-          "--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED",
-          "--add-opens=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED",
-          "--add-opens=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED",
-        ]
-      : [];
-
   // let user properties override base properties
   const launchArgs = [
     ...baseProperties,
-    ...addOpens,
     ...javaOptions,
     ...serverProperties,
     ...mainArgs,


### PR DESCRIPTION
This reverts commit cf748dde1b42cd156a25be44d4761cdb253e2b17.

Looks like we no longer need it after https://github.com/scalameta/metals/pull/5375