### PR TITLE
fix: use build target id instead of target name

### DIFF
--- a/packages/metals-vscode/src/test/extension/suites/testExplorer/testExplorerEvents.test.ts
+++ b/packages/metals-vscode/src/test/extension/suites/testExplorer/testExplorerEvents.test.ts
@@ -75,7 +75,7 @@ suite("Test Explorer events", () => {
       label: folderName,
       children: [
         {
-          id: targetName,
+          id: targetUri,
           label: targetName,
           children: [
             { id: "NoPackage", label: "NoPackage", uri, children: [] },
@@ -117,7 +117,7 @@ suite("Test Explorer events", () => {
       label: folderName,
       children: [
         {
-          id: targetName,
+          id: targetUri,
           label: targetName,
           children: [
             { id: "NoPackage", label: "NoPackage", uri, children: [] },
@@ -164,7 +164,7 @@ suite("Test Explorer events", () => {
       folderUri,
       foo
     );
-    removeTestItem(testController, targetName, folderUri, {
+    removeTestItem(testController, targetUri, folderUri, {
       ...foo,
       kind: "removeSuite",
     });
@@ -174,7 +174,7 @@ suite("Test Explorer events", () => {
       label: folderName,
       children: [
         {
-          id: targetName,
+          id: targetUri,
           label: targetName,
           children: [
             { id: "NoPackage", label: "NoPackage", uri, children: [] },
@@ -215,7 +215,7 @@ suite("Test Explorer events", () => {
       label: folderName,
       children: [
         {
-          id: targetName,
+          id: targetUri,
           label: targetName,
           children: [
             { id: "NoPackage", label: "NoPackage", uri, children: [] },

--- a/packages/metals-vscode/src/testExplorer/addTestCases.ts
+++ b/packages/metals-vscode/src/testExplorer/addTestCases.ts
@@ -60,7 +60,7 @@ export function addTestCases(
   }
   const workspaceFolderItem = testController.items.get(folderUri);
   if (workspaceFolderItem) {
-    const buildTargetItem = workspaceFolderItem.children.get(targetName);
+    const buildTargetItem = workspaceFolderItem.children.get(targetUri);
     if (buildTargetItem) {
       const testPath = prefixesOf(event.fullyQualifiedClassName, true);
       addTestCasesLoop(buildTargetItem, testPath);

--- a/packages/metals-vscode/src/testExplorer/addTestSuites.ts
+++ b/packages/metals-vscode/src/testExplorer/addTestSuites.ts
@@ -35,6 +35,7 @@ export function addTestSuite(
   const buildTargetItem = getOrCreateBuildTargetItem(
     testController,
     workspaceFolderItem,
+    targetUri,
     targetName
   );
 
@@ -82,14 +83,15 @@ export function addTestSuite(
 function getOrCreateBuildTargetItem(
   testController: vscode.TestController,
   workspaceFolderItem: vscode.TestItem,
+  targetUri: TargetUri,
   targetName: TargetName
 ): vscode.TestItem {
-  const buildTarget = workspaceFolderItem.children.get(targetName);
+  const buildTarget = workspaceFolderItem.children.get(targetUri);
   if (buildTarget) {
     return buildTarget;
   }
 
-  const createdNode = testController.createTestItem(targetName, targetName);
+  const createdNode = testController.createTestItem(targetUri, targetName);
   refineTestItem("module", createdNode, workspaceFolderItem);
   workspaceFolderItem.children.add(createdNode);
 

--- a/packages/metals-vscode/src/testExplorer/removeTestItem.ts
+++ b/packages/metals-vscode/src/testExplorer/removeTestItem.ts
@@ -1,10 +1,11 @@
 import * as vscode from "vscode";
-import { RemoveTestSuite, TargetName, FolderUri } from "./types";
+import { RemoveTestSuite, FolderUri } from "./types";
 import { prefixesOf, TestItemPath } from "./util";
+import { TargetUri } from "../types";
 
 export function removeTestItem(
   testController: vscode.TestController,
-  targetName: TargetName,
+  targetUri: TargetUri,
   folderUri: FolderUri,
   event: RemoveTestSuite
 ): void {
@@ -29,12 +30,12 @@ export function removeTestItem(
 
   const workspaceFolderItem = testController.items.get(folderUri);
   if (workspaceFolderItem) {
-    const buildTargetItem = workspaceFolderItem.children.get(targetName);
+    const buildTargetItem = workspaceFolderItem.children.get(targetUri);
     if (buildTargetItem) {
       const testPath = prefixesOf(event.fullyQualifiedClassName);
       removeTestItemLoop(buildTargetItem, testPath);
       if (buildTargetItem.children.size === 0) {
-        testController.items.delete(buildTargetItem.id);
+        workspaceFolderItem.children.delete(buildTargetItem.id);
       }
     }
     if (workspaceFolderItem.children.size === 0) {

--- a/packages/metals-vscode/src/testExplorer/testManager.ts
+++ b/packages/metals-vscode/src/testExplorer/testManager.ts
@@ -93,7 +93,7 @@ class TestManager {
       const folderName_ = folderName || ("root" as FolderName);
       for (const event of events) {
         if (event.kind === "removeSuite") {
-          removeTestItem(this.testController, targetName, folderUri_, event);
+          removeTestItem(this.testController, targetUri, folderUri_, event);
         } else if (event.kind === "addSuite") {
           addTestSuite(
             this.testController,
@@ -106,7 +106,7 @@ class TestManager {
         } else if (event.kind === "updateSuiteLocation") {
           updateTestSuiteLocation(
             this.testController,
-            targetName,
+            targetUri,
             folderUri_,
             event
           );

--- a/packages/metals-vscode/src/testExplorer/updateTestSuiteLocation.ts
+++ b/packages/metals-vscode/src/testExplorer/updateTestSuiteLocation.ts
@@ -1,6 +1,7 @@
 import * as vscode from "vscode";
-import { TargetName, UpdateSuiteLocation, FolderUri } from "./types";
+import { UpdateSuiteLocation, FolderUri } from "./types";
 import { prefixesOf, TestItemPath, toVscodeRange } from "./util";
+import { TargetUri } from "../types";
 
 /**
  *
@@ -11,7 +12,7 @@ import { prefixesOf, TestItemPath, toVscodeRange } from "./util";
  */
 export function updateTestSuiteLocation(
   testController: vscode.TestController,
-  targetName: TargetName,
+  targetUri: TargetUri,
   folderUri: FolderUri,
   event: UpdateSuiteLocation
 ): void {
@@ -36,7 +37,7 @@ export function updateTestSuiteLocation(
 
   const workspaceFolderItem = testController.items.get(folderUri);
   if (workspaceFolderItem) {
-    const buildTargetItem = workspaceFolderItem.children.get(targetName);
+    const buildTargetItem = workspaceFolderItem.children.get(targetUri);
     if (buildTargetItem) {
       const testPath = prefixesOf(event.fullyQualifiedClassName, true);
       updateTestSuiteLocationLoop(buildTargetItem, testPath);


### PR DESCRIPTION
connected to: https://github.com/scalameta/metals/issues/6581

This PR changes test exporter item representing build target to use build target URI instead of name as id, this way changes connected to build server switch are properly handled.