### PR TITLE
Fix race between code lens run and compilation

### DIFF
--- a/src/interfaces/ServerCommands.ts
+++ b/src/interfaces/ServerCommands.ts
@@ -53,6 +53,8 @@ export const ServerCommands = {
   CascadeCompile: "compile-cascade",
   /** Recompile all build targets in this workspace. */
   CleanCompile: "compile-clean",
+  /** Compile the given target and report if there were errors. */
+  CompileTarget: "compile-target",
   /**
    * Copy the contents of a worksheet to your local buffer.
    *

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,3 +21,13 @@ export type FullyQualifiedClassName = newtype<
 export interface BuildTargetIdentifier {
   uri: TargetUri;
 }
+
+export interface CompileResult {
+  statusCode: BuildStatusCode;
+}
+
+export enum BuildStatusCode {
+  Ok = 1,
+  Error = 2,
+  Cancelled = 3,
+}


### PR DESCRIPTION
This depends on this PR in metals landing first: https://github.com/scalameta/metals/pull/7315

This fixes with the "run" code lens which could run stale code.

Reproduce steps:

![image](https://github.com/user-attachments/assets/304b8583-417f-4a71-be74-e8ca876e3f29)

Press run. Press run again.

![image](https://github.com/user-attachments/assets/adbe3ab7-b118-4e2c-9754-3ca8df0b8fbc)

Press run. Press run again.

Expected result:

FOO
FOO
BAR
BAR

Actual result:

FOO
FOO
FOO
BAR

----

This issue also surfaced in anther way when introducing a compile error and pressing "run" before it disappeared. This would lead to stale code being executed. Now this shows an error instead suggesting to open the Problems pane.