### PR TITLE
style: use trailing commas

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -3,8 +3,7 @@
  * @type {import("prettier").Config}
  */
 const config = {
-  trailingComma: "none",
-  tabWidth: 2
+  tabWidth: 2,
 };
 
 export default config;

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -9,30 +9,30 @@ const { FlatCompat } = require("@eslint/eslintrc");
 const compat = new FlatCompat({
   baseDirectory: __dirname,
   recommendedConfig: js.configs.recommended,
-  allConfig: js.configs.all
+  allConfig: js.configs.all,
 });
 
 module.exports = defineConfig([
   {
     languageOptions: {
-      parser: tsParser
+      parser: tsParser,
     },
 
     plugins: {
-      "@typescript-eslint": typescriptEslint
+      "@typescript-eslint": typescriptEslint,
     },
 
     extends: compat.extends(
       "eslint:recommended",
       "plugin:@typescript-eslint/recommended",
-      "prettier"
-    )
+      "prettier",
+    ),
   },
   globalIgnores([
     "out/*",
     "**/*.js",
     "src/test/unit/getJavaHome.test.ts",
-    "src/test/unit/checkForUpdate.test.ts"
+    "src/test/unit/checkForUpdate.test.ts",
   ]),
   {
     files: ["**/*.ts"],
@@ -40,8 +40,8 @@ module.exports = defineConfig([
       "@typescript-eslint/no-explicit-any": [
         "warn",
         {
-          ignoreRestArgs: true
-        }
+          ignoreRestArgs: true,
+        },
       ],
 
       "no-unused-vars": "off",
@@ -51,15 +51,15 @@ module.exports = defineConfig([
         {
           argsIgnorePattern: "^_",
           varsIgnorePattern: "^_",
-          caughtErrorsIgnorePattern: "^_"
-        }
+          caughtErrorsIgnorePattern: "^_",
+        },
       ],
 
       "@typescript-eslint/no-non-null-assertion": "error",
       "guard-for-in": "error",
       "no-var": "error",
       curly: "error",
-      "no-useless-escape": "off"
-    }
-  }
+      "no-useless-escape": "off",
+    },
+  },
 ]);

--- a/src/ConfigurationTarget.ts
+++ b/src/ConfigurationTarget.ts
@@ -1,4 +1,4 @@
 export enum ConfigurationTarget {
   Global,
-  Workspace
+  Workspace,
 }

--- a/src/checkServerVersion.ts
+++ b/src/checkServerVersion.ts
@@ -28,7 +28,7 @@ interface CheckServerVersionParams {
 export async function checkServerVersion({
   config,
   updateConfig,
-  onOutdated
+  onOutdated,
 }: CheckServerVersionParams) {
   const { serverVersion, latestServerVersion, configurationTarget } =
     serverVersionInfo(config);
@@ -56,7 +56,7 @@ export async function checkServerVersion({
         updateConfig({
           configSection,
           latestServerVersion,
-          configurationTarget
+          configurationTarget,
         });
       }
     };
@@ -65,7 +65,7 @@ export async function checkServerVersion({
       upgradeChoice,
       openSettingsChoice,
       dismissChoice,
-      upgrade
+      upgrade,
     });
   }
 }
@@ -90,6 +90,6 @@ function serverVersionInfo(config: WorkspaceConfiguration): {
   return {
     serverVersion: computedVersion,
     latestServerVersion: defaultAndGlobal?.defaultValue,
-    configurationTarget
+    configurationTarget,
   };
 }

--- a/src/commands/restartServer.ts
+++ b/src/commands/restartServer.ts
@@ -1,6 +1,6 @@
 import {
   ShutdownRequest,
-  ExitNotification
+  ExitNotification,
 } from "vscode-languageserver-protocol";
 import { LanguageClient } from "../interfaces/LanguageClient";
 import { exec, ChildProcess } from "child_process";
