### PR TITLE
bugfix: Don't show panel if unable to parse release notes

### DIFF
--- a/packages/metals-vscode/src/releaseNotesProvider.ts
+++ b/packages/metals-vscode/src/releaseNotesProvider.ts
@@ -66,7 +66,14 @@ async function showReleaseNotesImpl(
   // below are helper functions
 
   async function showPanel(version: string, releaseNotesUrl: string) {
-    const releaseNotes = await getReleaseNotesMarkdown(releaseNotesUrl);
+    const timeoutMs = 10000; // 10 seconds timeout
+    const timeoutPromise = new Promise<(_: vscode.Uri) => string>((_, reject) =>
+      setTimeout(() => reject(new Error("Request timed out")), timeoutMs)
+    );
+    const releaseNotes = await Promise.race([
+      getReleaseNotesMarkdown(releaseNotesUrl),
+      timeoutPromise,
+    ]);
 
     const panel = vscode.window.createWebviewPanel(
       `scalameta.metals.whatsNew`,


### PR DESCRIPTION
It seems previously it would always become visible right away (might be recent VS Code change). Now, we delay showing until the very end.