### PR TITLE
bugfix: Fix issues when zgc is not fully supported

### DIFF
--- a/packages/metals-languageclient/src/__tests__/getJavaHome.test.ts
+++ b/packages/metals-languageclient/src/__tests__/getJavaHome.test.ts
@@ -61,7 +61,7 @@ describe("getJavaHome", () => {
       new MockOutput()
     );
     jest.restoreAllMocks();
-    expect(javaHome).toBe(JAVA_HOME);
+    expect(javaHome.path).toBe(JAVA_HOME);
   });
 
   // needs to run on a machine with an actual JAVA_HOME set up
@@ -90,7 +90,7 @@ describe("getJavaHome", () => {
       new MockOutput()
     );
     jest.restoreAllMocks();
-    expect(javaHome).toBe(pathJavaHome);
+    expect(javaHome.path).toBe(pathJavaHome);
   });
 });
 

--- a/packages/metals-languageclient/src/getJavaConfig.ts
+++ b/packages/metals-languageclient/src/getJavaConfig.ts
@@ -1,9 +1,11 @@
+import { JavaHome } from "./getJavaHome";
 import { getJavaOptions } from "./getJavaOptions";
 import * as path from "path";
 
 export interface JavaConfig {
   javaOptions: string[];
   javaPath: string;
+  javaHome: JavaHome;
   coursier: string;
   coursierMirrorFilePath: string | undefined;
   extraEnv: {
@@ -13,7 +15,7 @@ export interface JavaConfig {
 
 interface GetJavaConfigOptions {
   workspaceRoot: string | undefined;
-  javaHome: string;
+  javaHome: JavaHome;
   coursier: string;
   coursierMirrorFilePath: string | undefined;
   customRepositories: string[] | undefined;
@@ -27,7 +29,7 @@ export function getJavaConfig({
   customRepositories = [],
 }: GetJavaConfigOptions): JavaConfig {
   const javaOptions = getJavaOptions(workspaceRoot);
-  const javaPath = path.join(javaHome, "bin", "java");
+  const javaPath = path.join(javaHome.path, "bin", "java");
 
   const coursierRepositories =
     customRepositories.length > 0
@@ -45,6 +47,7 @@ export function getJavaConfig({
   return {
     javaOptions,
     javaPath,
+    javaHome,
     coursier,
     coursierMirrorFilePath,
     extraEnv,

--- a/packages/metals-vscode/src/extension.ts
+++ b/packages/metals-vscode/src/extension.ts
@@ -344,12 +344,12 @@ function launchMetals(
   // Make editing Scala docstrings slightly nicer.
   enableScaladocIndentation();
 
-  const serverOptions = getServerOptions({
+  const serverOptions = getServerOptions(
     metalsClasspath,
     serverProperties,
-    javaConfig,
-    clientName: "vscode",
-  });
+    "vscode",
+    javaConfig
+  );
 
   const initializationOptions: MetalsInitializationOptions = {
     compilerOptions: {


### PR DESCRIPTION
Turns out setting ZGC on graalvm for JDK 17 will break communication between metals server and vs code as it prints an unexpected warning to STDOUT