### PR TITLE
improvement: Set semantic highlighting to true by default

### DIFF
--- a/packages/metals-vscode/package.json
+++ b/packages/metals-vscode/package.json
@@ -345,7 +345,7 @@
         },
         "metals.enableSemanticHighlighting": {
           "type": "boolean",
-          "default": false,
+          "default": true,
           "markdownDescription": "When this option is enabled, Metals will provide semantic tokens for clients that support it. The feature is still experimental and does not work for all sources."
         },
         "metals.testUserInterface": {


### PR DESCRIPTION
I had it one for the last half a year and it's been pretty stable. Most themes require you to turn it on separately, co this only causes additional confusion.