### PR TITLE
feat: expose API to get language client

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -132,7 +132,11 @@ const decorationType: TextEditorDecorationType =
 
 const config = workspace.getConfiguration("metals");
 
-export async function activate(context: ExtensionContext): Promise<void> {
+export interface MetalsApi {
+  currentLanguageClient(): LanguageClient | undefined;
+}
+
+export async function activate(context: ExtensionContext): Promise<MetalsApi> {
   const serverVersion = getServerVersion(config, context);
   detectConfigurationChanges();
   configureSettingsDefaults();
@@ -166,6 +170,10 @@ export async function activate(context: ExtensionContext): Promise<void> {
       outputChannel
     );
   }
+
+  return {
+    currentLanguageClient: () => currentClient
+  };
 }
 
 function migrateOldSettings(): void {


### PR DESCRIPTION
This makes it possible to get a reference to the `LanguageClient` from other VS code plugins, which opens up possibilities for tighter programmatic integration (ex. confirm project is correctly imported, additional ad-hoc LSP requests).