### PR TITLE
bugfix: Don't run command without clicking and fix infinite recursion

### DIFF
--- a/packages/metals-vscode/src/extension.ts
+++ b/packages/metals-vscode/src/extension.ts
@@ -569,9 +569,9 @@ function launchMetals(
         commands.executeCommand(workbenchCommands.focusDiagnostics)
       );
 
-      registerCommand(ClientCommands.RunDoctor, () =>
-        commands.executeCommand(ClientCommands.RunDoctor)
-      );
+      registerCommand(ClientCommands.RunDoctor, async () => {
+        await doctorProvider.runDoctor();
+      });
 
       registerCommand(ClientCommands.ToggleLogs, () => {
         if (channelOpen) {
@@ -722,13 +722,7 @@ function launchMetals(
             item.tooltip = params.tooltip;
           }
           if (params.command) {
-            const command = params.command;
             item.command = params.command;
-            commands.getCommands().then((values) => {
-              if (values.includes(command)) {
-                commands.executeCommand(command);
-              }
-            });
           } else {
             item.command = undefined;
           }


### PR DESCRIPTION
Previously, we would run a command without clicking on the status bar, which could be problematic if a message was shown multiple times. We would also invoke the RunDoctor command, which invokes itself. Now, RunDoctor invokes the correct part of the extension and status bar command is not invoked right away.

I am not sure why this never happened before, but might be a change in VS Code that prompted it.