### PR TITLE
don't override `JAVA_HOME` env variable

### DIFF
--- a/packages/metals-languageclient/src/getJavaConfig.ts
+++ b/packages/metals-languageclient/src/getJavaConfig.ts
@@ -40,7 +40,6 @@ export function getJavaConfig({
   const extraEnv = {
     ...coursierRepositories,
     ...coursierMirrors,
-    JAVA_HOME: javaHome,
   };
 
   return {


### PR DESCRIPTION
connected to: https://github.com/scalameta/metals/pull/6204