### PR TITLE
bugfix: Use temurin explicitely

### DIFF
--- a/packages/metals-languageclient/src/setupCoursier.ts
+++ b/packages/metals-languageclient/src/setupCoursier.ts
@@ -52,7 +52,7 @@ export async function setupCoursier(
   const resolveJavaHomeWithCoursier = async (coursier: string) => {
     await run(
       coursier,
-      ["java", "--jvm", javaVersion, "-version"],
+      ["java", "--jvm", `temurin:${javaVersion}`, "-version"],
       handleOutput
     );
 


### PR DESCRIPTION
Older coursier versions might look for adopt as default.