@@ -17,7 +17,7 @@ const timeoutMs = 4000;
  */
 export function restartServer(
   client: LanguageClient,
-  showMessage: ShowMessage
+  showMessage: ShowMessage,
 ): () => Promise<void> {
   return () => {
     const { showInformationMessage, showWarningMessage } =
@@ -35,7 +35,7 @@ export function restartServer(
     return Promise.race([gracefullyTerminate, timeout(timeoutMs)]).catch(() => {
       showWarningMessage(
         "Metals is unresponsive, killing the process and starting a new server.",
-        "warning"
+        "warning",
       );
 
       // NOTE(gabro): we know LanguageClient contains the _serverProcess private property,

--- a/src/debugger/hotCodeReplace.ts
+++ b/src/debugger/hotCodeReplace.ts
@@ -19,7 +19,7 @@ export function initializeHotCodeReplace() {
     vscode.commands.executeCommand(
       "setContext",
       HCR_ACTIVE,
-      session && !session.configuration.noDebug
+      session && !session.configuration.noDebug,
     );
   });
 }
@@ -35,7 +35,7 @@ export async function applyHCR() {
     vscode.window
       .showWarningMessage(
         "Failed to apply the changes because hot code replace is not supported by run mode, " +
-          "would you like to restart the program?"
+          "would you like to restart the program?",
       )
       .then((res) => {
         if (res === "Yes") {
@@ -50,7 +50,7 @@ export async function applyHCR() {
   const redefineRequest = debugSession.customRequest("redefineClasses");
   vscode.window.setStatusBarMessage(
     "$(sync~spin) Applying code changes...",
-    redefineRequest
+    redefineRequest,
   );
   const response = await redefineRequest;
 
@@ -61,7 +61,7 @@ export async function applyHCR() {
 
   if (!response?.changedClasses?.length) {
     vscode.window.showWarningMessage(
-      "No classes were reloaded, please check the logs"
+      "No classes were reloaded, please check the logs",
     );
     return;
   }
@@ -69,6 +69,6 @@ export async function applyHCR() {
   const changed = response.changedClasses.length;
   vscode.window.setStatusBarMessage(
     `$(check) ${changed} Class${changed > 1 ? "es" : ""} reloaded`,
-    5 * 1000
+    5 * 1000,
   );
 }

--- a/src/decorationProtocol.ts
+++ b/src/decorationProtocol.ts
@@ -3,7 +3,7 @@ import { NotificationType } from "vscode-jsonrpc";
 import {
   DecorationRenderOptions,
   DecorationInstanceRenderOptions,
-  Range
+  Range,
 } from "vscode";
 
 /**
@@ -14,7 +14,7 @@ import {
  */
 export namespace DecorationTypeDidChange {
   export const type = new NotificationType<DecorationRenderOptions>(
-    "metals/decorationTypeDidChange"
+    "metals/decorationTypeDidChange",
   );
 }
 
@@ -35,6 +35,6 @@ export interface PublishDecorationsParams {
 
 export namespace DecorationsRangesDidChange {
   export const type = new NotificationType<PublishDecorationsParams>(
-    "metals/publishDecorations"
+    "metals/publishDecorations",
   );
 }

--- a/src/detectLaunchConfigurationChanges.ts
+++ b/src/detectLaunchConfigurationChanges.ts
@@ -10,7 +10,7 @@ interface PromptRestartParams {
 export function detectLaunchConfigurationChanges(
   workspace: Workspace,
   promptRestart: (params: PromptRestartParams) => Thenable<void>,
-  additionalRestartKeys: string[] = []
+  additionalRestartKeys: string[] = [],
 ): void {
   workspace.onDidChangeConfiguration((e) => {
     const promptRestartKeys = [
@@ -20,17 +20,17 @@ export function detectLaunchConfigurationChanges(
       UserConfiguration.MetalsJavaHome,
       UserConfiguration.CustomRepositories,
       UserConfiguration.CoursierMirror,
-      ...additionalRestartKeys
+      ...additionalRestartKeys,
     ];
     const shouldPromptRestart = promptRestartKeys.some((key) =>
-      e.affectsConfiguration(`metals.${key}`)
+      e.affectsConfiguration(`metals.${key}`),
     );
     if (shouldPromptRestart) {
       promptRestart({
         message:
           "Server launch configuration change detected. Reload the window for changes to take effect",
         reloadWindowChoice: "Reload Window",
-        dismissChoice: "Not now"
+        dismissChoice: "Not now",
       });
     }
   });

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -4,14 +4,14 @@ import {
   Uri,
   ViewColumn,
   WebviewPanel,
-  window
+  window,
 } from "vscode";
 import {
   Disposable,
   ExecuteCommandParams,
   ExecuteCommandRequest,
   LanguageClient,
-  NotificationType
+  NotificationType,
 } from "vscode-languageclient/node";
 import { ClientCommands } from "./interfaces/ClientCommands";
 import { ServerCommands } from "./interfaces/ServerCommands";
@@ -34,7 +34,7 @@ export class DoctorProvider implements Disposable {
   isOpened = false;
   constructor(
     private client: LanguageClient,
-    private context: ExtensionContext
+    private context: ExtensionContext,
   ) {}
 
   dispose(): void {
@@ -47,16 +47,16 @@ export class DoctorProvider implements Disposable {
         "metals-doctor",
         "Metals Doctor",
         ViewColumn.Active,
-        { enableCommandUris: true, enableScripts: true }
+        { enableCommandUris: true, enableScripts: true },
       );
       this.doctor.iconPath = Uri.file(
-        path.join(this.context.extensionPath, "icons", "doctor.svg")
+        path.join(this.context.extensionPath, "icons", "doctor.svg"),
       );
       this.isOpened = true;
 
       this.doctor.onDidDispose(() => {
         this.client.sendNotification(doctorNotification, {
-          visible: false
+          visible: false,
         });
         this.isOpened = false;
         this.doctor = undefined;
@@ -81,7 +81,7 @@ export class DoctorProvider implements Disposable {
 
   async runDoctor(): Promise<void> {
     await this.client.sendRequest(ExecuteCommandRequest.type, {
-      command: ServerCommands.DoctorRun
+      command: ServerCommands.DoctorRun,
     });
     this.isOpened = true;
   }

--- a/src/downloadProgress.ts
+++ b/src/downloadProgress.ts
@@ -14,7 +14,7 @@ export function downloadProgress({
   download,
   onProgress,
   onComplete,
-  onError
+  onError,
 }: DownlodProgressParams): Promise<string> {
   const stdout: Buffer[] = [];
   const stderr: Buffer[] = [];

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -31,14 +31,14 @@ import {
   tests as vscodeTextExplorer,
   debug,
   DebugSessionCustomEvent,
-  ThemeColor
+  ThemeColor,
 } from "vscode";
 import {
   LanguageClient,
   LanguageClientOptions,
   RevealOutputChannelOn,
   ExecuteCommandRequest,
-  CancellationToken
+  CancellationToken,
 } from "vscode-languageclient/node";
 import { LazyProgress } from "./lazyProgress";
 import * as fs from "fs";
@@ -53,7 +53,7 @@ import { openSymbolSearch } from "./openSymbolSearch";
 import {
   createFindInFilesTreeView,
   executeFindInFiles,
-  startFindInFilesProvider
+  startFindInFilesProvider,
 } from "./findInFiles";
 import * as ext from "./hoverExtension";
 import { decodeAndShowFile, MetalsFileProvider } from "./metalsContentProvider";
@@ -63,7 +63,7 @@ import {
   getJavaVersionOverride,
   getTextDocumentPositionParams,
   getValueFromConfig,
-  metalsDir
+  metalsDir,
 } from "./util";
 import { createTestManager } from "./testExplorer/testManager";
 import { BuildTargetUpdate } from "./testExplorer/types";
@@ -75,13 +75,13 @@ import { showReleaseNotes } from "./releaseNotesProvider";
 import {
   openSettingsAction,
   USER_NOTIFICATION_EVENT,
-  SCALA_LANGID
+  SCALA_LANGID,
 } from "./consts";
 import { ScalaCodeLensesParams } from "./debugger/types";
 import { applyHCR, initializeHotCodeReplace } from "./debugger/hotCodeReplace";
 import {
   MetalsTreeViewRevealType,
-  MetalsTreeViews
+  MetalsTreeViews,
 } from "./interfaces/TreeViewProtocol";
 import { JavaVersion } from "./getJavaHome";
 import { setupCoursier } from "./setupCoursier";
@@ -96,17 +96,17 @@ import { ClientCommands } from "./interfaces/ClientCommands";
 import {
   ExecuteClientCommandType,
   MetalsDidFocusTypeType as MetalsDidFocusType,
-  MetalsOpenWindowParams
+  MetalsOpenWindowParams,
 } from "./interfaces/Extensions";
 import { TestUIKind } from "./interfaces/TestUI";
 import { MetalsStatusType } from "./interfaces/MetalsStatus";
 import {
   DebugDiscoveryParams,
-  RunType
+  RunType,
 } from "./interfaces/DebugDiscoveryParams";
 import {
   MetalsInputBoxHandle,
-  MetalsInputBoxType
+  MetalsInputBoxType,
 } from "./interfaces/MetalsInputBox";
 import { MetalsQuickPickType } from "./interfaces/MetalsQuickPick";
 import { MetalsSlowTaskType } from "./interfaces/MetalsSlowTask";
@@ -121,13 +121,13 @@ let currentClient: LanguageClient | undefined;
 // Inline needs to be first to be shown always first
 const inlineDecorationType: TextEditorDecorationType =
   window.createTextEditorDecorationType({
-    rangeBehavior: DecorationRangeBehavior.OpenOpen
+    rangeBehavior: DecorationRangeBehavior.OpenOpen,
   });
 
 const decorationType: TextEditorDecorationType =
   window.createTextEditorDecorationType({
     isWholeLine: true,
-    rangeBehavior: DecorationRangeBehavior.OpenClosed
+    rangeBehavior: DecorationRangeBehavior.OpenClosed,
   });
 
 const config = workspace.getConfiguration("metals");
@@ -146,7 +146,7 @@ export async function activate(context: ExtensionContext): Promise<MetalsApi> {
     {
       location: ProgressLocation.Window,
       title: `Starting Metals server...`,
-      cancellable: false
+      cancellable: false,
     },
     async () => {
       commands.executeCommand("setContext", "metals:enabled", true);
@@ -157,7 +157,7 @@ export async function activate(context: ExtensionContext): Promise<MetalsApi> {
         outputChannel.appendLine(`${err}`);
         window.showErrorMessage(`${err}`);
       }
-    }
+    },
   );
 
   const disableReleaseNotes =
@@ -167,12 +167,12 @@ export async function activate(context: ExtensionContext): Promise<MetalsApi> {
       "onExtensionStart",
       context,
       serverVersion,
-      outputChannel
+      outputChannel,
     );
   }
 
   return {
-    currentLanguageClient: () => currentClient
+    currentLanguageClient: () => currentClient,
   };
 }
 
@@ -189,14 +189,14 @@ function migrateOldSettings(): void {
   const implicitConversions = config.get<boolean>(implicitConvSetting) ?? false;
   [inferredTypeSetting, implicitArgsSetting, implicitConvSetting].forEach(
     (setting) =>
-      config.update(setting, undefined, ConfigurationTarget.Workspace)
+      config.update(setting, undefined, ConfigurationTarget.Workspace),
   );
   type SettingTuple = [string, boolean];
   const settings: SettingTuple[] = [
     ["inferredTypes", inferredType],
     ["typeParameters", typeParameters],
     ["implicitArguments", implicitArgs],
-    ["implicitConversions", implicitConversions]
+    ["implicitConversions", implicitConversions],
   ];
   settings.forEach(([key, enabled]: SettingTuple) => {
     const newKey = `inlayHints.${key}.enable`;
@@ -212,7 +212,7 @@ export function deactivate(): Thenable<void> | undefined {
 function debugInformation(
   serverVersion: string,
   serverProperties: string[],
-  javaConfig: JavaConfig
+  javaConfig: JavaConfig,
 ) {
   return `  Metals version: ${serverVersion}  
   Server properties: ${serverProperties} 
@@ -229,7 +229,7 @@ async function fetchAndLaunchMetals(
   context: ExtensionContext,
   serverVersion: string,
   javaVersion: JavaVersion,
-  forceCoursierJar = false
+  forceCoursierJar = false,
 ) {
   outputChannel.appendLine(`Metals version: ${serverVersion}`);
 
@@ -255,7 +255,7 @@ async function fetchAndLaunchMetals(
     context.extensionPath,
     outputChannel,
     forceCoursierJar,
-    serverProperties.concat(getJavaOptions(workspaceRoot))
+    serverProperties.concat(getJavaOptions(workspaceRoot)),
   );
 
   const canRetryWithJar =
@@ -264,7 +264,7 @@ async function fetchAndLaunchMetals(
   function retry(error: any): Promise<any> {
     if (canRetryWithJar) {
       outputChannel.appendLine(
-        "Trying again with the embedded coursier. This might take longer."
+        "Trying again with the embedded coursier. This might take longer.",
       );
       return fetchAndLaunchMetals(context, serverVersion, javaVersion, true);
     } else {
@@ -277,14 +277,14 @@ async function fetchAndLaunchMetals(
     javaHome,
     coursier,
     customRepositories,
-    coursierMirrorFilePath: coursierMirror
+    coursierMirrorFilePath: coursierMirror,
   });
 
   const fetchProcess = fetchMetals({
     serverVersion,
     serverProperties,
     javaConfig,
-    outputChannel
+    outputChannel,
   });
 
   const title = `Downloading Metals v${serverVersion}`;
@@ -300,14 +300,14 @@ async function fetchAndLaunchMetals(
           classpath,
           serverProperties,
           javaConfig,
-          serverVersion
+          serverVersion,
         ).catch((reason): Promise<any> => {
           outputChannel.appendLine(
-            "Launching Metals failed with the following:"
+            "Launching Metals failed with the following:",
           );
           outputChannel.appendLine(reason.message);
           outputChannel.appendLine(
-            debugInformation(serverVersion, serverProperties, javaConfig)
+            debugInformation(serverVersion, serverProperties, javaConfig),
           );
           return retry(reason);
         });
@@ -315,11 +315,11 @@ async function fetchAndLaunchMetals(
       (reason) => {
         if (reason instanceof Error) {
           outputChannel.appendLine(
-            "Downloading Metals failed with the following:"
+            "Downloading Metals failed with the following:",
           );
           outputChannel.appendLine(reason.message);
           outputChannel.appendLine(
-            debugInformation(serverVersion, serverProperties, javaConfig)
+            debugInformation(serverVersion, serverProperties, javaConfig),
           );
         }
         if (canRetryWithJar) {
@@ -350,7 +350,7 @@ async function fetchAndLaunchMetals(
             }
           });
         }
-      }
+      },
     );
 }
 
@@ -360,7 +360,7 @@ function launchMetals(
   metalsClasspath: string,
   serverProperties: string[],
   javaConfig: JavaConfig,
-  serverVersion: string
+  serverVersion: string,
 ) {
   // Make editing Scala docstrings slightly nicer.
   enableScaladocIndentation();
@@ -369,20 +369,20 @@ function launchMetals(
     metalsClasspath,
     serverProperties,
     "vscode",
-    javaConfig
+    javaConfig,
   );
 
   const commandArgs = [
     serverOptions.run.command,
-    ...(serverOptions.run.args || [])
+    ...(serverOptions.run.args || []),
   ];
   const isDebugLogging = (serverOptions.run.args || []).some((arg) =>
-    arg.includes("-Dmetals.loglevel=debug")
+    arg.includes("-Dmetals.loglevel=debug"),
   );
 
   if (isDebugLogging) {
     outputChannel.appendLine(
-      `Launching Metals with command: ${commandArgs.join(" ")}`
+      `Launching Metals with command: ${commandArgs.join(" ")}`,
     );
   }
 
@@ -390,7 +390,7 @@ function launchMetals(
     compilerOptions: {
       completionCommand: "editor.action.triggerSuggest",
       overrideDefFormat: "unicode",
-      parameterHintsCommand: "editor.action.triggerParameterHints"
+      parameterHintsCommand: "editor.action.triggerParameterHints",
     },
     copyWorksheetOutputProvider: true,
     decorationProvider: true,
@@ -414,7 +414,7 @@ function launchMetals(
     commandInHtmlFormat: "vscode",
     doctorVisibilityProvider: true,
     bspStatusBarProvider: "on",
-    moduleStatusBarProvider: "on"
+    moduleStatusBarProvider: "on",
   };
 
   const clientOptions: LanguageClientOptions = {
@@ -422,27 +422,27 @@ function launchMetals(
       { scheme: "file", language: "scala" },
       { scheme: "file", language: "java" },
       { scheme: "jar", language: "scala" },
-      { scheme: "jar", language: "java" }
+      { scheme: "jar", language: "java" },
     ],
     synchronize: {
-      configurationSection: "metals"
+      configurationSection: "metals",
     },
     revealOutputChannelOn: RevealOutputChannelOn.Never,
     outputChannel: outputChannel,
     initializationOptions,
     middleware: {
-      provideHover: hoverLinksMiddlewareHook
+      provideHover: hoverLinksMiddlewareHook,
     },
     markdown: {
-      isTrusted: true
+      isTrusted: true,
     },
-    diagnosticCollectionName: "Metals"
+    diagnosticCollectionName: "Metals",
   };
 
   function hoverLinksMiddlewareHook(
     document: TextDocument,
     position: Position,
-    token: CancellationToken
+    token: CancellationToken,
   ): ProviderResult<Hover> {
     const editor = window.activeTextEditor;
     const pos = client.code2ProtocolConverter.asPosition(position);
@@ -456,9 +456,9 @@ function launchMetals(
           textDocument:
             client.code2ProtocolConverter.asTextDocumentIdentifier(document),
           position: pos,
-          range: range
+          range: range,
         },
-        token
+        token,
       )
       .then(
         (result) => {
@@ -466,7 +466,7 @@ function launchMetals(
         },
         () => {
           return Promise.resolve(null);
-        }
+        },
       );
   }
 
@@ -474,13 +474,13 @@ function launchMetals(
     "metals",
     "Metals",
     serverOptions,
-    clientOptions
+    clientOptions,
   );
 
   currentClient = client;
   function registerCommand(
     command: string,
-    callback: (...args: any[]) => unknown
+    callback: (...args: any[]) => unknown,
   ) {
     context.subscriptions.push(commands.registerCommand(command, callback));
   }
@@ -491,19 +491,19 @@ function launchMetals(
       textEditor: TextEditor,
       edit: TextEditorEdit,
       ...args: any[]
-    ) => unknown
+    ) => unknown,
   ) {
     context.subscriptions.push(
-      commands.registerTextEditorCommand(command, callback)
+      commands.registerTextEditorCommand(command, callback),
     );
   }
 
   function registerTextDocumentContentProvider(
     scheme: string,
-    provider: TextDocumentContentProvider
+    provider: TextDocumentContentProvider,
   ) {
     context.subscriptions.push(
-      workspace.registerTextDocumentContentProvider(scheme, provider)
+      workspace.registerTextDocumentContentProvider(scheme, provider),
     );
   }
 
@@ -529,7 +529,7 @@ function launchMetals(
       client,
       metalsFileProvider,
       uri,
-      "semanticdb-compact"
+      "semanticdb-compact",
     );
   });
 
@@ -538,7 +538,7 @@ function launchMetals(
       client,
       metalsFileProvider,
       uri,
-      "semanticdb-detailed"
+      "semanticdb-detailed",
     );
   });
 
@@ -547,7 +547,7 @@ function launchMetals(
       client,
       metalsFileProvider,
       uri,
-      "semanticdb-proto"
+      "semanticdb-proto",
     );
   });
 
@@ -561,8 +561,8 @@ function launchMetals(
       // NOTE(gabro): this is due to mismatching versions of vscode-languageserver-protocol
       // which are not trivial to fix, currently
       client,
-      window
-    )
+      window,
+    ),
   );
 
   registerCommand(
@@ -572,8 +572,8 @@ function launchMetals(
         "onUserDemand",
         context,
         serverVersion,
-        outputChannel
-      )
+        outputChannel,
+      ),
   );
 
   return client.start().then(
@@ -587,15 +587,15 @@ function launchMetals(
             "metals-stacktrace",
             "Analyze Stacktrace",
             ViewColumn.Beside,
-            { enableCommandUris: true }
+            { enableCommandUris: true },
           );
           stacktrace.iconPath = {
             light: Uri.file(
-              path.join(context.extensionPath, "icons", "exception-light.svg")
+              path.join(context.extensionPath, "icons", "exception-light.svg"),
             ),
             dark: Uri.file(
-              path.join(context.extensionPath, "icons", "exception-dark.svg")
-            )
+              path.join(context.extensionPath, "icons", "exception-dark.svg"),
+            ),
           };
           context.subscriptions.push(stacktrace);
           stacktrace.onDidDispose(() => {
@@ -622,12 +622,12 @@ function launchMetals(
         ServerCommands.ScalaCliStop,
         ServerCommands.ZipReports,
         ServerCommands.ResetWorkspace,
-        "open-new-github-issue"
+        "open-new-github-issue",
       ].forEach((command) => {
         registerCommand("metals." + command, async () =>
           client.sendRequest(ExecuteCommandRequest.type, {
-            command: command
-          })
+            command: command,
+          }),
         );
       });
 
@@ -660,7 +660,7 @@ function launchMetals(
         } else {
           // pick from list of targets
           const targets = await client.sendRequest(ExecuteCommandRequest.type, {
-            command: ServerCommands.ListBuildTargets
+            command: ServerCommands.ListBuildTargets,
           });
           const picked = await window.showQuickPick(targets);
           if (picked) {
@@ -672,7 +672,7 @@ function launchMetals(
       let channelOpen = false;
 
       registerCommand(ClientCommands.FocusDiagnostics, () =>
-        commands.executeCommand(workbenchCommands.focusDiagnostics)
+        commands.executeCommand(workbenchCommands.focusDiagnostics),
       );
 
       registerCommand(ClientCommands.RunDoctor, async () => {
@@ -706,9 +706,9 @@ function launchMetals(
               if (reason instanceof Error) {
                 window.showErrorMessage(reason.message);
               }
-            }
+            },
           );
-        }
+        },
       );
 
       registerCommand(
@@ -718,7 +718,7 @@ function launchMetals(
           const compileResult: CompileResult | null | undefined =
             await commands.executeCommand(
               ServerCommands.CompileTarget,
-              param.targets[0]
+              param.targets[0],
             );
           switch (compileResult?.statusCode) {
             case BuildStatusCode.Ok:
@@ -732,7 +732,7 @@ function launchMetals(
                   if (reason instanceof Error) {
                     window.showErrorMessage(reason.message);
                   }
-                }
+                },
               );
               break;
             case BuildStatusCode.Error:
@@ -740,7 +740,7 @@ function launchMetals(
                 .showErrorMessage(
                   "Cannot execute code lens due to compilation errors.",
                   { modal: true },
-                  "View Problems"
+                  "View Problems",
                 )
                 .then((action) => {
                   if (action === "View Problems") {
@@ -751,13 +751,13 @@ function launchMetals(
             case BuildStatusCode.Cancelled:
               window.showErrorMessage(
                 "Cannot run code lens. Build was cancelled.",
-                { modal: true }
+                { modal: true },
               );
               break;
             default:
             // server emits error in this case
           }
-        }
+        },
       );
 
       // should be the compilation of a currently opened file
@@ -766,30 +766,30 @@ function launchMetals(
 
       const codeLensRefresher: CodeLensProvider = {
         onDidChangeCodeLenses: compilationDoneEmitter.event,
-        provideCodeLenses: () => undefined
+        provideCodeLenses: () => undefined,
       };
 
       languages.registerCodeLensProvider(
         { scheme: "file", language: "scala" },
-        codeLensRefresher
+        codeLensRefresher,
       );
       languages.registerCodeLensProvider(
         { scheme: "jar", language: "scala" },
-        codeLensRefresher
+        codeLensRefresher,
       );
 
       const getTestUI = () =>
         getValueFromConfig<TestUIKind>(
           config,
           "testUserInterface",
-          "Test Explorer"
+          "Test Explorer",
         );
 
       const getTestEnvVars = () => {
         const envVars = getValueFromConfig<Record<string, string>>(
           config,
           "testEnvironmentVariables",
-          {}
+          {},
         );
         return envVars;
       };
@@ -801,7 +801,7 @@ function launchMetals(
       const testManager = createTestManager(
         client,
         istTestManagerDisabled,
-        getTestEnvVars
+        getTestEnvVars,
       );
 
       const disableTestExplorer = workspace.onDidChangeConfiguration(() => {
@@ -826,7 +826,7 @@ function launchMetals(
               commands.executeCommand(
                 `metals.${ClientCommands.GotoLocation}`,
                 location,
-                metalsFileProvider
+                metalsFileProvider,
               );
               break;
             }
@@ -840,7 +840,7 @@ function launchMetals(
                 commands.executeCommand(
                   "vscode.openFolder",
                   Uri.parse(openWindowParams.uri),
-                  openWindowParams.openNewWindow
+                  openWindowParams.openNewWindow,
                 );
               }
               break;
@@ -872,7 +872,7 @@ function launchMetals(
             default:
               outputChannel.appendLine(`unknown command: ${params.command}`);
           }
-        }
+        },
       );
 
       context.subscriptions.push(executeClientCommandDisposable);
@@ -880,12 +880,12 @@ function launchMetals(
       // it is currently doing, for example "Compiling..".
       const metalsItem = window.createStatusBarItem(
         StatusBarAlignment.Right,
-        100
+        100,
       );
       const bspItem = window.createStatusBarItem(StatusBarAlignment.Right, 100);
       const moduleItem = window.createStatusBarItem(
         StatusBarAlignment.Right,
-        100
+        100,
       );
       metalsItem.command = ClientCommands.ToggleLogs;
       metalsItem.hide();
@@ -916,18 +916,18 @@ function launchMetals(
 
           if (params.level == "error") {
             item.backgroundColor = new ThemeColor(
-              "statusBarItem.errorBackground"
+              "statusBarItem.errorBackground",
             );
           } else if (params.level == "warn") {
             item.backgroundColor = new ThemeColor(
-              "statusBarItem.warningBackground"
+              "statusBarItem.warningBackground",
             );
           } else {
             item.backgroundColor = undefined;
           }
 
           item.command = params.metalsCommand || params.command;
-        }
+        },
       );
       context.subscriptions.push(metalsStatusDisposable);
 
@@ -940,7 +940,7 @@ function launchMetals(
           args: undefined,
           jvmOptions: undefined,
           env: undefined,
-          envFile: undefined
+          envFile: undefined,
         };
         scalaDebugger.startDiscovery(true, args).then((wasStarted) => {
           if (!wasStarted) {
@@ -958,7 +958,7 @@ function launchMetals(
           args: undefined,
           jvmOptions: undefined,
           env: undefined,
-          envFile: undefined
+          envFile: undefined,
         };
         scalaDebugger.startDiscovery(true, args).then((wasStarted) => {
           if (!wasStarted) {
@@ -972,15 +972,15 @@ function launchMetals(
         (editor) => {
           client.sendRequest(ExecuteCommandRequest.type, {
             command: ServerCommands.GotoSuperMethod,
-            arguments: [getTextDocumentPositionParams(editor)]
+            arguments: [getTextDocumentPositionParams(editor)],
           });
-        }
+        },
       );
 
       registerTextEditorCommand(`metals.scalafix-run`, (editor) => {
         client.sendRequest(ExecuteCommandRequest.type, {
           command: "scalafix-run",
-          arguments: [getTextDocumentPositionParams(editor)]
+          arguments: [getTextDocumentPositionParams(editor)],
         });
       });
 
@@ -989,9 +989,9 @@ function launchMetals(
           command: "scalafix-run-only",
           arguments: [
             {
-              textDocumentPositionParams: getTextDocumentPositionParams(editor)
-            }
-          ]
+              textDocumentPositionParams: getTextDocumentPositionParams(editor),
+            },
+          ],
         });
       });
 
@@ -1000,21 +1000,21 @@ function launchMetals(
         (editor) => {
           client.sendRequest(ExecuteCommandRequest.type, {
             command: ServerCommands.SuperMethodHierarchy,
-            arguments: [getTextDocumentPositionParams(editor)]
+            arguments: [getTextDocumentPositionParams(editor)],
           });
-        }
+        },
       );
 
       registerCommand(`metals.${ServerCommands.AnalyzeStacktrace}`, () => {
         env.clipboard.readText().then((clip) => {
           if (clip.trim().length < 1) {
             window.showInformationMessage(
-              "Clipboard appears to be empty, copy stacktrace to clipboard and retry this command"
+              "Clipboard appears to be empty, copy stacktrace to clipboard and retry this command",
             );
           } else {
             client.sendRequest(ExecuteCommandRequest.type, {
               command: "analyze-stacktrace",
-              arguments: [clip]
+              arguments: [clip],
             });
           }
         });
@@ -1028,43 +1028,43 @@ function launchMetals(
             client
               .sendRequest(ExecuteCommandRequest.type, {
                 command: ServerCommands.CopyWorksheetOutput,
-                arguments: [uri.toString()]
+                arguments: [uri.toString()],
               })
               .then((result) => {
                 window.showInformationMessage(result);
                 if (result.value) {
                   env.clipboard.writeText(result.value);
                   window.showInformationMessage(
-                    "Copied worksheet evaluation to clipboard."
+                    "Copied worksheet evaluation to clipboard.",
                   );
                 }
               });
           } else {
             window.showWarningMessage(
-              "You must be in a worksheet to use this feature."
+              "You must be in a worksheet to use this feature.",
             );
           }
-        }
+        },
       );
 
       registerCommand(`metals.${ServerCommands.ResetChoice}`, (args = []) => {
         client.sendRequest(ExecuteCommandRequest.type, {
           command: ServerCommands.ResetChoice,
-          arguments: args
+          arguments: args,
         });
       });
 
       registerCommand(`metals.reset-notifications`, (args = []) => {
         client.sendRequest(ExecuteCommandRequest.type, {
           command: "reset-notifications",
-          arguments: args
+          arguments: args,
         });
       });
 
       registerCommand(`metals.${ServerCommands.Goto}`, (args) => {
         client.sendRequest(ExecuteCommandRequest.type, {
           command: ServerCommands.Goto,
-          arguments: args
+          arguments: args,
         });
       });
 
@@ -1074,20 +1074,20 @@ function launchMetals(
           if (location) {
             gotoLocation(location, metalsFileProvider);
           }
-        }
+        },
       );
 
       registerCommand("metals.reveal-active-file", () => {
         if (treeViews) {
           const editor = window.visibleTextEditors.find((e) =>
-            isSupportedLanguage(e.document.languageId)
+            isSupportedLanguage(e.document.languageId),
           );
           if (editor) {
             const params = getTextDocumentPositionParams(editor);
             return window.withProgress(
               {
                 location: ProgressLocation.Window,
-                title: "Metals: Reveal Active File in Side Bar"
+                title: "Metals: Reveal Active File in Side Bar",
               },
               (progress) => {
                 return client
@@ -1098,19 +1098,19 @@ function launchMetals(
                       treeViews.reveal(result);
                     }
                   });
-              }
+              },
             );
           }
         } else {
           window.showErrorMessage(
-            "This version of Metals does not support tree views."
+            "This version of Metals does not support tree views.",
           );
         }
       });
 
       registerCommand(ClientCommands.EchoCommand, (arg: string) => {
         client.sendRequest(ExecuteCommandRequest.type, {
-          command: arg
+          command: arg,
         });
       });
 
@@ -1151,9 +1151,9 @@ function launchMetals(
         async (directory: Uri) => {
           return client.sendRequest(ExecuteCommandRequest.type, {
             command: ServerCommands.NewScalaFile,
-            arguments: [directory?.toString()]
+            arguments: [directory?.toString()],
           });
-        }
+        },
       );
 
       registerCommand(
@@ -1161,15 +1161,15 @@ function launchMetals(
         async (directory: Uri) => {
           return client.sendRequest(ExecuteCommandRequest.type, {
             command: ServerCommands.NewJavaFile,
-            arguments: [directory?.toString()]
+            arguments: [directory?.toString()],
           });
-        }
+        },
       );
 
       const findInFilesProvider = startFindInFilesProvider(context);
       const findInFilesView = createFindInFilesTreeView(
         findInFilesProvider,
-        context
+        context,
       );
 
       registerCommand(`metals.find-text-in-dependency-jars`, async () =>
@@ -1178,15 +1178,15 @@ function launchMetals(
           findInFilesProvider,
           findInFilesView,
           metalsFileProvider,
-          outputChannel
-        )
+          outputChannel,
+        ),
       );
 
       registerCommand(`metals.new-scala-worksheet`, async () => {
         const sendRequest = (args: Array<string | undefined>) => {
           return client.sendRequest(ExecuteCommandRequest.type, {
             command: ServerCommands.NewScalaFile,
-            arguments: args
+            arguments: args,
           });
         };
         const currentUri = window.activeTextEditor?.document.uri;
@@ -1197,7 +1197,7 @@ function launchMetals(
           const fullPath = path.join(parentPath, `${name}.worksheet.sc`);
           if (fs.existsSync(fullPath)) {
             window.showWarningMessage(
-              `A worksheet ${name}.worksheet.sc already exists, opening it instead`
+              `A worksheet ${name}.worksheet.sc already exists, opening it instead`,
             );
             return workspace
               .openTextDocument(fullPath)
@@ -1212,21 +1212,21 @@ function launchMetals(
 
       registerCommand(`metals.${ServerCommands.NewScalaProject}`, async () => {
         return client.sendRequest(ExecuteCommandRequest.type, {
-          command: ServerCommands.NewScalaProject
+          command: ServerCommands.NewScalaProject,
         });
       });
 
       const workspaceUri = currentWorkspaceFolder()?.uri;
       // NOTE: we offer a custom symbol search command to work around the limitations of the built-in one, see https://github.com/microsoft/vscode/issues/98125 for more details.
       registerCommand(`metals.symbol-search`, () =>
-        openSymbolSearch(client, metalsFileProvider, workspaceUri)
+        openSymbolSearch(client, metalsFileProvider, workspaceUri),
       );
 
       window.onDidChangeActiveTextEditor((editor) => {
         if (editor && isSupportedLanguage(editor.document.languageId)) {
           client.sendNotification(
             MetalsDidFocusType,
-            editor.document.uri.toString()
+            editor.document.uri.toString(),
           );
         }
       });
@@ -1263,18 +1263,18 @@ function launchMetals(
               {
                 location: ProgressLocation.Notification,
                 title: params.message + showLogs,
-                cancellable: true
+                cancellable: true,
               },
               (progress, progressToken) => {
                 // Update total running time every second.
                 let seconds = params.secondsElapsed || waitTime;
                 progress.report({
-                  message: readableSeconds(seconds)
+                  message: readableSeconds(seconds),
                 });
                 const interval = setInterval(() => {
                   seconds += 1;
                   progress.report({
-                    message: readableSeconds(seconds)
+                    message: readableSeconds(seconds),
                   });
                 }, 1000);
 
@@ -1297,7 +1297,7 @@ function launchMetals(
                     setTimeout(() => progressResolve(undefined), 1000);
                   });
                 });
-              }
+              },
             );
           }, delay * 1000);
 
@@ -1312,11 +1312,11 @@ function launchMetals(
       const packageJson = JSON.parse(
         fs.readFileSync(
           path.join(context.extensionPath, "package.json"),
-          "utf8"
-        )
+          "utf8",
+        ),
       );
       const viewIds = packageJson.contributes.views["metals-explorer"].map(
-        (view: { id: string }) => view.id
+        (view: { id: string }) => view.id,
       );
       treeViews = startTreeView(client, outputChannel, context, viewIds);
       context.subscriptions.concat(treeViews.disposables);
@@ -1329,17 +1329,17 @@ function launchMetals(
           const editors = window.visibleTextEditors;
           const path = Uri.parse(params.uri).toString();
           const workheetEditors = editors.filter(
-            (editor) => editor.document.uri.toString() == path
+            (editor) => editor.document.uri.toString() == path,
           );
           if (workheetEditors.length > 0) {
             const options = params.options.map<DecorationOptions>((o) => {
               return {
                 range: new Range(
                   new Position(o.range.start.line, o.range.start.character),
-                  new Position(o.range.end.line, o.range.end.character)
+                  new Position(o.range.end.line, o.range.end.character),
                 ),
                 hoverMessage: o.hoverMessage?.value,
-                renderOptions: o.renderOptions
+                renderOptions: o.renderOptions,
               };
             });
             workheetEditors.forEach((editor) => {
@@ -1351,10 +1351,10 @@ function launchMetals(
             });
           } else {
             outputChannel.appendLine(
-              `Ignoring decorations for non-active document '${params.uri}'.`
+              `Ignoring decorations for non-active document '${params.uri}'.`,
             );
           }
-        }
+        },
       );
       context.subscriptions.push(decorationsRangesDidChangeDispoasable);
       registerCommand("metals.debug.hotCodeReplace", () => {
@@ -1367,14 +1367,14 @@ function launchMetals(
         outputChannel.appendLine("Could not launch Metals Language Server:");
         outputChannel.appendLine(reason.message);
       }
-    }
+    },
   );
 }
 
 function trackDownloadProgress(
   title: string,
   output: OutputChannel,
-  download: ChildProcessPromise
+  download: ChildProcessPromise,
 ): Promise<string> {
   const progress = new LazyProgress();
   return downloadProgress({
@@ -1384,7 +1384,7 @@ function trackDownloadProgress(
     onProgress: (msg) => {
       output.appendLine(msg);
       progress.startOrContinue(title, output, download);
-    }
+    },
   });
 }
 
@@ -1410,7 +1410,7 @@ function enableScaladocIndentation() {
       // ^(.*\*/)?\s*\}.*$
       decreaseIndentPattern: /^(.*\*\/)?\s*\}.*$/,
       // ^.*\{[^}"']*$
-      increaseIndentPattern: /^.*\{[^}"']*$/
+      increaseIndentPattern: /^.*\{[^}"']*$/,
     },
     wordPattern:
       /(-?\d*\.\d\w*)|([^\`\~\!\@\#\%\^\&\*\(\)\-\=\+\[\{\]\}\\\|\;\:\'\"\,\.\<\>\/\?\s]+)/g,
@@ -1421,38 +1421,38 @@ function enableScaladocIndentation() {
         afterText: /^\s*\*\/$/,
         action: {
           indentAction: IndentAction.IndentOutdent,
-          appendText: " * "
-        }
+          appendText: " * ",
+        },
       },
       {
         // indent in places with optional braces
         beforeText: increaseIndentPattern(),
-        action: { indentAction: IndentAction.Indent }
+        action: { indentAction: IndentAction.Indent },
       },
       {
         // e.g. /** ...|
         beforeText: /^\s*\/\*\*(?!\/)([^\*]|\*(?!\/))*$/,
-        action: { indentAction: IndentAction.None, appendText: " * " }
+        action: { indentAction: IndentAction.None, appendText: " * " },
       },
       {
         // e.g.  * ...| Javadoc style
         beforeText: /^(\t|(\ \ ))*\ \*(\ ([^\*]|\*(?!\/))*)?$/,
-        action: { indentAction: IndentAction.None, appendText: "* " }
+        action: { indentAction: IndentAction.None, appendText: "* " },
       },
       {
         // e.g.  * ...| Scaladoc style
         beforeText: /^(\t|(\ \ ))*\*(\ ([^\*]|\*(?!\/))*)?$/,
-        action: { indentAction: IndentAction.None, appendText: "* " }
+        action: { indentAction: IndentAction.None, appendText: "* " },
       },
       {
         // e.g.  */|
         beforeText: /^(\t|(\ \ ))*\ \*\/\s*$/,
-        action: { indentAction: IndentAction.None, removeText: 1 }
+        action: { indentAction: IndentAction.None, removeText: 1 },
       },
       {
         // e.g.  *-----*/|
         beforeText: /^(\t|(\ \ ))*\ \*[^/]*\*\/\s*$/,
-        action: { indentAction: IndentAction.None, removeText: 1 }
+        action: { indentAction: IndentAction.None, removeText: 1 },
       },
       {
         // stop vscode from indenting automatically to last known indentation
@@ -1463,9 +1463,9 @@ function enableScaladocIndentation() {
          *}
          */
         afterText: /[^\]\}\)]+/,
-        action: { indentAction: IndentAction.None }
-      }
-    ]
+        action: { indentAction: IndentAction.None },
+      },
+    ],
   });
 }
 
@@ -1479,7 +1479,7 @@ function detectConfigurationChanges() {
           if (choice === reloadWindowChoice) {
             commands.executeCommand(workbenchCommands.reloadWindow);
           }
-        })
+        }),
   );
 }
 
@@ -1504,7 +1504,7 @@ function configureSettingsDefaults() {
     newValues: Record<string, boolean>,
     configurationTarget:
       | ConfigurationTarget.Global
-      | ConfigurationTarget.Workspace
+      | ConfigurationTarget.Workspace,
   ) {
     const config = workspace.getConfiguration(configKey);
     const configProperty = config.inspect<Record<string, boolean>>(propertyKey);
@@ -1519,7 +1519,7 @@ function configureSettingsDefaults() {
     config.update(
       propertyKey,
       { ...currentValues, ...newValues },
-      configurationTarget
+      configurationTarget,
     );
   }
   updateFileConfig(
@@ -1527,17 +1527,17 @@ function configureSettingsDefaults() {
     "watcherExclude",
     {
       "**/.bloop": true,
-      "**/.metals": true
+      "**/.metals": true,
     },
-    ConfigurationTarget.Global
+    ConfigurationTarget.Global,
   );
   updateFileConfig(
     "files",
     "watcherExclude",
     {
-      "**/target": true
+      "**/target": true,
     },
-    ConfigurationTarget.Workspace
+    ConfigurationTarget.Workspace,
   );
 }
 
@@ -1548,7 +1548,7 @@ function toggleInlayHintsSetting(setting: string) {
   config.update(
     `${setting}.enable`,
     !currentValues,
-    ConfigurationTarget.Workspace
+    ConfigurationTarget.Workspace,
   );
 }
 
@@ -1561,7 +1561,7 @@ function registerDebugEventListener(context: ExtensionContext) {
       ) {
         handleUserNotification(customEvent);
       }
-    })
+    }),
   );
 }
 

--- a/src/fetchMetals.ts
+++ b/src/fetchMetals.ts
@@ -23,16 +23,16 @@ export async function fetchMetals({
   serverVersion,
   serverProperties,
   javaConfig: { javaOptions, coursier, extraEnv, javaPath },
-  outputChannel
+  outputChannel,
 }: FetchMetalsOptions): Promise<PackedChildPromise> {
   const serverDependency = calcServerDependency(serverVersion);
 
   const fetchProperties = serverProperties.filter(
-    (p) => !p.startsWith("-agentlib")
+    (p) => !p.startsWith("-agentlib"),
   );
   if (fetchProperties.length != serverProperties.length) {
     outputChannel.appendLine(
-      'Ignoring "-agentlib" option when fetching Metals with Coursier'
+      'Ignoring "-agentlib" option when fetching Metals with Coursier',
     );
   }
 
@@ -53,14 +53,14 @@ export async function fetchMetals({
     "sonatype:snapshots",
     "-r",
     "https://central.sonatype.com/repository/maven-snapshots/",
-    "-p"
+    "-p",
   ];
 
   const environment = {
     env: {
       ...process.env,
-      ...extraEnv
-    }
+      ...extraEnv,
+    },
   };
 
   if (coursier.endsWith(".jar")) {
@@ -69,17 +69,17 @@ export async function fetchMetals({
       ...fetchProperties,
       "-Dfile.encoding=UTF-8",
       "-jar",
-      coursier
+      coursier,
     ].concat(coursierArgs);
     return { promise: spawn(javaPath, jarArgs, environment) };
   } else {
     const javaArgs: Array<string> = convertToCoursierProperties(
       javaOptions.concat(["-Dfile.encoding=UTF-8"]).concat(fetchProperties),
-      false
+      false,
     );
 
     return {
-      promise: spawn(coursier, javaArgs.concat(coursierArgs), environment)
+      promise: spawn(coursier, javaArgs.concat(coursierArgs), environment),
     };
   }
 }

--- a/src/findInFiles.ts
+++ b/src/findInFiles.ts
@@ -14,7 +14,7 @@ import {
   TreeView,
   Uri,
   window,
-  workspace
+  workspace,
 } from "vscode";
 import { LanguageClient, Location } from "vscode-languageclient/node";
 import { MetalsFileProvider } from "./metalsContentProvider";
@@ -22,7 +22,7 @@ import { MetalsFileProvider } from "./metalsContentProvider";
 class TopLevel {
   constructor(
     readonly positions: PositionInFile[],
-    readonly resourceUri: Uri
+    readonly resourceUri: Uri,
   ) {}
 
   readonly key = "TopLevel";
@@ -32,7 +32,7 @@ class PositionInFile {
   constructor(
     readonly location: Location,
     readonly uri: Uri,
-    readonly label: string
+    readonly label: string,
   ) {}
 
   readonly key = "PositionInFile";
@@ -41,12 +41,12 @@ class PositionInFile {
 type Node = TopLevel | PositionInFile;
 
 export function startFindInFilesProvider(
-  context: ExtensionContext
+  context: ExtensionContext,
 ): FindInFilesProvider {
   const findInFilesProvider = new FindInFilesProvider();
   const treeDataProvider = window.registerTreeDataProvider(
     "metalsFindInFiles",
-    findInFilesProvider
+    findInFilesProvider,
   );
   context.subscriptions.push(treeDataProvider);
 
@@ -55,12 +55,12 @@ export function startFindInFilesProvider(
 
 export function createFindInFilesTreeView(
   provider: FindInFilesProvider,
-  context: ExtensionContext
+  context: ExtensionContext,
 ): TreeView<unknown> {
   commands.executeCommand("setContext", "metals.showFindInFiles", false);
   const treeView = window.createTreeView("metalsFindInFiles", {
     treeDataProvider: provider,
-    showCollapseAll: true
+    showCollapseAll: true,
   });
 
   const didChangeSelection = treeView.onDidChangeSelection(async (e) => {
@@ -74,7 +74,7 @@ export function createFindInFilesTreeView(
         case "PositionInFile": {
           const positionInFile = head;
           const textDocument = await workspace.openTextDocument(
-            positionInFile.uri
+            positionInFile.uri,
           );
           const textEditor = await window.showTextDocument(textDocument);
           const range = positionInFile.location.range;
@@ -83,7 +83,7 @@ export function createFindInFilesTreeView(
           const selection = new Selection(end, start);
           const vscodeRange = new Range(
             new Position(range.start.line, range.start.character),
-            new Position(range.end.line, range.end.character)
+            new Position(range.end.line, range.end.character),
           );
           textEditor.revealRange(vscodeRange, TextEditorRevealType.InCenter);
           textEditor.selection = selection;
@@ -102,13 +102,13 @@ export async function executeFindInFiles(
   provider: FindInFilesProvider,
   view: TreeView<unknown>,
   metalsFileProvider: MetalsFileProvider,
-  outputChannel: OutputChannel
+  outputChannel: OutputChannel,
 ): Promise<void> {
   try {
     const include = await window
       .showInputBox({
         prompt: "Enter file mask",
-        placeHolder: ".conf"
+        placeHolder: ".conf",
       })
       .then((include) => {
         if (include === undefined) {
@@ -122,7 +122,7 @@ export async function executeFindInFiles(
 
     const pattern = await window
       .showInputBox({
-        prompt: "Enter search pattern"
+        prompt: "Enter search pattern",
       })
       .then((pattern) => {
         if (pattern === undefined) {
@@ -138,8 +138,8 @@ export async function executeFindInFiles(
       "metals/findTextInDependencyJars",
       {
         options: { include },
-        query: { pattern }
-      }
+        query: { pattern },
+      },
     );
 
     commands.executeCommand("setContext", "metals.showFindInFiles", true);
@@ -154,14 +154,14 @@ export async function executeFindInFiles(
     }
   } catch (error) {
     outputChannel.appendLine(
-      "Error finding text in dependency jars: " + JSON.stringify(error)
+      "Error finding text in dependency jars: " + JSON.stringify(error),
     );
   }
 }
 
 async function toTopLevel(
   locations: Location[],
-  metalsFileProvider: MetalsFileProvider
+  metalsFileProvider: MetalsFileProvider,
 ): Promise<TopLevel[]> {
   const locationsByFile = new Map<string, Location[]>();
 
@@ -193,7 +193,7 @@ async function toTopLevel(
       } else {
         return new TopLevel([] as PositionInFile[], uri);
       }
-    })
+    }),
   );
 }
 
@@ -209,7 +209,7 @@ class FindInFilesProvider implements TreeDataProvider<Node> {
         const topLevelResult: TreeItem = {
           resourceUri: element.resourceUri,
           description: element.resourceUri.path,
-          collapsibleState: TreeItemCollapsibleState.Expanded
+          collapsibleState: TreeItemCollapsibleState.Expanded,
         };
 
         return topLevelResult;
@@ -229,12 +229,12 @@ class FindInFilesProvider implements TreeDataProvider<Node> {
           end.character + trimmedLabel.length - element.label.length;
         const highlightedLabel: TreeItemLabel = {
           label: trimmedLabel,
-          highlights: [[trimmedStartCol, trimmedEndCol]]
+          highlights: [[trimmedStartCol, trimmedEndCol]],
         };
         const positionResult: TreeItem = {
           label: highlightedLabel,
           description: shortDescription,
-          resourceUri: element.uri
+          resourceUri: element.uri,
         };
 
         return positionResult;
@@ -261,7 +261,7 @@ class FindInFilesProvider implements TreeDataProvider<Node> {
         return Promise.resolve(undefined);
       case "PositionInFile":
         return Promise.resolve(
-          this.items.find((topLevel) => topLevel.positions.includes(element))
+          this.items.find((topLevel) => topLevel.positions.includes(element)),
         );
     }
   }

--- a/src/findOnPath.ts
+++ b/src/findOnPath.ts
@@ -7,7 +7,7 @@ import * as path from "path";
 export function toPromise<E, A>(te: TaskEither<E, A>): Promise<A> {
   return te().then(
     (res) =>
-      new Promise((resolve, reject) => pipe(res, E.fold(reject, resolve)))
+      new Promise((resolve, reject) => pipe(res, E.fold(reject, resolve))),
   );
 }
 
@@ -34,7 +34,7 @@ export function findOnPath(names: string[]) {
           return names.some(
             (name) =>
               p.endsWith(path.sep + name + ".bat") ||
-              p.endsWith(path.sep + name + ".exe")
+              p.endsWith(path.sep + name + ".exe"),
           );
         } else {
           return names.some((name) => p.endsWith(path.sep + name));

--- a/src/getJavaConfig.ts
+++ b/src/getJavaConfig.ts
@@ -26,7 +26,7 @@ export function getJavaConfig({
   javaHome,
   coursier,
   coursierMirrorFilePath,
-  customRepositories = []
+  customRepositories = [],
 }: GetJavaConfigOptions): JavaConfig {
   const javaOptions = getJavaOptions(workspaceRoot);
   const javaPath = path.join(javaHome.path, "bin", "java");
@@ -41,7 +41,7 @@ export function getJavaConfig({
 
   const extraEnv = {
     ...coursierRepositories,
-    ...coursierMirrors
+    ...coursierMirrors,
   };
 
   return {
@@ -50,6 +50,6 @@ export function getJavaConfig({
     javaHome,
     coursier,
     coursierMirrorFilePath,
-    extraEnv
+    extraEnv,
   };
 }

--- a/src/getJavaHome.ts
+++ b/src/getJavaHome.ts
@@ -24,7 +24,7 @@ export interface JavaHome {
  */
 export async function getJavaHome(
   javaVersion: JavaVersion,
-  outputChannel: OutputChannel
+  outputChannel: OutputChannel,
 ): Promise<JavaHome | undefined> {
   const fromEnvValue = await fromEnv(javaVersion, outputChannel);
   return fromEnvValue || (await fromPath(javaVersion, outputChannel));
@@ -34,12 +34,12 @@ const versionRegex = /\"\d\d/;
 export async function validateJavaVersion(
   javaHome: string,
   javaVersion: JavaVersion,
-  outputChannel: OutputChannel
+  outputChannel: OutputChannel,
 ): Promise<JavaHome | undefined> {
   const javaBin = path.join(javaHome, "bin", "java");
   try {
     const javaVersionOut = spawn(javaBin, ["-version"], {
-      encoding: "utf8"
+      encoding: "utf8",
     });
 
     javaVersionOut.stderr?.on("data", (out: Buffer) => {
@@ -53,7 +53,7 @@ export async function validateJavaVersion(
       return {
         path: javaHome,
         description: javaInfoStr,
-        version: matches[0].slice(1, 3)
+        version: matches[0].slice(1, 3),
       };
     }
   } catch (error) {
@@ -65,7 +65,7 @@ export async function validateJavaVersion(
 
 function propertyValueOf(
   input: string,
-  propertyName: string
+  propertyName: string,
 ): string | undefined {
   const start = input.indexOf(propertyName);
   if (start === -1) {
@@ -83,7 +83,7 @@ function propertyValueOf(
 
 export async function fromPath(
   javaVersion: JavaVersion,
-  outputChannel: OutputChannel
+  outputChannel: OutputChannel,
 ): Promise<JavaHome | undefined> {
   function getLastThreeLines(text: string): string {
     const lines = text.split(/\r?\n/);
@@ -93,7 +93,7 @@ export async function fromPath(
   if (javaExecutable) {
     const realJavaPath = realpathSync(javaExecutable);
     outputChannel.appendLine(
-      `Searching for Java on PATH. Found java executable under ${javaExecutable} that resolves to ${realJavaPath}`
+      `Searching for Java on PATH. Found java executable under ${javaExecutable} that resolves to ${realJavaPath}`,
     );
     const cmdArgs = ["-XshowSettings:properties", "-version"];
     try {
@@ -102,7 +102,7 @@ export async function fromPath(
       const discoveredJavaHome = propertyValueOf(cmdOutput, "java.home");
       const discoveredJavaVersion = propertyValueOf(
         cmdOutput,
-        "java.specification.version"
+        "java.specification.version",
       );
 
       if (
@@ -113,16 +113,16 @@ export async function fromPath(
         return {
           path: discoveredJavaHome,
           description: getLastThreeLines(cmdOutput),
-          version: discoveredJavaVersion
+          version: discoveredJavaVersion,
         };
       } else {
         outputChannel.appendLine(
-          `Java version doesn't match the required one of ${javaVersion}`
+          `Java version doesn't match the required one of ${javaVersion}`,
         );
       }
     } catch (error) {
       outputChannel.appendLine(
-        `Failed while running ${realJavaPath} ${cmdArgs.join(" ")}`
+        `Failed while running ${realJavaPath} ${cmdArgs.join(" ")}`,
       );
       outputChannel.appendLine(`${error}`);
     }
@@ -131,23 +131,23 @@ export async function fromPath(
 
 export async function fromEnv(
   javaVersion: JavaVersion,
-  outputChannel: OutputChannel
+  outputChannel: OutputChannel,
 ): Promise<JavaHome | undefined> {
   const javaHome = process.env["JAVA_HOME"];
   if (javaHome) {
     outputChannel.appendLine(
-      `Checking Java in JAVA_HOME, which points to ${javaHome}`
+      `Checking Java in JAVA_HOME, which points to ${javaHome}`,
     );
     const validatedJavaHome = await validateJavaVersion(
       javaHome,
       javaVersion,
-      outputChannel
+      outputChannel,
     );
     if (validatedJavaHome) {
       return validatedJavaHome;
     } else {
       outputChannel.appendLine(
-        `Java version doesn't match the required one of ${javaVersion}`
+        `Java version doesn't match the required one of ${javaVersion}`,
       );
     }
   }

--- a/src/getJavaOptions.ts
+++ b/src/getJavaOptions.ts
@@ -21,7 +21,7 @@ function sanitizeOption(option: string): string {
 
 export function convertToCoursierProperties(
   serverProperties: string[],
-  isCoursierJar: boolean
+  isCoursierJar: boolean,
 ): string[] {
   // setting properties on windows native launcher doesn't work
   if (!isCoursierJar && process.platform == "win32") {

--- a/src/getServerOptions.ts
+++ b/src/getServerOptions.ts
@@ -5,7 +5,7 @@ export function getServerOptions(
   metalsClasspath: string,
   serverProperties: string[],
   clientName: string,
-  javaConfig: JavaConfig
+  javaConfig: JavaConfig,
 ): ServerOptions {
   const baseProperties = ["-Xss4m", "-Xms100m"];
 
@@ -36,7 +36,7 @@ export function getServerOptions(
     ...baseProperties,
     ...javaConfig.javaOptions,
     ...filteredServerProperties,
-    ...mainArgs
+    ...mainArgs,
   ];
 
   const env = () => ({ ...process.env, ...javaConfig.extraEnv });
@@ -45,12 +45,12 @@ export function getServerOptions(
     run: {
       command: javaConfig.javaPath,
       args: launchArgs,
-      options: { env: env() }
+      options: { env: env() },
     },
     debug: {
       command: javaConfig.javaPath,
       args: launchArgs,
-      options: { env: env() }
-    }
+      options: { env: env() },
+    },
   };
 }

--- a/src/getServerVersion.ts
+++ b/src/getServerVersion.ts
@@ -3,7 +3,7 @@ import {
   ExtensionContext,
   window,
   WorkspaceConfiguration,
-  ConfigurationTarget as VConfigurationTarget
+  ConfigurationTarget as VConfigurationTarget,
 } from "vscode";
 import * as workbenchCommands from "./workbenchCommands";
 import http from "https";
@@ -18,7 +18,7 @@ const suggestLatestUpgrade = "suggestLatestUpgrade";
 
 export function getServerVersion(
   config: WorkspaceConfiguration,
-  context: ExtensionContext
+  context: ExtensionContext,
 ): string {
   /* eslint-disable @typescript-eslint/no-non-null-assertion */
   const serverVersionConfig = config.get<string>(serverVersionSection);
@@ -33,11 +33,11 @@ export function getServerVersion(
 async function validateCurrentVersion(
   serverVersion: string,
   config: WorkspaceConfiguration,
-  context: ExtensionContext
+  context: ExtensionContext,
 ): Promise<void> {
   const suggestUpgradeSetting = getConfigValue<boolean>(
     config,
-    suggestLatestUpgrade
+    suggestLatestUpgrade,
   );
 
   const checkForUpdateRepo = new DefaultCheckForUpdateRepo(context);
@@ -48,7 +48,7 @@ async function validateCurrentVersion(
         serverVersion,
         todayString(),
         fromVSCode(suggestUpgradeSetting.target),
-        checkForUpdateRepo
+        checkForUpdateRepo,
       );
     } else {
       return false;
@@ -69,19 +69,19 @@ async function validateCurrentVersion(
             config.update(
               serverVersionSection,
               nextVersion,
-              suggestUpgradeSetting.target
+              suggestUpgradeSetting.target,
             );
             checkForUpdateRepo.saveLastUpdated(
               nextVersion,
               todayString(),
-              fromVSCode(suggestUpgradeSetting.target)
+              fromVSCode(suggestUpgradeSetting.target),
             );
           } else if (result == ignoreChoice) {
             // extend the current version expiration date
             checkForUpdateRepo.saveLastUpdated(
               serverVersion,
               todayString(),
-              fromVSCode(suggestUpgradeSetting.target)
+              fromVSCode(suggestUpgradeSetting.target),
             );
           }
         });
@@ -122,13 +122,13 @@ function warnIfIsOutdated(config: WorkspaceConfiguration): void {
         message,
         upgradeChoice,
         openSettingsChoice,
-        dismissChoice
+        dismissChoice,
       } = outdatedParams;
       const choice = await window.showWarningMessage(
         message,
         upgradeChoice,
         openSettingsChoice,
-        dismissChoice
+        dismissChoice,
       );
       switch (choice) {
         case upgradeChoice:
@@ -138,7 +138,7 @@ function warnIfIsOutdated(config: WorkspaceConfiguration): void {
           commands.executeCommand(workbenchCommands.openSettings);
           break;
       }
-    }
+    },
   });
 }
 

--- a/src/goToLocation.ts
+++ b/src/goToLocation.ts
@@ -10,13 +10,13 @@ export interface WindowLocation {
 
 export function gotoLocation(
   location: WindowLocation,
-  metalsFileProvider?: MetalsFileProvider
+  metalsFileProvider?: MetalsFileProvider,
 ): void {
   const range = new Range(
     location.range.start.line,
     location.range.start.character,
     location.range.end.line,
-    location.range.end.character
+    location.range.end.character,
   );
   let vs = ViewColumn.Active;
   if (location.otherWindow) {
@@ -25,7 +25,7 @@ export function gotoLocation(
         .filter(
           (vte) =>
             window.activeTextEditor?.document.uri.scheme != "output" &&
-            vte.viewColumn
+            vte.viewColumn,
         )
         .pop()?.viewColumn || ViewColumn.Beside;
   }
@@ -37,7 +37,7 @@ export function gotoLocation(
   workspace.openTextDocument(uri).then((textDocument) =>
     window.showTextDocument(textDocument, {
       selection: range,
-      viewColumn: vs
-    })
+      viewColumn: vs,
+    }),
   );
 }

--- a/src/hoverExtension.ts
+++ b/src/hoverExtension.ts
@@ -4,11 +4,11 @@ import {
   Range,
   RequestType,
   TextDocumentIdentifier,
-  WorkDoneProgressParams
+  WorkDoneProgressParams,
 } from "vscode-languageclient";
 
 export const hover = new RequestType<HoverParams, Hover | null, void>(
-  "textDocument/hover"
+  "textDocument/hover",
 );
 
 export interface HoverParams extends WorkDoneProgressParams {

--- a/src/interfaces/ClientCommands.ts
+++ b/src/interfaces/ClientCommands.ts
@@ -48,7 +48,7 @@ export const ClientCommands = {
   /**
    * Connect or reconnect to build server.
    */
-  BuildConnect: "metals-build-connect"
+  BuildConnect: "metals-build-connect",
 } as const;
 
 export type ClientCommands = typeof ClientCommands;

--- a/src/interfaces/ConfigurationTarget.ts
+++ b/src/interfaces/ConfigurationTarget.ts
@@ -1,5 +1,5 @@
 export enum ConfigurationTarget {
   Global = 1,
   Workspace = 2,
-  WorkspaceFolder = 3
+  WorkspaceFolder = 3,
 }

--- a/src/interfaces/DebugDiscoveryParams.ts
+++ b/src/interfaces/DebugDiscoveryParams.ts
@@ -13,5 +13,5 @@ export enum RunType {
   Run = "run",
   RunOrTestFile = "runOrTestFile",
   TestFile = "testFile",
-  TestTarget = "testTarget"
+  TestTarget = "testTarget",
 }

--- a/src/interfaces/Extensions.ts
+++ b/src/interfaces/Extensions.ts
@@ -1,6 +1,6 @@
 import {
   NotificationType,
-  ExecuteCommandParams
+  ExecuteCommandParams,
 } from "vscode-languageserver-protocol";
 
 /**
@@ -24,7 +24,7 @@ export const ExecuteClientCommandType =
  * - https://scalameta.org/metals/docs/editors/new-editor.html#metalsdidfocustextdocument
  */
 export const MetalsDidFocusTypeType = new NotificationType<string>(
-  "metals/didFocusTextDocument"
+  "metals/didFocusTextDocument",
 );
 
 /**

--- a/src/interfaces/LanguageClient.ts
+++ b/src/interfaces/LanguageClient.ts
@@ -1,13 +1,13 @@
 import {
   RequestType0,
   CancellationToken,
-  NotificationType0
+  NotificationType0,
 } from "vscode-languageserver-protocol";
 
 export interface LanguageClient {
   sendRequest<R, E>(
     type: RequestType0<R, E>,
-    token?: CancellationToken
+    token?: CancellationToken,
   ): Thenable<R>;
   sendNotification(type: NotificationType0): void;
 }

--- a/src/interfaces/MetalsInputBox.ts
+++ b/src/interfaces/MetalsInputBox.ts
@@ -15,7 +15,7 @@ export const MetalsInputBoxType = new RequestType<
 >("metals/inputBox");
 
 export const MetalsInputBoxHandle = function (
-  result: string | undefined
+  result: string | undefined,
 ): MetalsInputBoxResult {
   if (result === undefined || result.trim() === "") {
     return { cancelled: true };
@@ -43,7 +43,7 @@ export interface InputBoxOptions {
   value?: string;
   /** * Selection of the prefilled [`value`](#InputBoxOptions.value). Defined as tuple of two number where the * first is the inclusive start index and the second the exclusive end index. When `undefined` the whole * word will be selected, when empty (start equals end) only the cursor will be set, * otherwise the defined range will be selected.  */ valueSelection?: [
     number,
-    number
+    number,
   ];
 
   /**
@@ -75,6 +75,6 @@ export interface InputBoxOptions {
    * Return `undefined`, `null`, or the empty string when 'value' is valid.
    */
   validateInput?(
-    value: string
+    value: string,
   ): string | undefined | null | Thenable<string | undefined | null>;
 }

--- a/src/interfaces/MetalsStatus.ts
+++ b/src/interfaces/MetalsStatus.ts
@@ -11,7 +11,7 @@ import { NotificationType } from "vscode-languageserver-protocol";
  * that they should not demand too much attention from the user.
  */
 export const MetalsStatusType = new NotificationType<MetalsStatusParams>(
-  "metals/status"
+  "metals/status",
 );
 
 export interface MetalsStatusParams {

--- a/src/interfaces/ServerCommands.ts
+++ b/src/interfaces/ServerCommands.ts
@@ -116,7 +116,7 @@ export const ServerCommands = {
   /**
    * Delete all directories in .bloop and restart the Bloop server.
    */
-  ResetWorkspace: "reset-workspace"
+  ResetWorkspace: "reset-workspace",
 } as const;
 
 type ServerCommands = typeof ServerCommands;

--- a/src/interfaces/ShowMessage.ts
+++ b/src/interfaces/ShowMessage.ts
@@ -46,7 +46,7 @@ export function normalize(showMessage: ShowMessage): VSCodeShowMessage {
       showErrorMessage(message) {
         showMessage.showMessage(message, "error");
         return Promise.resolve(undefined);
-      }
+      },
     };
   }
   return showMessage;

--- a/src/interfaces/TreeViewProtocol.ts
+++ b/src/interfaces/TreeViewProtocol.ts
@@ -5,7 +5,7 @@ import {
   Command,
   RequestType,
   NotificationType,
-  TextDocumentPositionParams
+  TextDocumentPositionParams,
 } from "vscode-languageserver-protocol";
 
 export interface MetalsTreeViews {
@@ -61,7 +61,7 @@ export interface MetalsTreeViewDidChangeParams {
 }
 export const MetalsTreeViewDidChangeType =
   new NotificationType<MetalsTreeViewDidChangeParams>(
-    "metals/treeViewDidChange"
+    "metals/treeViewDidChange",
   );
 
 export interface MetalsTreeViewParentParams {
@@ -88,7 +88,7 @@ export interface MetalsTreeViewVisibilityDidChangeParams {
 
 export const MetalsTreeViewVisibilityDidChangeType =
   new NotificationType<MetalsTreeViewVisibilityDidChangeParams>(
-    "metals/treeViewVisibilityDidChange"
+    "metals/treeViewVisibilityDidChange",
   );
 
 export interface MetalsTreeViewNodeCollapseDidChangeParams {
@@ -102,7 +102,7 @@ export interface MetalsTreeViewNodeCollapseDidChangeParams {
 
 export const MetalsTreeViewNodeCollapseDidChangeType =
   new NotificationType<MetalsTreeViewNodeCollapseDidChangeParams>(
-    "metals/treeViewNodeCollapseDidChange"
+    "metals/treeViewNodeCollapseDidChange",
   );
 
 export interface MetalsTreeRevealResult {

--- a/src/interfaces/UserConfiguration.ts
+++ b/src/interfaces/UserConfiguration.ts
@@ -28,5 +28,5 @@ export enum UserConfiguration {
   /**
    * Repository to use instead of maven central for example `https://jcenter.bintray.com`
    */
-  CoursierMirror = "coursierMirror"
+  CoursierMirror = "coursierMirror",
 }

--- a/src/isDottyIdeEnabled.ts
+++ b/src/isDottyIdeEnabled.ts
@@ -7,16 +7,16 @@ import { existsSync } from "fs";
  * @param workspaceRoot the workspace root, if defined
  */
 export function checkDottyIde(
-  workspaceRoot: string | undefined
+  workspaceRoot: string | undefined,
 ): { enabled: true; path: string } | { enabled: false } {
   if (workspaceRoot) {
     const dottyIdeArtifactPath = path.join(
       workspaceRoot,
-      ".dotty-ide-artifact"
+      ".dotty-ide-artifact",
     );
     return {
       enabled: existsSync(dottyIdeArtifactPath),
-      path: dottyIdeArtifactPath
+      path: dottyIdeArtifactPath,
     };
   }
   return { enabled: false };

--- a/src/lazyProgress.ts
+++ b/src/lazyProgress.ts
@@ -8,7 +8,7 @@ export class LazyProgress {
   startOrContinue(
     title: string,
     output: OutputChannel,
-    download: Promise<unknown>
+    download: Promise<unknown>,
   ): void {
     if (!this.progress) {
       this.progress = window.withProgress(
@@ -28,7 +28,7 @@ export class LazyProgress {
                 output.hide();
               })
               .then(complete, complete);
-          })
+          }),
       );
     }
   }

--- a/src/metalsContentProvider.ts
+++ b/src/metalsContentProvider.ts
@@ -4,7 +4,7 @@ import {
   TextDocumentContentProvider,
   Uri,
   window,
-  workspace
+  workspace,
 } from "vscode";
 import { ExecuteCommandRequest } from "vscode-languageclient";
 import { LanguageClient } from "vscode-languageclient/node";
@@ -32,7 +32,7 @@ export class MetalsFileProvider implements TextDocumentContentProvider {
       .sendRequest(ExecuteCommandRequest.type, {
         command: ServerCommands.DecodeFile,
         // skip encoding - jar:file: gets too aggressively encoded
-        arguments: [uri.toString(true)]
+        arguments: [uri.toString(true)],
       })
       .then((result) => {
         const { value, error } = result as DecoderResponse;
@@ -59,7 +59,7 @@ export async function decodeAndShowFile(
   client: LanguageClient,
   metalsFileProvider: MetalsFileProvider,
   uri: Uri | undefined,
-  decodeExtension: DecodeExtension
+  decodeExtension: DecodeExtension,
 ): Promise<void> {
   // returns an active editor uri, fallbacks to currently active file
   function uriWithFallback(): Uri | undefined {
@@ -70,7 +70,7 @@ export async function decodeAndShowFile(
       const editor = window.visibleTextEditors.find(
         (e) =>
           isSupportedLanguage(e.document.languageId) ||
-          e.document.fileName.endsWith(decodeExtension)
+          e.document.fileName.endsWith(decodeExtension),
       );
       return editor?.document.uri;
     }
@@ -99,8 +99,8 @@ export async function decodeAndShowFile(
           "metals.choose-class",
           {
             textDocument: { uri: currentUri.toString() },
-            kind: decodeExtension === "tasty-decoded" ? "tasty" : "class"
-          }
+            kind: decodeExtension === "tasty-decoded" ? "tasty" : "class",
+          },
         );
         if (value) {
           uriToResource = Uri.parse(value);
@@ -111,7 +111,7 @@ export async function decodeAndShowFile(
 
       if (uriToResource) {
         uriWithParams = Uri.parse(
-          `metalsDecode:${uriToResource.toString()}.${decodeExtension}`
+          `metalsDecode:${uriToResource.toString()}.${decodeExtension}`,
         );
       }
     }

--- a/src/mirrors.ts
+++ b/src/mirrors.ts
@@ -9,7 +9,7 @@ const mirrorProperty = "coursierMirror";
  * @returns path to the mirror config file described in https://get-coursier.io/blog/#mirrors
  */
 export function getCoursierMirrorPath(
-  config: WorkspaceConfiguration
+  config: WorkspaceConfiguration,
 ): string | undefined {
   const mirrorConfig = getConfigValue<string>(config, mirrorProperty);
 
@@ -27,7 +27,7 @@ function writeMirrorFile(mirrorString: string, target: ConfigurationTarget) {
   const file = path.join(dotMetalsDir, "mirror.properties");
   const mirrorContents = [
     "metals.from=https://repo1.maven.org/maven2",
-    `metals.to=${mirrorString}`
+    `metals.to=${mirrorString}`,
   ].join("\n");
   fs.writeFileSync(file, mirrorContents);
   return file;

--- a/src/openSymbolSearch.ts
+++ b/src/openSymbolSearch.ts
@@ -4,7 +4,7 @@ import {
   SymbolInformation,
   CancellationTokenSource,
   SymbolKind,
-  Uri
+  Uri,
 } from "vscode";
 import { LanguageClient, Location } from "vscode-languageclient/node";
 import { gotoLocation, WindowLocation } from "./goToLocation";
@@ -30,7 +30,7 @@ class SymbolItem implements QuickPickItem {
     this.alwaysShow = true;
     this.location = Location.create(
       si.location.uri.toString(),
-      si.location.range
+      si.location.range,
     );
   }
 }
@@ -38,7 +38,7 @@ class SymbolItem implements QuickPickItem {
 export function openSymbolSearch(
   client: LanguageClient,
   metalsFileProvider: MetalsFileProvider,
-  workspace: Uri | undefined
+  workspace: Uri | undefined,
 ): void {
   const inputBox = window.createQuickPick<SymbolItem>();
   inputBox.placeholder =
@@ -48,7 +48,7 @@ export function openSymbolSearch(
 
   const activeTextEditor = window.activeTextEditor;
   const wordRange = activeTextEditor?.document?.getWordRangeAtPosition(
-    activeTextEditor?.selection.active
+    activeTextEditor?.selection.active,
   );
   const wordUnderCursor =
     wordRange && activeTextEditor?.document?.getText(wordRange);
@@ -68,7 +68,7 @@ export function openSymbolSearch(
       .sendRequest(
         "workspace/symbol",
         { query: inputBox.value },
-        cancelToken.token
+        cancelToken.token,
       )
       .then((v) => {
         const symbols = v as SymbolInformation[];
@@ -82,7 +82,7 @@ export function openSymbolSearch(
     const windowLocation: WindowLocation = {
       uri: location.uri,
       range: location.range,
-      otherWindow: false
+      otherWindow: false,
     };
     inputBox.dispose();
 

--- a/src/releaseNotesProvider.ts
+++ b/src/releaseNotesProvider.ts
@@ -22,7 +22,7 @@ export async function showReleaseNotes(
   calledOn: CalledOn,
   context: ExtensionContext,
   serverVersion: string,
-  outputChannel: vscode.OutputChannel
+  outputChannel: vscode.OutputChannel,
 ): Promise<void> {
   try {
     const result = await showReleaseNotesImpl(calledOn, context, serverVersion);
@@ -32,7 +32,7 @@ export async function showReleaseNotes(
     }
   } catch (error) {
     outputChannel.appendLine(
-      `Error, couldn't show release notes for Metals ${serverVersion}`
+      `Error, couldn't show release notes for Metals ${serverVersion}`,
     );
     outputChannel.appendLine(`${error}`);
   }
@@ -41,7 +41,7 @@ export async function showReleaseNotes(
 async function showReleaseNotesImpl(
   calledOn: CalledOn,
   context: ExtensionContext,
-  currentVersion: string
+  currentVersion: string,
 ): Promise<Either<string, void>> {
   const state = context.globalState;
 
@@ -69,28 +69,28 @@ async function showReleaseNotesImpl(
   async function showPanel(version: string, releaseNotesUrl: string) {
     const timeoutMs = 10000; // 10 seconds timeout
     const timeoutPromise = new Promise<(_: vscode.Uri) => string>((_, reject) =>
-      setTimeout(() => reject(new Error("Request timed out")), timeoutMs)
+      setTimeout(() => reject(new Error("Request timed out")), timeoutMs),
     );
     const releaseNotes = await Promise.race([
       getReleaseNotesMarkdown(releaseNotesUrl),
-      timeoutPromise
+      timeoutPromise,
     ]);
 
     const panel = vscode.window.createWebviewPanel(
       `scalameta.metals.whatsNew`,
       `Metals ${version} release notes`,
-      vscode.ViewColumn.One
+      vscode.ViewColumn.One,
     );
 
     panel.iconPath = vscode.Uri.file(
-      path.join(context.extensionPath, "icons", "scalameta-logo.png")
+      path.join(context.extensionPath, "icons", "scalameta-logo.png"),
     );
 
     // Uri with additional styles for webview
     const stylesPathMainPath = vscode.Uri.joinPath(
       context.extensionUri,
       "media",
-      "styles.css"
+      "styles.css",
     );
 
     // need to transform Uri
@@ -149,7 +149,7 @@ async function showReleaseNotesImpl(
     return isNewerVersion
       ? makeRight(cleanVersion)
       : makeLeft(
-          `not showing release notes since they've already been seen for your current version`
+          `not showing release notes since they've already been seen for your current version`,
         );
   }
 }
@@ -163,13 +163,13 @@ async function showReleaseNotesImpl(
  * contains can be converted to name of markdown file with release notes.
  */
 async function getMarkdownLink(
-  version: string
+  version: string,
 ): Promise<Either<string, string>> {
   const releaseInfoUrl = `https://api.github.com/repos/scalameta/metals/releases/tags/v${version}`;
   const options = {
     headers: {
-      "User-Agent": "metals"
-    }
+      "User-Agent": "metals",
+    },
   };
   const stringifiedContent = await fetchFrom(releaseInfoUrl, options);
   const body = JSON.parse(stringifiedContent)["body"] as string;
@@ -181,7 +181,7 @@ async function getMarkdownLink(
 
   // matches (2022)/(06)/(03)/(aluminium) via capture groups
   const matchResult = body.match(
-    new RegExp("(\\d\\d\\d\\d)/(\\d\\d)/(\\d\\d)/(\\w+)")
+    new RegExp("(\\d\\d\\d\\d)/(\\d\\d)/(\\d\\d)/(\\w+)"),
   );
   // whole expression + 4 capture groups = 5 entries
   if (matchResult?.length === 5) {
@@ -218,11 +218,11 @@ interface Authors {
  * proxy to webview.asWebviewUri
  */
 async function getReleaseNotesMarkdown(
-  releaseNotesUrl: string
+  releaseNotesUrl: string,
 ): Promise<(_: vscode.Uri) => string> {
   const text = await fetchFrom(releaseNotesUrl);
   const authorsYaml = await fetchFrom(
-    "https://raw.githubusercontent.com/scalameta/metals/main/website/blog/authors.yml"
+    "https://raw.githubusercontent.com/scalameta/metals/main/website/blog/authors.yml",
   );
   const authors = load(authorsYaml) as Authors;
   // every release notes starts with metadata format

--- a/src/repository/CheckForUpdateRepo.ts
+++ b/src/repository/CheckForUpdateRepo.ts
@@ -11,7 +11,7 @@ export interface CheckForUpdateRepo {
   saveLastUpdated(
     serverVersion: string,
     lastUpdatedAt: string,
-    target: ConfigurationTarget
+    target: ConfigurationTarget,
   ): void;
 }
 
@@ -27,14 +27,14 @@ export class DefaultCheckForUpdateRepo implements CheckForUpdateRepo {
     const lastUpdatedAt = state.get<string>(this.LastUpdatedAtKey);
     return {
       prevVersion,
-      lastUpdatedAt
+      lastUpdatedAt,
     };
   }
 
   saveLastUpdated(
     serverVersion: string,
     lastUpdatedAt: string,
-    target: ConfigurationTarget
+    target: ConfigurationTarget,
   ): void {
     const state = this.storage(target);
     state.update(this.CurrentVersionKey, serverVersion);

--- a/src/service/checkForUpdate.ts
+++ b/src/service/checkForUpdate.ts
@@ -10,7 +10,7 @@ export async function needCheckForUpdates(
   currentVersion: string,
   today: string,
   target: ConfigurationTarget,
-  repo: CheckForUpdateRepo
+  repo: CheckForUpdateRepo,
 ): Promise<boolean> {
   const { prevVersion, lastUpdatedAt } = repo.getLastUpdated(target);
 

--- a/src/setupCoursier.ts
+++ b/src/setupCoursier.ts
@@ -2,13 +2,13 @@ import {
   ChildProcessPromise,
   Output,
   PromisifySpawnOptions,
-  spawn
+  spawn,
 } from "promisify-child-process";
 import {
   JavaHome,
   JavaVersion,
   getJavaHome,
-  validateJavaVersion
+  validateJavaVersion,
 } from "./getJavaHome";
 import { OutputChannel } from "./interfaces/OutputChannel";
 import path from "path";
@@ -28,7 +28,7 @@ export async function setupCoursier(
   extensionPath: string,
   output: OutputChannel,
   forceCoursierJar: boolean,
-  serverProperties: string[]
+  serverProperties: string[],
 ): Promise<{ coursier: string; javaHome: JavaHome }> {
   const handleOutput = (out: Buffer) => {
     const msg = "\t" + out.toString().trim().split("\n").join("\n\t");
@@ -57,10 +57,10 @@ export async function setupCoursier(
           fs.rmSync(defaultCoursier, { force: true });
         }
         output.appendLine(
-          "Failed to fetch coursier. You may want to try installing coursier manually and adding it to PATH."
+          "Failed to fetch coursier. You may want to try installing coursier manually and adding it to PATH.",
         );
         output.appendLine(
-          "Will try to use jar based coursier if Java is available on the machine."
+          "Will try to use jar based coursier if Java is available on the machine.",
         );
         return undefined;
       });
@@ -69,7 +69,7 @@ export async function setupCoursier(
   const resolveJavaHomeWithCoursier = async (coursier: string) => {
     const nonJvmServerProperties = convertToCoursierProperties(
       serverProperties,
-      coursier.endsWith(".jar")
+      coursier.endsWith(".jar"),
     );
     try {
       // This seems to throw on Windows despite the fact that the path exists
@@ -80,9 +80,9 @@ export async function setupCoursier(
           ...nonJvmServerProperties,
           "--jvm",
           `temurin:${javaVersion}`,
-          "-version"
+          "-version",
         ],
-        handleOutput
+        handleOutput,
       );
     } catch (err) {
       output.appendLine(`Error checking downloading java version: ${err}`);
@@ -94,11 +94,11 @@ export async function setupCoursier(
         "java-home",
         ...nonJvmServerProperties,
         "--jvm",
-        `temurin:${javaVersion}`
+        `temurin:${javaVersion}`,
       ],
       {
-        encoding: "utf8"
-      }
+        encoding: "utf8",
+      },
     );
 
     getJavaPath.stderr?.on("data", (out: Buffer) => {
@@ -127,13 +127,13 @@ export async function setupCoursier(
 
   if (!javaHome && coursier) {
     output.appendLine(
-      `No installed java with version ${javaVersion} found. Will fetch one using coursier:`
+      `No installed java with version ${javaVersion} found. Will fetch one using coursier:`,
     );
     const coursierJavaHome = await resolveJavaHomeWithCoursier(coursier);
     const validatedJavaHome = await validateJavaVersion(
       coursierJavaHome,
       javaVersion,
-      output
+      output,
     );
     if (validatedJavaHome) {
       javaHome = validatedJavaHome;
@@ -154,13 +154,13 @@ export async function setupCoursier(
   } else {
     throw Error(
       `Cannot resolve Java home or coursier, JAVA_HOME should exist with a version of at least ${javaVersion}.` +
-        `Alternatively, you can reduce the requirement using "metals.javaVersion" setting and override the path using "metals.metalsJavaHome" setting.`
+        `Alternatively, you can reduce the requirement using "metals.javaVersion" setting and override the path using "metals.metalsJavaHome" setting.`,
     );
   }
 }
 
 export async function validateCoursier(
-  defaultCoursier?: string | undefined
+  defaultCoursier?: string | undefined,
 ): Promise<string | undefined> {
   const validate = async (coursier: string) => {
     try {
@@ -192,18 +192,18 @@ export async function validateCoursier(
 
 export async function fetchCoursier(
   coursierFetchPath: string,
-  handleOutput: (out: Buffer) => void
+  handleOutput: (out: Buffer) => void,
 ) {
   async function runChainedCommands(
     command: string[],
-    initValue?: Promise<Output> | undefined
+    initValue?: Promise<Output> | undefined,
   ) {
     const out = command.reduce((acc, curr) => {
       const res = () => {
         const commandArr = curr.split(" ");
         return run(commandArr[0], commandArr.slice(1), handleOutput, {
           cwd: coursierFetchPath,
-          shell: true
+          shell: true,
         });
       };
       return acc ? acc.then(() => res()) : res();
@@ -216,7 +216,7 @@ export async function fetchCoursier(
     return runChainedCommands([
       `curl -fLo cs-x86_64-pc-win32.zip https://github.com/coursier/launchers/raw/${coursierCommit}/cs-x86_64-pc-win32.zip`,
       "tar -xf cs-x86_64-pc-win32.zip",
-      "move cs-x86_64-pc-win32.exe cs.exe"
+      "move cs-x86_64-pc-win32.exe cs.exe",
     ]);
   } else {
     const gzPath =
@@ -232,7 +232,7 @@ export async function fetchCoursier(
     const command = `curl -fL ${gzPath} | gzip -d > cs && chmod +x cs`;
     const result = await run(command, undefined, handleOutput, {
       shell: true,
-      cwd: coursierFetchPath
+      cwd: coursierFetchPath,
     });
     return result.code;
   }
@@ -242,7 +242,7 @@ function run(
   command: string,
   args?: string[],
   handleOutput?: (out: Buffer) => void | undefined,
-  options?: PromisifySpawnOptions | undefined
+  options?: PromisifySpawnOptions | undefined,
 ): ChildProcessPromise {
   const result = args ? spawn(command, args, options) : spawn(command, options);
   if (handleOutput) {

--- a/src/test/extension/runTest.ts
+++ b/src/test/extension/runTest.ts
@@ -7,7 +7,7 @@ async function main(): Promise<void> {
     // Passed to `--extensionDevelopmentPath`
     const extensionDevelopmentPath: string = path.resolve(
       __dirname,
-      "../../../"
+      "../../../",
     );
 
     // The path to the extension test script
@@ -23,7 +23,7 @@ async function main(): Promise<void> {
       version: "1.89.1",
       reuseMachineInstall: true,
       launchArgs: ["--disable-extension"],
-      reporter
+      reporter,
     });
   } catch (_err) {
     process.exit(1);

--- a/src/test/extension/suites/index.ts
+++ b/src/test/extension/suites/index.ts
@@ -3,7 +3,7 @@ import Mocha from "mocha";
 import { glob } from "glob";
 export function run(
   testsRoot: string,
-  cb: (error: unknown, failures?: number) => void
+  cb: (error: unknown, failures?: number) => void,
 ): void {
   // Create the mocha test
   const mocha = new Mocha({ ui: "tdd" });

--- a/src/test/extension/suites/testExplorer/analyzeTestRun.test.ts
+++ b/src/test/extension/suites/testExplorer/analyzeTestRun.test.ts
@@ -5,7 +5,7 @@ import {
   SuiteName,
   TestName,
   TestRunActions,
-  TestSuiteResult
+  TestSuiteResult,
 } from "../../../../testExplorer/types";
 import { refineRunnableTestItem } from "../../../../testExplorer/util";
 import { buildTarget } from "./util";
@@ -18,9 +18,9 @@ const passed: TestSuiteResult[] = [
     duration: 100,
     tests: [
       { kind: "passed", testName: "TestSuite.test1" as TestName, duration: 10 },
-      { kind: "passed", testName: "TestSuite.test2" as TestName, duration: 90 }
-    ]
-  }
+      { kind: "passed", testName: "TestSuite.test2" as TestName, duration: 90 },
+    ],
+  },
 ];
 
 const failed: TestSuiteResult[] = [
@@ -33,12 +33,12 @@ const failed: TestSuiteResult[] = [
         testName: "TestSuite.test1" as TestName,
         error: "Error",
         duration: 10,
-        location: { file: "file://test", line: 1 }
+        location: { file: "file://test", line: 1 },
       },
       { kind: "passed", testName: "TestSuite.test2" as TestName, duration: 90 },
-      { kind: "skipped", testName: "TestSuite.test3" as TestName }
-    ]
-  }
+      { kind: "skipped", testName: "TestSuite.test3" as TestName },
+    ],
+  },
 ];
 
 interface TestResults {
@@ -58,7 +58,7 @@ function getRunActions(): [TestRunActions, TestResults] {
     failed: (
       test: vscode.TestItem,
       msg: vscode.TestMessage | readonly vscode.TestMessage[],
-      duration?: number
+      duration?: number,
     ) => {
       results.failed.push({ id: test.id, duration, msg });
     },
@@ -69,7 +69,7 @@ function getRunActions(): [TestRunActions, TestResults] {
 
     skipped: (test: vscode.TestItem) => {
       results.skipped.push({ id: test.id });
-    }
+    },
   };
 
   return [actions, results];
@@ -82,7 +82,7 @@ function arrayEqual<T>(actual: T[], expected: T[]): void {
 suite("Analyze tests results", () => {
   const testController = vscode.tests.createTestController(
     "testController",
-    "Test Explorer"
+    "Test Explorer",
   );
 
   test("suite passed", () => {
@@ -93,7 +93,7 @@ suite("Analyze tests results", () => {
       testItem,
       targetUri,
       targetName,
-      testItem
+      testItem,
     );
     analyzeTestRun(action, [refined], passed);
     arrayEqual(results.failed, []);
@@ -111,7 +111,7 @@ suite("Analyze tests results", () => {
       testItem,
       targetUri,
       targetName,
-      testItem
+      testItem,
     );
 
     analyzeTestRun(action, [refined], failed);
@@ -124,11 +124,11 @@ suite("Analyze tests results", () => {
             message: "Error",
             location: new vscode.Location(
               vscode.Uri.parse("file://test"),
-              new vscode.Position(1, 0)
-            )
-          }
-        ]
-      }
+              new vscode.Position(1, 0),
+            ),
+          },
+        ],
+      },
     ]);
     arrayEqual(results.skipped, []);
     arrayEqual(results.passed, []);
@@ -142,7 +142,7 @@ suite("Analyze tests results", () => {
       testItem,
       targetUri,
       targetName,
-      testItem
+      testItem,
     );
     const child1 = testController.createTestItem("test1", "test1");
     const child2 = testController.createTestItem("test2", "test2");
@@ -153,16 +153,22 @@ suite("Analyze tests results", () => {
         child1,
         targetUri,
         targetName,
-        refined
+        refined,
       ),
       refineRunnableTestItem(
         "testcase",
         child2,
         targetUri,
         targetName,
-        refined
+        refined,
       ),
-      refineRunnableTestItem("testcase", child3, targetUri, targetName, refined)
+      refineRunnableTestItem(
+        "testcase",
+        child3,
+        targetUri,
+        targetName,
+        refined,
+      ),
     ]);
 
     analyzeTestRun(action, [refined], failed);
@@ -174,10 +180,10 @@ suite("Analyze tests results", () => {
           message: "Error",
           location: new vscode.Location(
             vscode.Uri.parse("file://test"),
-            new vscode.Position(1, 0)
-          )
-        }
-      }
+            new vscode.Position(1, 0),
+          ),
+        },
+      },
     ]);
     arrayEqual(results.passed, [{ id: "test2", duration: 90 }]);
     arrayEqual(results.skipped, [{ id: "test3" }]);
@@ -191,7 +197,7 @@ suite("Analyze tests results", () => {
       testItem,
       targetUri,
       targetName,
-      testItem
+      testItem,
     );
     const child1 = testController.createTestItem("test1", "test1");
     const child2 = testController.createTestItem("test2", "test2");
@@ -201,7 +207,7 @@ suite("Analyze tests results", () => {
       child1,
       targetUri,
       targetName,
-      refined
+      refined,
     );
     [
       refinedChild,
@@ -210,9 +216,15 @@ suite("Analyze tests results", () => {
         child2,
         targetUri,
         targetName,
-        refined
+        refined,
       ),
-      refineRunnableTestItem("testcase", child3, targetUri, targetName, refined)
+      refineRunnableTestItem(
+        "testcase",
+        child3,
+        targetUri,
+        targetName,
+        refined,
+      ),
     ].forEach((c) => refined.children.add(c));
 
     analyzeTestRun(action, [refinedChild], failed);
@@ -224,10 +236,10 @@ suite("Analyze tests results", () => {
           message: "Error",
           location: new vscode.Location(
             vscode.Uri.parse("file://test"),
-            new vscode.Position(1, 0)
-          )
-        }
-      }
+            new vscode.Position(1, 0),
+          ),
+        },
+      },
     ]);
     arrayEqual(results.passed, []);
     arrayEqual(results.skipped, []);

--- a/src/test/extension/suites/testExplorer/data.ts
+++ b/src/test/extension/suites/testExplorer/data.ts
@@ -2,19 +2,19 @@ import { Location, Range } from "vscode-languageclient/node";
 import {
   AddTestCases,
   AddTestSuite,
-  ClassName
+  ClassName,
 } from "../../../../testExplorer/types";
 import { FullyQualifiedClassName } from "../../../../types";
 
 const defaultRange: Range = {
   start: { line: 1, character: 1 },
-  end: { line: 1, character: 2 }
+  end: { line: 1, character: 2 },
 };
 
 function makeLocation(uri: string, range: Range = defaultRange): Location {
   return {
     uri,
-    range
+    range,
   };
 }
 const location = makeLocation("");
@@ -25,7 +25,7 @@ export const noPackage: AddTestSuite = {
   className: "NoPackage" as ClassName,
   symbol: "_empty_/NoPackage#",
   location,
-  canResolveChildren: false
+  canResolveChildren: false,
 };
 
 export const foo: AddTestSuite = {
@@ -34,7 +34,7 @@ export const foo: AddTestSuite = {
   className: "Foo" as ClassName,
   symbol: "a/Foo#",
   location,
-  canResolveChildren: false
+  canResolveChildren: false,
 };
 
 export const fooBar: AddTestSuite = {
@@ -43,7 +43,7 @@ export const fooBar: AddTestSuite = {
   className: "FooBar" as ClassName,
   symbol: "a/b/FooBar#",
   location,
-  canResolveChildren: false
+  canResolveChildren: false,
 };
 
 export const fooTestCases: AddTestCases = {
@@ -52,6 +52,6 @@ export const fooTestCases: AddTestCases = {
   className: "Foo" as ClassName,
   testCases: [
     { name: "test1", location },
-    { name: "test2", location }
-  ]
+    { name: "test2", location },
+  ],
 };

--- a/src/test/extension/suites/testExplorer/testExplorerEvents.test.ts
+++ b/src/test/extension/suites/testExplorer/testExplorerEvents.test.ts
@@ -25,17 +25,17 @@ function compareTestItem(item: vscode.TestItem, expected: TestItem) {
 
 function checkTestController(
   controller: vscode.TestController,
-  expectedRoot: TestItem
+  expectedRoot: TestItem,
 ): void {
   function checkTestItem(
     node: vscode.TestItem | undefined,
-    expected: TestItem
+    expected: TestItem,
   ) {
     assert(
       node != null,
       `There is no test item for id ${expected.id}\n${prettyPrint(
-        controller.items
-      )}`
+        controller.items,
+      )}`,
     );
     if (node) {
       compareTestItem(node, expected);
@@ -51,7 +51,7 @@ function checkTestController(
 suite("Test Explorer events", () => {
   const testController = vscode.tests.createTestController(
     "testController" + randomString(),
-    "Test Explorer"
+    "Test Explorer",
   );
 
   const cleanup = () => {
@@ -67,7 +67,7 @@ suite("Test Explorer events", () => {
       targetUri,
       folderName,
       folderUri,
-      noPackage
+      noPackage,
     );
 
     checkTestController(testController, {
@@ -77,9 +77,11 @@ suite("Test Explorer events", () => {
         {
           id: targetUri,
           label: targetName,
-          children: [{ id: "NoPackage", label: "NoPackage", uri, children: [] }]
-        }
-      ]
+          children: [
+            { id: "NoPackage", label: "NoPackage", uri, children: [] },
+          ],
+        },
+      ],
     });
     cleanup();
   });
@@ -91,7 +93,7 @@ suite("Test Explorer events", () => {
       targetUri,
       folderName,
       folderUri,
-      noPackage
+      noPackage,
     );
     addTestSuite(
       testController,
@@ -99,7 +101,7 @@ suite("Test Explorer events", () => {
       targetUri,
       folderName,
       folderUri,
-      foo
+      foo,
     );
     addTestSuite(
       testController,
@@ -107,7 +109,7 @@ suite("Test Explorer events", () => {
       targetUri,
       folderName,
       folderUri,
-      fooBar
+      fooBar,
     );
 
     checkTestController(testController, {
@@ -127,20 +129,20 @@ suite("Test Explorer events", () => {
                   id: "a.Foo",
                   label: "Foo",
                   uri,
-                  children: []
+                  children: [],
                 },
                 {
                   id: "a.b",
                   label: "b",
                   children: [
-                    { id: "a.b.FooBar", label: "FooBar", uri, children: [] }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      ]
+                    { id: "a.b.FooBar", label: "FooBar", uri, children: [] },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
     });
     cleanup();
   });
@@ -152,7 +154,7 @@ suite("Test Explorer events", () => {
       targetUri,
       folderName,
       folderUri,
-      noPackage
+      noPackage,
     );
     addTestSuite(
       testController,
@@ -160,11 +162,11 @@ suite("Test Explorer events", () => {
       targetUri,
       folderName,
       folderUri,
-      foo
+      foo,
     );
     removeTestItem(testController, targetUri, folderUri, {
       ...foo,
-      kind: "removeSuite"
+      kind: "removeSuite",
     });
 
     checkTestController(testController, {
@@ -174,9 +176,11 @@ suite("Test Explorer events", () => {
         {
           id: targetUri,
           label: targetName,
-          children: [{ id: "NoPackage", label: "NoPackage", uri, children: [] }]
-        }
-      ]
+          children: [
+            { id: "NoPackage", label: "NoPackage", uri, children: [] },
+          ],
+        },
+      ],
     });
     cleanup();
   });
@@ -188,7 +192,7 @@ suite("Test Explorer events", () => {
       targetUri,
       folderName,
       folderUri,
-      noPackage
+      noPackage,
     );
     addTestSuite(
       testController,
@@ -196,14 +200,14 @@ suite("Test Explorer events", () => {
       targetUri,
       folderName,
       folderUri,
-      foo
+      foo,
     );
     addTestCases(
       testController,
       targetName,
       targetUri,
       folderUri,
-      fooTestCases
+      fooTestCases,
     );
 
     checkTestController(testController, {
@@ -225,14 +229,14 @@ suite("Test Explorer events", () => {
                   uri,
                   children: [
                     { id: "test1", label: "test1", uri, children: [] },
-                    { id: "test2", label: "test2", uri, children: [] }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      ]
+                    { id: "test2", label: "test2", uri, children: [] },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
     });
     cleanup();
   });

--- a/src/test/extension/suites/testExplorer/util.ts
+++ b/src/test/extension/suites/testExplorer/util.ts
@@ -2,7 +2,7 @@ import * as vscode from "vscode";
 import {
   FolderName,
   FolderUri,
-  TargetName
+  TargetName,
 } from "../../../../testExplorer/types";
 import { TargetUri } from "../../../../types";
 
@@ -12,14 +12,14 @@ export function randomString(): string {
 
 export function buildFolder(
   folderName: string,
-  folderUri: string
+  folderUri: string,
 ): [FolderName, FolderUri] {
   return [folderName, folderUri] as [FolderName, FolderUri];
 }
 
 export function buildTarget(
   targetName: string,
-  targetUri: string
+  targetUri: string,
 ): [TargetName, TargetUri] {
   return [targetName, targetUri] as [TargetName, TargetUri];
 }
@@ -30,7 +30,7 @@ function traverse(items: vscode.TestItemCollection): unknown[] {
     testItems.push({
       id: c.id,
       label: c.label,
-      children: traverse(c.children)
+      children: traverse(c.children),
     });
   });
   return testItems;

--- a/src/test/unit/checkForUpdate.test.ts
+++ b/src/test/unit/checkForUpdate.test.ts
@@ -17,13 +17,13 @@ class MockRepo implements CheckForUpdateRepo {
   } {
     return {
       prevVersion: this.prevVersion,
-      lastUpdatedAt: this.lastUpdatedAt
+      lastUpdatedAt: this.lastUpdatedAt,
     };
   }
   saveLastUpdated(
     _serverVersion: string,
     _lastUpdatedAt: string,
-    _target: ConfigurationTarget
+    _target: ConfigurationTarget,
   ): void {
     return;
   }
@@ -39,13 +39,13 @@ describe("needCheckForUpdates", () => {
       currentVersion,
       today,
       ConfigurationTarget.Global,
-      repo
+      repo,
     );
     expect(actual).false;
     expect(spy.getCall(0).args).to.eql([
       currentVersion,
       today,
-      ConfigurationTarget.Global
+      ConfigurationTarget.Global,
     ]);
   });
 
@@ -59,13 +59,13 @@ describe("needCheckForUpdates", () => {
       currentVersion,
       today,
       ConfigurationTarget.Global,
-      repo
+      repo,
     );
     expect(actual).false;
     expect(spy.getCall(0).args).to.eql([
       currentVersion,
       today,
-      ConfigurationTarget.Global
+      ConfigurationTarget.Global,
     ]);
   });
 
@@ -78,7 +78,7 @@ describe("needCheckForUpdates", () => {
       currentVersion,
       today,
       ConfigurationTarget.Global,
-      repo
+      repo,
     );
     expect(actual).false;
     expect(spy.notCalled).true;
@@ -94,7 +94,7 @@ describe("needCheckForUpdates", () => {
       currentVersion,
       today,
       ConfigurationTarget.Global,
-      repo
+      repo,
     );
     expect(actual).true;
     expect(spy.notCalled).true;

--- a/src/test/unit/fetchMetals.test.ts
+++ b/src/test/unit/fetchMetals.test.ts
@@ -9,35 +9,35 @@ describe("fetchMetals", () => {
     it("should download from appropriate binaryVersion", () => {
       assert.strictEqual(
         calcServerDependency("0.11.1"),
-        expectedDep("2.12", "0.11.1")
+        expectedDep("2.12", "0.11.1"),
       );
       assert.strictEqual(
         calcServerDependency("0.11.2"),
-        expectedDep("2.12", "0.11.2")
+        expectedDep("2.12", "0.11.2"),
       );
       assert.strictEqual(
         calcServerDependency("0.11.2-SNAPSHOT"),
-        expectedDep("2.13", "0.11.2-SNAPSHOT")
+        expectedDep("2.13", "0.11.2-SNAPSHOT"),
       );
       assert.strictEqual(
         calcServerDependency("0.11.2-RC1"),
-        expectedDep("2.12", "0.11.2-RC1")
+        expectedDep("2.12", "0.11.2-RC1"),
       );
       assert.strictEqual(
         calcServerDependency("0.11.3"),
-        expectedDep("2.13", "0.11.3")
+        expectedDep("2.13", "0.11.3"),
       );
       assert.strictEqual(
         calcServerDependency("0.11.3-SNAPSHOT"),
-        expectedDep("2.13", "0.11.3-SNAPSHOT")
+        expectedDep("2.13", "0.11.3-SNAPSHOT"),
       );
       assert.strictEqual(
         calcServerDependency("0.11.3-RC1"),
-        expectedDep("2.13", "0.11.3-RC1")
+        expectedDep("2.13", "0.11.3-RC1"),
       );
       assert.strictEqual(
         calcServerDependency("0.11.2+32-536ff4b1-SNAPSHOT"),
-        expectedDep("2.13", "0.11.2+32-536ff4b1-SNAPSHOT")
+        expectedDep("2.13", "0.11.2+32-536ff4b1-SNAPSHOT"),
       );
       const customVersion = "com.acme:metals_1.2.3:3.2.1-foobar";
       assert.strictEqual(calcServerDependency(customVersion), customVersion);

--- a/src/test/unit/getJavaHome.test.ts
+++ b/src/test/unit/getJavaHome.test.ts
@@ -90,7 +90,7 @@ describe("getJavaHome", () => {
 
 function mockExistsFs(
   javaLinks: { binPath: string }[],
-  sandbox: sinon.SinonSandbox
+  sandbox: sinon.SinonSandbox,
 ): void {
   sandbox.stub(fs, "existsSync").callsFake((path: unknown) => {
     if (javaLinks.find((o) => o.binPath == path)) {
@@ -103,6 +103,6 @@ function mockExistsFs(
 
 function mockSpawn(resultString: string, sandbox: sinon.SinonSandbox): void {
   sandbox.stub(require("promisify-child-process"), "spawn").resolves({
-    stderr: resultString
+    stderr: resultString,
   });
 }

--- a/src/test/unit/getJavaOptions.test.ts
+++ b/src/test/unit/getJavaOptions.test.ts
@@ -17,7 +17,7 @@ describe("getJavaOptions", () => {
 
   const proxyOptions = [
     "-Dhttp.proxyHost=proxy.example.com",
-    "-Dhttp.proxyPort=1234"
+    "-Dhttp.proxyPort=1234",
   ];
 
   it("reads from .jvmopts", () => {
@@ -29,7 +29,7 @@ describe("getJavaOptions", () => {
   it("sanitizes options from .jvmopts", () => {
     const malformedOptions = [
       "-Dhttp.proxyHost=proxy.example.com   ",
-      "-Dhttp.proxyPort=1234  "
+      "-Dhttp.proxyPort=1234  ",
     ];
     const workspaceRoot = createWorskpace(malformedOptions);
     const options = getJavaOptions(workspaceRoot);
@@ -56,14 +56,14 @@ describe("getJavaOptions", () => {
     process.env = {
       ...originalEnv,
       JAVA_OPTS: javaOpts.join(" "),
-      JAVA_FLAGS: javaFlags.join(" ")
+      JAVA_FLAGS: javaFlags.join(" "),
     };
     const workspaceRoot = createWorskpace(proxyOptions);
     const options = getJavaOptions(workspaceRoot);
     assert.deepStrictEqual(options, [
       ...javaOpts,
       ...javaFlags,
-      ...proxyOptions
+      ...proxyOptions,
     ]);
   });
 
@@ -84,7 +84,7 @@ describe("getJavaOptions", () => {
 
 function createWorskpace(jvmOpts: string[]): string {
   const tmpDir = fs.mkdtempSync(
-    path.join(os.tmpdir(), "metals-languageclient")
+    path.join(os.tmpdir(), "metals-languageclient"),
   );
   fs.writeFileSync(path.join(tmpDir, ".jvmopts"), jvmOpts.join("\n"), "utf8");
   return tmpDir;

--- a/src/test/unit/indentPattern.test.ts
+++ b/src/test/unit/indentPattern.test.ts
@@ -11,7 +11,7 @@ function checkFunctions(indentPattern: RegExp) {
 
 describe("IncreaseIndentPattern Test Suite", () => {
   const [checkIncrease, checkNotIncrease] = checkFunctions(
-    increaseIndentPattern()
+    increaseIndentPattern(),
   );
 
   it("Scala3", () => {

--- a/src/test/unit/setupCoursier.test.ts
+++ b/src/test/unit/setupCoursier.test.ts
@@ -2,7 +2,7 @@ import path from "path";
 import {
   fetchCoursier,
   setupCoursier,
-  validateCoursier
+  validateCoursier,
 } from "../../setupCoursier";
 import { OutputChannel } from "../../interfaces/OutputChannel";
 import { log } from "console";
@@ -44,7 +44,7 @@ describe("setupCoursier", () => {
       await fetchCoursier(tmpDir, (out) => {
         log(out.toString().trim());
       }),
-      0
+      0,
     );
   });
 
@@ -57,7 +57,7 @@ describe("setupCoursier", () => {
       process.cwd(),
       new LogOutputChannel(),
       false,
-      ["-Xmx1000M", "-XX-fake!"]
+      ["-Xmx1000M", "-XX-fake!"],
     );
     assert.isTrue(fs.existsSync(coursier));
     assert.isTrue(fs.existsSync(javaHome.path));

--- a/src/testExplorer/addTestCases.ts
+++ b/src/testExplorer/addTestCases.ts
@@ -5,7 +5,7 @@ import {
   prefixesOf,
   refineRunnableTestItem,
   TestItemPath,
-  toVscodeRange
+  toVscodeRange,
 } from "./util";
 
 /**
@@ -21,11 +21,11 @@ export function addTestCases(
   targetName: TargetName,
   targetUri: TargetUri,
   folderUri: FolderUri,
-  event: AddTestCases
+  event: AddTestCases,
 ): void {
   function addTestCasesLoop(
     parent: vscode.TestItem,
-    testPrefix: TestItemPath | null
+    testPrefix: TestItemPath | null,
   ): void {
     if (testPrefix) {
       const child = parent.children.get(testPrefix.id);
@@ -33,7 +33,7 @@ export function addTestCases(
         addTestCasesLoop(child, testPrefix.next());
       } else {
         console.error(
-          "Cannot find test item for " + event.fullyQualifiedClassName
+          "Cannot find test item for " + event.fullyQualifiedClassName,
         );
       }
     } else {
@@ -44,14 +44,14 @@ export function addTestCases(
         const testItem = testController.createTestItem(
           name,
           displayName || name,
-          parsedUri
+          parsedUri,
         );
         refineRunnableTestItem(
           "testcase",
           testItem,
           targetUri,
           targetName,
-          parent
+          parent,
         );
         testItem.range = parsedRange;
         parent.children.add(testItem);

--- a/src/testExplorer/addTestSuites.ts
+++ b/src/testExplorer/addTestSuites.ts
@@ -6,7 +6,7 @@ import {
   TestItemPath,
   refineRunnableTestItem,
   refineTestItem,
-  toVscodeRange
+  toVscodeRange,
 } from "./util";
 
 /**
@@ -24,24 +24,24 @@ export function addTestSuite(
   targetUri: TargetUri,
   folderName: FolderName,
   folderUri: FolderUri,
-  event: AddTestSuite
+  event: AddTestSuite,
 ): void {
   const workspaceFolderItem = getOrCreateWorkspaceFolderItem(
     testController,
     folderName,
-    folderUri
+    folderUri,
   );
 
   const buildTargetItem = getOrCreateBuildTargetItem(
     testController,
     workspaceFolderItem,
     targetUri,
-    targetName
+    targetName,
   );
 
   function addTestSuiteLoop(
     parent: vscode.TestItem,
-    testPrefix: TestItemPath | null
+    testPrefix: TestItemPath | null,
   ) {
     if (testPrefix) {
       const child = parent.children.get(testPrefix.id);
@@ -62,7 +62,7 @@ export function addTestSuite(
       const testItem = testController.createTestItem(
         fullyQualifiedClassName,
         className,
-        parsedUri
+        parsedUri,
       );
       refineRunnableTestItem("suite", testItem, targetUri, targetName, parent);
       // if canResolveChildren is true then test item is shown as expandable in the Test Explorer view
@@ -84,7 +84,7 @@ function getOrCreateBuildTargetItem(
   testController: vscode.TestController,
   workspaceFolderItem: vscode.TestItem,
   targetUri: TargetUri,
-  targetName: TargetName
+  targetName: TargetName,
 ): vscode.TestItem {
   const buildTarget = workspaceFolderItem.children.get(targetUri);
   if (buildTarget) {
@@ -105,7 +105,7 @@ function getOrCreateBuildTargetItem(
 function getOrCreateWorkspaceFolderItem(
   testController: vscode.TestController,
   folderName: FolderName,
-  folderUri: FolderUri
+  folderUri: FolderUri,
 ): vscode.TestItem {
   const workspaceFolder = testController.items.get(folderUri);
   if (workspaceFolder) {

--- a/src/testExplorer/analyzeTestRun.ts
+++ b/src/testExplorer/analyzeTestRun.ts
@@ -7,7 +7,7 @@ import {
   SuiteName,
   TestName,
   TestRunActions,
-  TestSuiteResult
+  TestSuiteResult,
 } from "./types";
 import { gatherTestItems } from "./util";
 
@@ -24,7 +24,7 @@ export function analyzeTestRun(
   run: TestRunActions,
   tests: RunnableMetalsTestItem[],
   testSuitesResults: TestSuiteResult[],
-  teardown?: () => void
+  teardown?: () => void,
 ): void {
   const results = createResultsMap(testSuitesResults);
   for (const test of tests) {
@@ -58,10 +58,10 @@ export function analyzeTestRun(
  * Transforms array of suite results into mapping between suite name and suite result.
  */
 function createResultsMap(
-  testSuitesResults: TestSuiteResult[]
+  testSuitesResults: TestSuiteResult[],
 ): Map<SuiteName, TestSuiteResult> {
   const resultsTuples: [SuiteName, TestSuiteResult][] = testSuitesResults.map(
-    (result) => [result.suiteName, result]
+    (result) => [result.suiteName, result],
   );
   const results = new Map(resultsTuples);
   return results;
@@ -74,7 +74,7 @@ function analyzeTestCases(
   run: TestRunActions,
   result: TestSuiteResult,
   testCases: vscode.TestItem[],
-  parent?: vscode.TestItem
+  parent?: vscode.TestItem,
 ) {
   const parentName = parent?.id || "";
   const testCasesResults = createTestCasesMap(result, parentName);
@@ -114,7 +114,7 @@ function analyzeTestCases(
  */
 function createTestCasesMap(
   testSuiteResult: TestSuiteResult,
-  parentName: string
+  parentName: string,
 ): Map<TestName, SingleTestResult> {
   const tuples: [TestName, SingleTestResult][] = testSuiteResult.tests.map(
     (test) => {
@@ -123,7 +123,7 @@ function createTestCasesMap(
           ? test.testName.slice(parentName.length + 1)
           : test.testName;
       return [name as TestName, test];
-    }
+    },
   );
   const testCasesResult = new Map(tuples);
   return testCasesResult;
@@ -136,7 +136,7 @@ function createTestCasesMap(
 function analyzeTestSuite(
   run: TestRunActions,
   result: TestSuiteResult,
-  testSuite: vscode.TestItem
+  testSuite: vscode.TestItem,
 ) {
   const failed = result.tests.filter(isFailed);
   if (failed.length > 0) {
@@ -167,8 +167,8 @@ function toTestMessage(failed: Failed): vscode.TestMessage {
       message: ansicolor.strip(failed.error),
       location: new vscode.Location(
         vscode.Uri.parse(failed.location.file),
-        new vscode.Position(failed.location.line, 0)
-      )
+        new vscode.Position(failed.location.line, 0),
+      ),
     };
   }
   return { message: ansicolor.strip(failed.error) };

--- a/src/testExplorer/removeTestItem.ts
+++ b/src/testExplorer/removeTestItem.ts
@@ -7,13 +7,13 @@ export function removeTestItem(
   testController: vscode.TestController,
   targetUri: TargetUri,
   folderUri: FolderUri,
-  event: RemoveTestSuite
+  event: RemoveTestSuite,
 ): void {
   const { fullyQualifiedClassName } = event;
 
   function removeTestItemLoop(
     parent: vscode.TestItem,
-    testPrefix: TestItemPath | null
+    testPrefix: TestItemPath | null,
   ): void {
     if (testPrefix) {
       const child = parent.children.get(testPrefix.id);

--- a/src/testExplorer/testManager.ts
+++ b/src/testExplorer/testManager.ts
@@ -2,7 +2,7 @@ import * as vscode from "vscode";
 import { TestRunProfileKind, tests } from "vscode";
 import {
   ExecuteCommandRequest,
-  LanguageClient
+  LanguageClient,
 } from "vscode-languageclient/node";
 import { addTestCases } from "./addTestCases";
 import { addTestSuite } from "./addTestSuites";
@@ -14,7 +14,7 @@ import { updateTestSuiteLocation } from "./updateTestSuiteLocation";
 export function createTestManager(
   client: LanguageClient,
   isDisabled: boolean,
-  environmentVariables: () => Record<string, string>
+  environmentVariables: () => Record<string, string>,
 ): TestManager {
   return new TestManager(client, isDisabled, environmentVariables);
 }
@@ -22,7 +22,7 @@ export function createTestManager(
 class TestManager {
   readonly testController = tests.createTestController(
     "metalsTestController",
-    "Metals Test Explorer"
+    "Metals Test Explorer",
   );
 
   private isDisabled = false;
@@ -32,7 +32,7 @@ class TestManager {
   constructor(
     private readonly client: LanguageClient,
     isDisabled: boolean,
-    environmentVariables: () => Record<string, string>
+    environmentVariables: () => Record<string, string>,
   ) {
     if (isDisabled) {
       this.disable();
@@ -54,11 +54,11 @@ class TestManager {
             callback,
             request,
             token,
-            this.environmentVariables
+            this.environmentVariables,
           );
         }
       },
-      true
+      true,
     );
 
     this.testController.createRunProfile(
@@ -73,11 +73,11 @@ class TestManager {
             callback,
             request,
             token,
-            this.environmentVariables
+            this.environmentVariables,
           );
         }
       },
-      false
+      false,
     );
 
     this.testController.resolveHandler = async (item?: vscode.TestItem) => {
@@ -98,7 +98,7 @@ class TestManager {
    */
   disable(): void {
     this.testController.items.forEach((item) =>
-      this.testController.items.delete(item.id)
+      this.testController.items.delete(item.id),
     );
     this.isDisabled = true;
   }
@@ -109,7 +109,7 @@ class TestManager {
       targetName,
       folderUri,
       folderName,
-      events
+      events,
     } of updates) {
       const folderUri_ = folderUri || ("root" as FolderUri);
       const folderName_ = folderName || ("root" as FolderName);
@@ -123,14 +123,14 @@ class TestManager {
             targetUri,
             folderName_,
             folderUri_,
-            event
+            event,
           );
         } else if (event.kind === "updateSuiteLocation") {
           updateTestSuiteLocation(
             this.testController,
             targetUri,
             folderUri_,
-            event
+            event,
           );
         } else if (event.kind === "addTestCases") {
           addTestCases(
@@ -138,7 +138,7 @@ class TestManager {
             targetName,
             targetUri,
             folderUri_,
-            event
+            event,
           );
         }
       }
@@ -155,13 +155,13 @@ class TestManager {
     return this.client
       .sendRequest(ExecuteCommandRequest.type, {
         command: "discover-tests",
-        arguments: args
+        arguments: args,
       })
       .then(
         (updates: BuildTargetUpdate[]) => {
           this.updateTestExplorer(updates);
         },
-        (err) => console.error(err)
+        (err) => console.error(err),
       );
   }
 }

--- a/src/testExplorer/testRunHandler.ts
+++ b/src/testExplorer/testRunHandler.ts
@@ -3,7 +3,7 @@ import { CancellationToken, TestController, TestRunRequest } from "vscode";
 import { debugServerFromUri, DebugSession } from "../debugger/scalaDebugger";
 import {
   ScalaTestSuitesDebugRequest,
-  ScalaTestSuiteSelection
+  ScalaTestSuiteSelection,
 } from "../debugger/types";
 import { TargetUri } from "../types";
 import { analyzeTestRun } from "./analyzeTestRun";
@@ -11,7 +11,7 @@ import {
   DapEvent,
   MetalsTestItem,
   RunnableMetalsTestItem,
-  TestSuiteResult
+  TestSuiteResult,
 } from "./types";
 import { gatherTestItems } from "./util";
 import { ServerCommands } from "../interfaces/ServerCommands";
@@ -42,10 +42,10 @@ vscode.debug.registerDebugAdapterTrackerFactory("scala", {
           ) {
             suiteResults.get(session.id)?.push(msg.body.data);
           }
-        }
+        },
       };
     }
-  }
+  },
 });
 
 /**
@@ -60,7 +60,7 @@ export async function runHandler(
   afterFinished: () => void,
   request: TestRunRequest,
   token: CancellationToken,
-  environmentVariables: () => Record<string, string>
+  environmentVariables: () => Record<string, string>,
 ): Promise<void> {
   const run = testController.createTestRun(request);
   const includes = new Set((request.include as MetalsTestItem[]) ?? []);
@@ -108,12 +108,12 @@ export async function runHandler(
     if (kind === "suite") {
       return {
         className: test.id,
-        tests: []
+        tests: [],
       };
     } else {
       return {
         className: test._metalsParent.id,
-        tests: [test.id]
+        tests: [test.id],
       };
     }
   });
@@ -127,7 +127,7 @@ export async function runHandler(
         targetUri,
         testSuiteSelection,
         queue,
-        environmentVariables()
+        environmentVariables(),
       );
     }
   } finally {
@@ -145,12 +145,12 @@ async function runDebugSession(
   targetUri: TargetUri,
   testSuiteSelection: ScalaTestSuiteSelection[],
   tests: RunnableMetalsTestItem[],
-  environmentVariables: Record<string, string> = {}
+  environmentVariables: Record<string, string> = {},
 ): Promise<void> {
   const session = await createDebugSession(
     targetUri,
     testSuiteSelection,
-    environmentVariables
+    environmentVariables,
   );
   if (!session) {
     return;
@@ -170,7 +170,7 @@ async function runDebugSession(
 async function createDebugSession(
   targetUri: TargetUri,
   suites: ScalaTestSuiteSelection[],
-  environmentVariables: Record<string, string> = {}
+  environmentVariables: Record<string, string> = {},
 ): Promise<DebugSession | undefined> {
   const debugSessionParams: ScalaTestSuitesDebugRequest = {
     target: { uri: targetUri },
@@ -178,13 +178,13 @@ async function createDebugSession(
       suites,
       jvmOptions: [],
       environmentVariables: Object.entries(environmentVariables).map(
-        ([key, value]) => `${key}=${value}`
-      )
-    }
+        ([key, value]) => `${key}=${value}`,
+      ),
+    },
   };
   return vscode.commands.executeCommand<DebugSession>(
     ServerCommands.DebugAdapterStart,
-    debugSessionParams
+    debugSessionParams,
   );
 }
 
@@ -202,7 +202,7 @@ async function startDebugging(session: DebugSession, noDebug: boolean) {
     noDebug,
     request: "launch",
     debugServer: port,
-    kind: testRunnerId
+    kind: testRunnerId,
   };
   return vscode.debug.startDebugging(undefined, configuration);
 }
@@ -214,7 +214,7 @@ async function startDebugging(session: DebugSession, noDebug: boolean) {
  */
 async function analyzeResults(
   run: vscode.TestRun,
-  tests: RunnableMetalsTestItem[]
+  tests: RunnableMetalsTestItem[],
 ) {
   return new Promise<void>((resolve) => {
     const disposable = vscode.debug.onDidTerminateDebugSession(
@@ -231,7 +231,7 @@ async function analyzeResults(
         analyzeTestRun(run, tests, testSuitesResult, teardown);
         run.end();
         return resolve();
-      }
+      },
     );
   });
 }

--- a/src/testExplorer/types.ts
+++ b/src/testExplorer/types.ts
@@ -128,7 +128,7 @@ export interface TestRunActions {
   failed?(
     test: vscode.TestItem,
     message: vscode.TestMessage | readonly vscode.TestMessage[],
-    duration?: number
+    duration?: number,
   ): void;
   passed?(test: vscode.TestItem, duration?: number): void;
   skipped?(test: vscode.TestItem): void;

--- a/src/testExplorer/updateTestSuiteLocation.ts
+++ b/src/testExplorer/updateTestSuiteLocation.ts
@@ -14,11 +14,11 @@ export function updateTestSuiteLocation(
   testController: vscode.TestController,
   targetUri: TargetUri,
   folderUri: FolderUri,
-  event: UpdateSuiteLocation
+  event: UpdateSuiteLocation,
 ): void {
   function updateTestSuiteLocationLoop(
     parent: vscode.TestItem,
-    testPrefix: TestItemPath | null
+    testPrefix: TestItemPath | null,
   ): void {
     if (testPrefix) {
       const child = parent.children.get(testPrefix.id);
@@ -26,7 +26,7 @@ export function updateTestSuiteLocation(
         updateTestSuiteLocationLoop(child, testPrefix.next());
       } else {
         console.error(
-          "Cannot find test item for " + event.fullyQualifiedClassName
+          "Cannot find test item for " + event.fullyQualifiedClassName,
         );
       }
     } else {

--- a/src/testExplorer/util.ts
+++ b/src/testExplorer/util.ts
@@ -10,7 +10,7 @@ import {
   TestCaseMetalsTestItem,
   RunnableMetalsTestItem,
   WorkSpaceFolderTestItem,
-  MetalsTestItemKind
+  MetalsTestItemKind,
 } from "./types";
 
 // https://www.typescriptlang.org/docs/handbook/2/functions.html#function-overloads
@@ -33,7 +33,7 @@ export function refineTestItem(kind: "package", test: vscode.TestItem, parent: v
 export function refineTestItem(
   kind: MetalsTestItemKind,
   test: vscode.TestItem,
-  parent?: vscode.TestItem
+  parent?: vscode.TestItem,
 ): MetalsTestItem {
   return refineTestItemAux(kind, test as MetalsTestItem, parent);
 }
@@ -41,7 +41,7 @@ export function refineTestItem(
 export function refineTestItemAux(
   kind: MetalsTestItemKind,
   test: MetalsTestItem,
-  parent?: vscode.TestItem
+  parent?: vscode.TestItem,
 ): MetalsTestItem {
   test._metalsKind = kind;
   if (kind !== "workspaceFolder") {
@@ -60,7 +60,7 @@ export function refineRunnableTestItem(
   test: vscode.TestItem,
   targetUri: TargetUri,
   targetName: TargetName,
-  parent?: vscode.TestItem
+  parent?: vscode.TestItem,
 ): MetalsTestItem {
   const cast = test as RunnableMetalsTestItem;
   cast._metalsTargetName = targetName;
@@ -73,12 +73,12 @@ export function toVscodeRange(range: Range): vscode.Range {
     range.start.line,
     range.start.character,
     range.end.line,
-    range.end.character
+    range.end.character,
   );
 }
 
 export function gatherTestItems(
-  testCollection: vscode.TestItemCollection
+  testCollection: vscode.TestItemCollection,
 ): MetalsTestItem[] {
   const tests: MetalsTestItem[] = [];
   testCollection.forEach((test) => tests.push(test as MetalsTestItem));
@@ -114,7 +114,7 @@ export interface TestItemPath {
  */
 export function prefixesOf(
   fullyQualifiedName: FullyQualifiedClassName,
-  includeSelf = false
+  includeSelf = false,
 ): TestItemPath | null {
   const partitioned = fullyQualifiedName.split(".");
   const parts = includeSelf
@@ -130,13 +130,13 @@ export function prefixesOf(
   function makeTestPrefix(
     idx: number,
     parts: string[],
-    prefixes: string[]
+    prefixes: string[],
   ): TestItemPath | null {
     if (prefixes[idx] != null) {
       return {
         id: prefixes[idx],
         label: parts[idx],
-        next: () => makeTestPrefix(idx + 1, parts, prefixes)
+        next: () => makeTestPrefix(idx + 1, parts, prefixes),
       };
     } else {
       return null;

--- a/src/treeview.ts
+++ b/src/treeview.ts
@@ -11,7 +11,7 @@ import {
   Uri,
   TreeView,
   ExtensionContext,
-  ThemeIcon
+  ThemeIcon,
 } from "vscode";
 import {
   MetalsTreeRevealResult,
@@ -21,14 +21,14 @@ import {
   MetalsTreeViewNodeCollapseDidChangeType,
   MetalsTreeViewParentType,
   MetalsTreeViews,
-  MetalsTreeViewVisibilityDidChangeType
+  MetalsTreeViewVisibilityDidChangeType,
 } from "./interfaces/TreeViewProtocol";
 
 export function startTreeView(
   client: LanguageClient,
   out: OutputChannel,
   context: ExtensionContext,
-  viewIds: string[]
+  viewIds: string[],
 ): MetalsTreeViews {
   const allProviders: Map<string, MetalsTreeDataProvider> = new Map();
   const allViews: Map<string, TreeView<string>> = new Map();
@@ -47,12 +47,12 @@ export function startTreeView(
       out,
       viewId,
       allProviders,
-      context
+      context,
     );
     allProviders.set(viewId, provider);
     const view = window.createTreeView(viewId, {
       treeDataProvider: provider,
-      showCollapseAll: true
+      showCollapseAll: true,
     });
     allViews.set(viewId, view);
 
@@ -60,7 +60,7 @@ export function startTreeView(
     const onDidChangeVisibility = view.onDidChangeVisibility((e) => {
       client.sendNotification(MetalsTreeViewVisibilityDidChangeType, {
         viewId: viewId,
-        visible: e.visible
+        visible: e.visible,
       });
     });
     const onDidChangeExpandNode = view.onDidExpandElement((e) => {
@@ -68,7 +68,7 @@ export function startTreeView(
       client.sendNotification(MetalsTreeViewNodeCollapseDidChangeType, {
         viewId: viewId,
         nodeUri: e.element,
-        collapsed: false
+        collapsed: false,
       });
     });
     const onDidChangeCollapseNode = view.onDidCollapseElement((e) => {
@@ -76,7 +76,7 @@ export function startTreeView(
       client.sendNotification(MetalsTreeViewNodeCollapseDidChangeType, {
         viewId: viewId,
         nodeUri: e.element,
-        collapsed: true
+        collapsed: true,
       });
     });
 
@@ -84,7 +84,7 @@ export function startTreeView(
       view,
       onDidChangeVisibility,
       onDidChangeExpandNode,
-      onDidChangeCollapseNode
+      onDidChangeCollapseNode,
     ];
   });
 
@@ -106,7 +106,7 @@ export function startTreeView(
           provider.didChange.fire(undefined);
         }
       });
-    }
+    },
   );
   context.subscriptions.push(metalsTreeViewDidChangeDispoasble);
 
@@ -122,7 +122,7 @@ export function startTreeView(
             if (isDestinationNode) {
               return view.reveal(uri, {
                 select: true,
-                focus: true
+                focus: true,
               });
             } else {
               return Promise.resolve();
@@ -140,7 +140,7 @@ export function startTreeView(
               return view.reveal(uri, {
                 expand: true,
                 select: isDestinationNode,
-                focus: isDestinationNode
+                focus: isDestinationNode,
               });
             });
           }
@@ -156,7 +156,7 @@ export function startTreeView(
           out.appendLine(`unknown view: ${params.viewId}`);
         }
       }
-    }
+    },
   };
 }
 
@@ -178,7 +178,7 @@ class MetalsTreeDataProvider implements TreeDataProvider<string> {
     readonly out: OutputChannel,
     readonly viewId: string,
     readonly views: Map<string, MetalsTreeDataProvider>,
-    readonly context: ExtensionContext
+    readonly context: ExtensionContext,
   ) {}
 
   // Populate TreeItem based on cached children response from the server.
@@ -201,7 +201,7 @@ class MetalsTreeDataProvider implements TreeDataProvider<string> {
           : undefined,
       command: item.command,
       tooltip: item.tooltip,
-      iconPath: item.icon ? this.iconPath(item.icon) : undefined
+      iconPath: item.icon ? this.iconPath(item.icon) : undefined,
     };
     return result;
   }
@@ -211,7 +211,7 @@ class MetalsTreeDataProvider implements TreeDataProvider<string> {
     return this.client
       .sendRequest(MetalsTreeViewParentType, {
         viewId: this.viewId,
-        nodeUri: uri
+        nodeUri: uri,
       })
       .then((result) => {
         return result.uri;
@@ -223,7 +223,7 @@ class MetalsTreeDataProvider implements TreeDataProvider<string> {
     return this.client
       .sendRequest(MetalsTreeViewChildrenType, {
         viewId: this.viewId,
-        nodeUri: uri
+        nodeUri: uri,
       })
       .then((result) => {
         result.nodes.forEach((n) => {
@@ -274,7 +274,7 @@ function notEmpty<TValue>(value: TValue | null | undefined): value is TValue {
 }
 
 function toTreeItemCollapsibleState(
-  s: MetalsTreeViewNode["collapseState"]
+  s: MetalsTreeViewNode["collapseState"],
 ): TreeItemCollapsibleState {
   switch (s) {
     case "expanded":

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,5 +29,5 @@ export interface CompileResult {
 export enum BuildStatusCode {
   Ok = 1,
   Error = 2,
-  Cancelled = 3
+  Cancelled = 3,
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -6,11 +6,11 @@ import {
   ConfigurationTarget,
   window,
   workspace,
-  WorkspaceFolder
+  WorkspaceFolder,
 } from "vscode";
 import {
   ExecuteCommandRequest,
-  TextDocumentPositionParams
+  TextDocumentPositionParams,
 } from "vscode-languageclient";
 import { LanguageClient } from "vscode-languageclient/node";
 import http from "https";
@@ -30,7 +30,7 @@ export type newtype<A, ID extends string> = A & {
 
 export function getConfigValue<A>(
   config: WorkspaceConfiguration,
-  key: string
+  key: string,
 ): { value: A; target: ConfigurationTarget } | undefined {
   const value = config.get<A>(key);
   /* eslint-disable @typescript-eslint/no-non-null-assertion */
@@ -49,7 +49,7 @@ export function getConfigValue<A>(
   } else if (defaultValue) {
     return {
       value: defaultValue,
-      target: ConfigurationTarget.Global
+      target: ConfigurationTarget.Global,
     };
   }
 }
@@ -73,12 +73,12 @@ export function currentWorkspaceFolder(): WorkspaceFolder | undefined {
 }
 
 export function getTextDocumentPositionParams(
-  editor: TextEditor
+  editor: TextEditor,
 ): TextDocumentPositionParams {
   const pos = editor.selection.active;
   return {
     textDocument: { uri: editor.document.uri.toString() },
-    position: { line: pos.line, character: pos.character }
+    position: { line: pos.line, character: pos.character },
   };
 }
 
@@ -89,14 +89,14 @@ export function executeCommand<T>(
 ): Promise<T> {
   return client.sendRequest(ExecuteCommandRequest.type, {
     command,
-    arguments: args
+    arguments: args,
   });
 }
 
 export function getValueFromConfig<T>(
   config: WorkspaceConfiguration,
   key: string,
-  defaultValue: T
+  defaultValue: T,
 ): T {
   const inspected = config.inspect<T>(key);
   const fromConfig =
@@ -131,7 +131,7 @@ export function getJavaVersionOverride(): string | undefined {
 
 export async function fetchFrom(
   url: string,
-  options?: http.RequestOptions
+  options?: http.RequestOptions,
 ): Promise<string> {
   const requestOptions: http.RequestOptions = { timeout: 5000, ...options };
   const promise = new Promise<string>((resolve, reject) => {
@@ -144,7 +144,7 @@ export async function fetchFrom(
       })
       .on("error", (e) => reject(e))
       .on("timeout", () =>
-        reject(`Timeout occured during get request at ${url}`)
+        reject(`Timeout occured during get request at ${url}`),
       );
   });
   return await promise;


### PR DESCRIPTION
## Summary

trailing commas are gives huge DX boost:
- much easier to reorder lines without worrying about trailing commas
- better diff

## Future Notes

might add https://git-scm.com/docs/git-blame#Documentation/git-blame.txt---ignore-revs-filefile in the future to skip git blaming formatting-only changes

## Additional Context

the prettier config `trailingComma: 'none'` was added in  [`c809a04` (#1612)](https://github.com/scalameta/metals-vscode/pull/1612/commits/c809a049a23158993dd8b044db73fed063fa1225) and [doesn't seems to be intentional.](https://discord.com/channels/632642981228314653/718047292749381662/1413171321168330944)