### PR TITLE
Prefer the metals VSCode extension to run in the "Workspace" as opposed to "UI"

### DIFF
--- a/packages/metals-vscode/package.json
+++ b/packages/metals-vscode/package.json
@@ -42,6 +42,7 @@
     "Programming Languages",
     "Debuggers"
   ],
+  "extensionKind": ["workspace", "ui"],
   "activationEvents": [
     "onCommand:metals.start-server",
     "onCommand:metals.new-scala-project",

--- a/packages/metals-vscode/package.json
+++ b/packages/metals-vscode/package.json
@@ -42,7 +42,10 @@
     "Programming Languages",
     "Debuggers"
   ],
-  "extensionKind": ["workspace", "ui"],
+  "extensionKind": [
+    "workspace",
+    "ui"
+  ],
   "activationEvents": [
     "onCommand:metals.start-server",
     "onCommand:metals.new-scala-project",


### PR DESCRIPTION
I've been experimenting with using metals in codespaces. 

Under certain conditions (e.g. firewalls), I believe the metals extension may struggle to communicate with it's build server if running in the on the UI side of the architecture. 

This change says "I prefer to run in the workspace (i..e next to the code, and where the build server also wants to be), but I can run on the UI side if you want me to". I think metals might also work in the UI under this architecture under permissive network conditions, so I have't chosen to prevent the UI side entirely.

I've had to manually set this flag a few times now, and I think it's more likely that metals will work better as a workspace extension universally, so I'm putting up for a PR as part of the extension manifest. 

Here is what I believe the relevant docs are;

https://code.visualstudio.com/api/advanced-topics/remote-extensions#architecture-and-extension-kinds

https://code.visualstudio.com/api/advanced-topics/extension-host#preferred-extension-location

https://code.visualstudio.com/api/references/extension-manifest