### PR TITLE
chore: Set runProvider as true

### DIFF
--- a/packages/metals-languageclient/src/interfaces/MetalsInitializationOptions.ts
+++ b/packages/metals-languageclient/src/interfaces/MetalsInitializationOptions.ts
@@ -12,6 +12,7 @@ interface CompilerInitializationOptions {
 
 export interface MetalsInitializationOptions {
   compilerOptions?: CompilerInitializationOptions;
+  runProvider?: boolean;
   debuggingProvider?: boolean;
   decorationProvider?: boolean;
   inlineDecorationProvider?: boolean;

--- a/packages/metals-vscode/src/extension.ts
+++ b/packages/metals-vscode/src/extension.ts
@@ -295,6 +295,7 @@ function launchMetals(
     decorationProvider: true,
     inlineDecorationProvider: true,
     debuggingProvider: true,
+    runProvider: true,
     doctorProvider: "html",
     didFocusProvider: true,
     executeClientCommandProvider: true,


### PR DESCRIPTION
Previously, we would not set runProvider and rely entirely on debugProvider, however in some cases where debug is not supported by the build server, we might actually want to use just run. Now, with this set it's possible to see that VS Code actually supports running on the client side and that can be used.