### PR TITLE
feature: Also run plain Java when noDebug from launch.json

### DIFF
--- a/packages/metals-languageclient/src/interfaces/DebugDiscoveryParams.ts
+++ b/packages/metals-languageclient/src/interfaces/DebugDiscoveryParams.ts
@@ -1,6 +1,12 @@
 export interface DebugDiscoveryParams {
-  path: string;
+  path: string | undefined;
+  mainClass: string | undefined;
+  buildTarget: string | undefined;
   runType: RunType;
+  args: string[] | undefined;
+  jvmOptions: string[] | undefined;
+  env: Map<string, string> | undefined;
+  envFile: string | undefined;
 }
 
 export enum RunType {

--- a/packages/metals-vscode/src/extension.ts
+++ b/packages/metals-vscode/src/extension.ts
@@ -842,6 +842,12 @@ function launchMetals(
         const args: DebugDiscoveryParams = {
           path: editor.document.uri.toString(true),
           runType: RunType.RunOrTestFile,
+          buildTarget: undefined,
+          mainClass: undefined,
+          args: undefined,
+          jvmOptions: undefined,
+          env: undefined,
+          envFile: undefined,
         };
         scalaDebugger.startDiscovery(true, args).then((wasStarted) => {
           if (!wasStarted) {
@@ -854,6 +860,12 @@ function launchMetals(
         const args: DebugDiscoveryParams = {
           path: editor.document.uri.toString(true),
           runType: RunType.TestTarget,
+          buildTarget: undefined,
+          mainClass: undefined,
+          args: undefined,
+          jvmOptions: undefined,
+          env: undefined,
+          envFile: undefined,
         };
         scalaDebugger.startDiscovery(true, args).then((wasStarted) => {
           if (!wasStarted) {


### PR DESCRIPTION
Previously, if user run code from code lenses they would get a java command running without DAP. However, if they wanted to add parameters and run via launch.json they would run it via DAP.

Now, even if running from configuration we will run with simple java command. One issue here is that we need to start debugger anyway of run via launch.json, but I worked around it by just running echo instead.

Needs https://github.com/scalameta/metals/pull/6306