### PR TITLE
improvement: Set toggle for showInferredType to switch between true,false and minimal

### DIFF
--- a/packages/metals-vscode/package.json
+++ b/packages/metals-vscode/package.json
@@ -220,7 +220,7 @@
       "properties": {
         "metals.serverVersion": {
           "type": "string",
-          "default": "1.0.0",
+          "default": "1.0.0+20-46905735-SNAPSHOT",
           "markdownDescription": "The version of the Metals server artifact. Requires reloading the window.  \n\n**VS Code extension version is guaranteed to work only with the default version, change if you know what you're doing**"
         },
         "metals.serverProperties": {
@@ -250,8 +250,14 @@
           "markdownDescription": "List of packages you'd like to be left out of completions, symbol searches, and code actions.\n\nEx. `akka.actor.typed.javadsl` will ensure nothing in the `javadsl` package gets recommended to you.\n\nYou can find the list of default exclusions [here on the Metals website](https://scalameta.org/metals/docs/editors/user-configuration/#excluded-packages).\n\nIf you need to remove one of the defaults, you can simply include it and preface it with `--`."
         },
         "metals.showInferredType": {
-          "type": "boolean",
-          "markdownDescription": "When this option is enabled, for each method that have inferred types that are not explicitely specified they are displayed as additional decorations."
+          "type": "string",
+          "default": "false",
+          "enum": [
+            "false",
+            "true",
+            "minimal"
+          ],
+          "markdownDescription": "When this option is set to true inferred type in all possible places will be shown. This includes types for values, definitions, cases, type parameters. With 'minimal' option Metals will not show inferred type for type parameters and more complicated pattern matches."
         },
         "metals.showImplicitArguments": {
           "type": "boolean",


### PR DESCRIPTION
Previously, showInferredType could only be true or false. Now it is a string value that can be also of value "minimal". Because of that I switched the setting to string enum, added an automigration part and switch toggle to go through all the options

Follow up from https://github.com/scalameta/metals/pull/5284#issuecomment-1634836066