### PR TITLE
improvement: Change default for autoIndent

### DIFF
--- a/package.json
+++ b/package.json
@@ -167,7 +167,8 @@
       "[scala]": {
         "editor.suggestSelection": "first",
         "editor.formatOnPaste": true,
-        "editor.formatOnType": true
+        "editor.formatOnType": true,
+        "editor.autoIndent": "advanced"
       }
     },
     "viewsContainers": {


### PR DESCRIPTION
It seems to not work very well for optional braces

Fixes https://github.com/scalameta/metals/issues/7462