### PR TITLE
improvement: Update Metals default JVM parameters

### DIFF
--- a/packages/metals-vscode/package.json
+++ b/packages/metals-vscode/package.json
@@ -228,7 +228,11 @@
             "type": "string"
           },
           "default": [
-            "-Xmx1G"
+            "-Xmx2G",
+            "-XX:+UseZGC",
+            "-XX:ZUncommitDelay=30",
+            "-XX:ZCollectionInterval=5",
+            "-XX:+IgnoreUnrecognizedVMOptions"
           ],
           "markdownDescription": "Optional list of properties to pass along to the Metals server. By default, the environment variable `JAVA_OPTS` and `.jvmopts` file are respected. Each property needs to be a separate item.\n\nExample: `-Dhttps.proxyHost=…`, `-Dhttps.proxyPort=…` or `-Dmetals.statistics=all`"
         },


### PR DESCRIPTION
This is now almost the same as Bloop and seems to reduce the overal memory used by Metals in the long run.
- -Xmx2G -> we can set higher maximum since the memory will be returned to the system
- -XX:+UseZGC -> this garbage collection will remove memory to the system once not needed
- -XX:ZUncommitDelay=30 -> is the delay before giving back the memory
- -XX:ZCollectionInterval=5 ->  maximum interval (in seconds) between two GC cycles when using ZGC
- -XX:+IgnoreUnrecognizedVMOptions -> safeguard if an option is not supported