### PR TITLE
improvement: Search PATH for Java to use

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: coursier/setup-action@v1
+        with:
+          jvm: temurin:17
       - uses: actions/setup-node@v2
         with:
           node-version: "16"

--- a/packages/metals-languageclient/src/__tests__/getJavaHome.test.ts
+++ b/packages/metals-languageclient/src/__tests__/getJavaHome.test.ts
@@ -1,4 +1,14 @@
 import path from "path";
+import { OutputChannel } from "../interfaces/OutputChannel";
+
+class MockOutput implements OutputChannel {
+  append(value: string): void {
+    console.log(value);
+  }
+  appendLine(value: string): void {
+    console.log(value);
+  }
+}
 
 const exampleJavaVersionString = `openjdk "17.0.1" 2021-10-19
   OpenJDK Runtime Environment (build 17.0.1+12-39)
@@ -25,6 +35,28 @@ describe("getJavaHome", () => {
     mockExistsFs(javaPaths);
     const javaHome = await require("../getJavaHome").getJavaHome("17");
     expect(javaHome).toBe(JAVA_HOME);
+  });
+
+  // needs to run on a machine with an actual JAVA_HOME set up
+  it("reads from real JAVA_HOME", async () => {
+    process.env = { ...originalEnv };
+    delete process.env.PATH;
+    const javaHome = await require("../getJavaHome").getJavaHome(
+      "17",
+      new MockOutput()
+    );
+    expect(javaHome).toBeDefined();
+  });
+
+  // needs to run on a machine with an actual java on PATH set up
+  it("reads from real PATH", async () => {
+    process.env = { ...originalEnv };
+    delete process.env.JAVA_HOME;
+    const javaHome = await require("../getJavaHome").getJavaHome(
+      "17",
+      new MockOutput()
+    );
+    expect(javaHome).toBeDefined();
   });
 });
 

--- a/packages/metals-languageclient/src/__tests__/setupCoursier.test.ts
+++ b/packages/metals-languageclient/src/__tests__/setupCoursier.test.ts
@@ -33,7 +33,8 @@ describe("setupCoursier", () => {
   });
 
   it("should not find coursier if not present in PATH", async () => {
-    expect(await validateCoursier("path/fake")).toBeUndefined();
+    process.env = {};
+    expect(await validateCoursier()).toBeUndefined();
   });
 
   it("should fetch coursier correctly", async () => {

--- a/packages/metals-languageclient/src/getJavaHome.ts
+++ b/packages/metals-languageclient/src/getJavaHome.ts
@@ -64,7 +64,7 @@ export async function fromPath(
     outputChannel.appendLine(
       `Found java executable under ${javaExecutable} that resolves to ${realJavaPath}`
     );
-    let possibleJavaHome = path.dirname(path.dirname(realJavaPath));
+    const possibleJavaHome = path.dirname(path.dirname(realJavaPath));
     const isValid = await validateJavaVersion(
       possibleJavaHome,
       javaVersion,

--- a/packages/metals-languageclient/src/getJavaHome.ts
+++ b/packages/metals-languageclient/src/getJavaHome.ts
@@ -1,6 +1,8 @@
 import path from "path";
 import { spawn } from "promisify-child-process";
 import { OutputChannel } from "./interfaces/OutputChannel";
+import { findOnPath } from "./util";
+import { realpathSync } from "fs";
 
 export type JavaVersion = "11" | "17" | "21";
 
@@ -19,7 +21,7 @@ export async function getJavaHome(
   outputChannel: OutputChannel
 ): Promise<string | undefined> {
   const fromEnvValue = await fromEnv(javaVersion, outputChannel);
-  return fromEnvValue;
+  return fromEnvValue || (await fromPath(javaVersion, outputChannel));
 }
 
 const versionRegex = /\"\d\d/;
@@ -50,6 +52,26 @@ async function validateJavaVersion(
     outputChannel.appendLine(`${error}`);
   }
   return false;
+}
+
+export async function fromPath(
+  javaVersion: JavaVersion,
+  outputChannel: OutputChannel
+): Promise<string | undefined> {
+  let javaExecutable = findOnPath(["java"]);
+  if (javaExecutable) {
+    let realJavaPath = realpathSync(javaExecutable);
+    outputChannel.appendLine(
+      `Found java executable under ${javaExecutable} that resolves to ${realJavaPath}`
+    );
+    let possibleJavaHome = path.dirname(path.dirname(realJavaPath));
+    const isValid = await validateJavaVersion(
+      possibleJavaHome,
+      javaVersion,
+      outputChannel
+    );
+    if (isValid) return possibleJavaHome;
+  }
 }
 
 export async function fromEnv(

--- a/packages/metals-languageclient/src/util.ts
+++ b/packages/metals-languageclient/src/util.ts
@@ -12,11 +12,11 @@ export function toPromise<E, A>(te: TaskEither<E, A>): Promise<A> {
 }
 
 export function findOnPath(names: string[]) {
-  const envPath = process.env["PATH"];
+  const envPath = process.env["PATH"] || process.env["Path"];
   const isWindows = process.platform === "win32";
 
   if (envPath) {
-    const possibleCoursier = envPath
+    const possibleExecutable = envPath
       .split(path.delimiter)
       .flatMap((p) => {
         try {
@@ -38,6 +38,6 @@ export function findOnPath(names: string[]) {
           return names.some((name) => p.endsWith(path.sep + name));
         }
       });
-    return possibleCoursier;
+    return possibleExecutable;
   }
 }

--- a/packages/metals-languageclient/src/util.ts
+++ b/packages/metals-languageclient/src/util.ts
@@ -1,10 +1,43 @@
 import { TaskEither } from "fp-ts/lib/TaskEither";
 import { pipe } from "fp-ts/lib/function";
 import * as E from "fp-ts/lib/Either";
+import path from "path";
+import fs from "fs";
 
 export function toPromise<E, A>(te: TaskEither<E, A>): Promise<A> {
   return te().then(
     (res) =>
       new Promise((resolve, reject) => pipe(res, E.fold(reject, resolve)))
   );
+}
+
+export function findOnPath(names: string[]) {
+  const envPath = process.env["PATH"];
+  const isWindows = process.platform === "win32";
+
+  if (envPath) {
+    const possibleCoursier = envPath
+      .split(path.delimiter)
+      .flatMap((p) => {
+        try {
+          if (fs.statSync(p).isDirectory()) {
+            return fs.readdirSync(p).map((sub) => path.resolve(p, sub));
+          } else return [p];
+        } catch (e) {
+          return [];
+        }
+      })
+      .find((p) => {
+        if (isWindows) {
+          return names.some(
+            (name) =>
+              p.endsWith(path.sep + name + ".bat") ||
+              p.endsWith(path.sep + name + ".exe")
+          );
+        } else {
+          return names.some((name) => p.endsWith(path.sep + name));
+        }
+      });
+    return possibleCoursier;
+  }
 }


### PR DESCRIPTION
Previously, we would rely on the separate library for detecting java, but we had no control on whether it worked and it doesn't seem actively used by a lot of people.

Now, we first check JAVA_HOME and then search PATH for the actual Java to use. If we can't find any of that we download ourselves. This seems simple enought logic.