### PR TITLE
improvement: Retry with coursier jar if anything fails

### DIFF
--- a/packages/metals-languageclient/src/__tests__/setupCoursier.test.ts
+++ b/packages/metals-languageclient/src/__tests__/setupCoursier.test.ts
@@ -50,7 +50,8 @@ describe("setupCoursier", () => {
       "17",
       tmpDir,
       process.cwd(),
-      new LogOutputChannel()
+      new LogOutputChannel(),
+      false
     );
     expect(fs.existsSync(coursier)).toBeTruthy;
     expect(fs.existsSync(javaHome)).toBeTruthy;

--- a/packages/metals-languageclient/src/setupCoursier.ts
+++ b/packages/metals-languageclient/src/setupCoursier.ts
@@ -19,7 +19,8 @@ export async function setupCoursier(
   javaVersion: JavaVersion,
   coursierFetchPath: string,
   extensionPath: string,
-  output: OutputChannel
+  output: OutputChannel,
+  forceCoursierJar: boolean
 ): Promise<{ coursier: string; javaHome: string }> {
   const handleOutput = (out: Buffer) => {
     const msg = out.toString().trim();
@@ -75,7 +76,12 @@ export async function setupCoursier(
     return ((await getJavaPath).stdout as string).trim();
   };
 
-  var coursier = await resolveCoursier();
+  var coursier: string | undefined;
+  if (forceCoursierJar) {
+    coursier = undefined;
+  } else {
+    coursier = await resolveCoursier();
+  }
   output.appendLine(`Using coursier located at ${coursier}`);
 
   var javaHome = await getJavaHome(javaVersion, output);


### PR DESCRIPTION
Previously, if anything failed with coursier native image, for example we wouldn't have proper encoding then user would not be able to do anything.

Now, if there is Java avaialable we can retry with the embedded coursier jar.

Might help with https://github.com/scalameta/metals-vscode/issues/1509