### PR TITLE
bugfix: Use normal debug console without a workspace

### DIFF
--- a/packages/metals-vscode/src/debugger/scalaDebugger.ts
+++ b/packages/metals-vscode/src/debugger/scalaDebugger.ts
@@ -88,8 +88,9 @@ async function runMain(main: ExtendedScalaRunMain): Promise<boolean> {
 
     await tasks.executeTask(task);
     return true;
+  } else {
+    return debug(true, main);
   }
-  return Promise.resolve(false);
 }
 
 export async function startDiscovery(


### PR DESCRIPTION
Turns out you cannot run a task without a workspace folder https://github.com/microsoft/vscode/issues/114381

Fixes https://github.com/scalameta/metals-vscode/issues/1532