### PR TITLE
improvement: Allow to override metals java home

### DIFF
--- a/packages/metals-languageclient/src/__tests__/setupCoursier.test.ts
+++ b/packages/metals-languageclient/src/__tests__/setupCoursier.test.ts
@@ -48,6 +48,7 @@ describe("setupCoursier", () => {
   it("should setup coursier correctly", async () => {
     const { coursier, javaHome } = await setupCoursier(
       "17",
+      undefined,
       tmpDir,
       process.cwd(),
       new LogOutputChannel(),

--- a/packages/metals-languageclient/src/detectLaunchConfigurationChanges.ts
+++ b/packages/metals-languageclient/src/detectLaunchConfigurationChanges.ts
@@ -17,6 +17,7 @@ export function detectLaunchConfigurationChanges(
       UserConfiguration.ServerVersion,
       UserConfiguration.ServerProperties,
       UserConfiguration.JavaVersion,
+      UserConfiguration.MetalsJavaHome,
       UserConfiguration.CustomRepositories,
       UserConfiguration.CoursierMirror,
       ...additionalRestartKeys,

--- a/packages/metals-languageclient/src/interfaces/UserConfiguration.ts
+++ b/packages/metals-languageclient/src/interfaces/UserConfiguration.ts
@@ -17,6 +17,10 @@ export enum UserConfiguration {
    */
   JavaVersion = "javaVersion",
   /**
+   * Java Home to be used by Metals instead of it inferring using javaVersion.
+   */
+  MetalsJavaHome = "metalsJavaHome",
+  /**
    * Additional repositories that can be used to download dependencies.
    * https://get-coursier.io/docs/other-repositories
    */

--- a/packages/metals-languageclient/src/setupCoursier.ts
+++ b/packages/metals-languageclient/src/setupCoursier.ts
@@ -23,6 +23,7 @@ const coursierCommit = "11b428f35ca84a598ca30cce1c35ae4f375e5ee3";
 
 export async function setupCoursier(
   javaVersion: JavaVersion,
+  javaHomeOverride: string | undefined,
   coursierFetchPath: string,
   extensionPath: string,
   output: OutputChannel,
@@ -106,7 +107,13 @@ export async function setupCoursier(
   }
   output.appendLine(`Using coursier located at ${coursier}`);
 
-  var javaHome = await getJavaHome(javaVersion, output);
+  var javaHome: JavaHome | undefined;
+
+  if (javaHomeOverride) {
+    javaHome = await validateJavaVersion(javaHomeOverride, javaVersion, output);
+  } else {
+    javaHome = await getJavaHome(javaVersion, output);
+  }
 
   if (!javaHome && coursier) {
     output.appendLine(
@@ -136,7 +143,7 @@ export async function setupCoursier(
   else
     throw Error(
       `Cannot resolve Java home or coursier, JAVA_HOME should exist with a version of at least ${javaVersion}.` +
-        `Alternatively, you can reduce the requirement using "metals.javaVersion" setting.`
+        `Alternatively, you can reduce the requirement using "metals.javaVersion" setting override the path using metals.metalsJavaHome setting.`
     );
 }
 

--- a/packages/metals-languageclient/src/setupCoursier.ts
+++ b/packages/metals-languageclient/src/setupCoursier.ts
@@ -143,7 +143,7 @@ export async function setupCoursier(
   else
     throw Error(
       `Cannot resolve Java home or coursier, JAVA_HOME should exist with a version of at least ${javaVersion}.` +
-        `Alternatively, you can reduce the requirement using "metals.javaVersion" setting override the path using metals.metalsJavaHome setting.`
+        `Alternatively, you can reduce the requirement using "metals.javaVersion" setting and override the path using "metals.metalsJavaHome" setting.`
     );
 }
 

--- a/packages/metals-vscode/package.json
+++ b/packages/metals-vscode/package.json
@@ -279,6 +279,11 @@
           "scope": "machine-overridable",
           "markdownDescription": "Optional path to the Java home directory that will be used for compiling the project.\n\nDefaults to JDK used by Metals's server (look: Java Version).\n\nThis Java version should be lower or equal to JDK version used by the Metals's server."
         },
+        "metals.metalsJavaHome": {
+          "type": "string",
+          "scope": "machine",
+          "markdownDescription": "Optional path to the Java home directory that will be used for the running Metals server.\n\nBy default Metals will try to infer it using the version specified in metals.javaVersion.\n\nThis Java version should be higher than 17."
+        },
         "metals.javaVersion": {
           "type": "string",
           "default": "17",

--- a/packages/metals-vscode/package.json
+++ b/packages/metals-vscode/package.json
@@ -282,7 +282,7 @@
         "metals.metalsJavaHome": {
           "type": "string",
           "scope": "machine",
-          "markdownDescription": "Optional path to the Java home directory that will be used for the running Metals server.\n\nBy default Metals will try to infer it using the version specified in metals.javaVersion.\n\nThis Java version should be higher than 17."
+          "markdownDescription": "Optional path to the Java home directory that will be used for the running Metals server.\n\nBy default Metals will try to infer it using the version specified in metals.javaVersion.\n\nThis Java version should be higher or equal to 17."
         },
         "metals.javaVersion": {
           "type": "string",

--- a/packages/metals-vscode/src/extension.ts
+++ b/packages/metals-vscode/src/extension.ts
@@ -86,6 +86,7 @@ import { decodeAndShowFile, MetalsFileProvider } from "./metalsContentProvider";
 import {
   currentWorkspaceFolder,
   getJavaVersionFromConfig,
+  getJavaVersionOverride,
   getTextDocumentPositionParams,
   getValueFromConfig,
   metalsDir,
@@ -230,6 +231,7 @@ async function fetchAndLaunchMetals(
 
   const { coursier, javaHome } = await metalsLanguageClient.setupCoursier(
     javaVersion,
+    getJavaVersionOverride(),
     metalsDirPath,
     context.extensionPath,
     outputChannel,

--- a/packages/metals-vscode/src/util.ts
+++ b/packages/metals-vscode/src/util.ts
@@ -115,6 +115,13 @@ export function getJavaVersionFromConfig() {
   return undefined;
 }
 
+export function getJavaVersionOverride(): string | undefined {
+  return workspace
+    .getConfiguration("metals")
+    .get<string>(UserConfiguration.MetalsJavaHome)
+    ?.trim();
+}
+
 export async function fetchFrom(
   url: string,
   options?: http.RequestOptions

--- a/packages/metals-vscode/src/util.ts
+++ b/packages/metals-vscode/src/util.ts
@@ -116,10 +116,15 @@ export function getJavaVersionFromConfig() {
 }
 
 export function getJavaVersionOverride(): string | undefined {
-  return workspace
+  const javaVersion = workspace
     .getConfiguration("metals")
     .get<string>(UserConfiguration.MetalsJavaHome)
     ?.trim();
+  if (javaVersion && javaVersion.length > 0) {
+    return javaVersion;
+  } else {
+    return undefined;
+  }
 }
 
 export async function fetchFrom(


### PR DESCRIPTION
Peviously, if use had JAVA_HOME and java on PATH pointing to JDK 11, we would download JDK 17 using coursier. This however might not work if there is no internet and there was no way to work around that. Now, we allow users to specify an override for those cases.

Fixes https://github.com/scalameta/metals-vscode/issues/1558