### PR TITLE
bugfix: Fetch test environment variables lazily

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -777,7 +777,7 @@ function launchMetals(
       const testManager = createTestManager(
         client,
         istTestManagerDisabled,
-        getTestEnvVars()
+        getTestEnvVars
       );
 
       const disableTestExplorer = workspace.onDidChangeConfiguration(() => {

--- a/src/testExplorer/testManager.ts
+++ b/src/testExplorer/testManager.ts
@@ -14,7 +14,7 @@ import { updateTestSuiteLocation } from "./updateTestSuiteLocation";
 export function createTestManager(
   client: LanguageClient,
   isDisabled: boolean,
-  environmentVariables: Record<string, string> = {}
+  environmentVariables: () => Record<string, string>
 ): TestManager {
   return new TestManager(client, isDisabled, environmentVariables);
 }
@@ -27,12 +27,12 @@ class TestManager {
 
   private isDisabled = false;
   private isRunning = false;
-  private environmentVariables: Record<string, string> = {};
+  private environmentVariables: () => Record<string, string> = () => ({});
 
   constructor(
     private readonly client: LanguageClient,
     isDisabled: boolean,
-    environmentVariables: Record<string, string> = {}
+    environmentVariables: () => Record<string, string>
   ) {
     if (isDisabled) {
       this.disable();

--- a/src/testExplorer/testRunHandler.ts
+++ b/src/testExplorer/testRunHandler.ts
@@ -60,7 +60,7 @@ export async function runHandler(
   afterFinished: () => void,
   request: TestRunRequest,
   token: CancellationToken,
-  environmentVariables: Record<string, string> = {}
+  environmentVariables: () => Record<string, string>
 ): Promise<void> {
   const run = testController.createTestRun(request);
   const includes = new Set((request.include as MetalsTestItem[]) ?? []);
@@ -127,7 +127,7 @@ export async function runHandler(
         targetUri,
         testSuiteSelection,
         queue,
-        environmentVariables
+        environmentVariables()
       );
     }
   } finally {


### PR DESCRIPTION
Otherwise, with every change user would have to restart the extension.

CC @amitmiran137  