### PR TITLE
improvement: Print Java all at once

### DIFF
--- a/packages/metals-languageclient/src/getJavaHome.ts
+++ b/packages/metals-languageclient/src/getJavaHome.ts
@@ -37,7 +37,6 @@ async function validateJavaVersion(
     });
 
     javaVersionOut.stderr?.on("data", (out: Buffer) => {
-      outputChannel.appendLine(`${javaBin} -version:`);
       const msg = "\t" + out.toString().trim().split("\n").join("\n\t");
       outputChannel.appendLine(msg);
     });

--- a/packages/metals-languageclient/src/setupCoursier.ts
+++ b/packages/metals-languageclient/src/setupCoursier.ts
@@ -22,8 +22,8 @@ export async function setupCoursier(
   output: OutputChannel
 ): Promise<{ coursier: string; javaHome: string }> {
   const handleOutput = (out: Buffer) => {
-    const msg = out.toString().trim();
-    output.appendLine("Coursier: \n" + msg);
+    const msg = "\t" + out.toString().trim().split("\n").join("\n\t");
+    output.appendLine(msg);
   };
 
   const resolveCoursier = async () => {
@@ -82,7 +82,7 @@ export async function setupCoursier(
 
   if (!javaHome && coursier) {
     output.appendLine(
-      `No installed java with version ${javaVersion} found. Will fetch one using coursier.`
+      `No installed java with version ${javaVersion} found. Will fetch one using coursier:`
     );
     javaHome = await resolveJavaHomeWithCoursier(coursier);
   }


### PR DESCRIPTION
![image](https://github.com/scalameta/metals-vscode/assets/3807253/c34ede59-90b2-43c0-8adb-81a0114e3c11)

It seems that when writing on date we can get one line first and then the other, which would duplicate the `(`${javaBin} -version:`)` message