### PR TITLE
fix: avoid importing fp-ts modules from fp-ts/lib/

### DIFF
--- a/src/findOnPath.ts
+++ b/src/findOnPath.ts
@@ -1,6 +1,6 @@
-import { TaskEither } from "fp-ts/lib/TaskEither";
-import { pipe } from "fp-ts/lib/function";
-import * as E from "fp-ts/lib/Either";
+import { TaskEither } from "fp-ts/TaskEither";
+import { pipe } from "fp-ts/function";
+import * as E from "fp-ts/Either";
 import fs from "fs";
 import * as path from "path";
 


### PR DESCRIPTION
It's no longer recommended to import from `fp-ts/lib/` -- see https://gcanti.github.io/fp-ts/modules/TaskEither.ts.html#tapeither

The current way of importing from `fp-ts/lib/` is affecting another project that I am working on, which causes the build for that project to fail. 

This PR should have no breaking changes for metals-vscode. My changes pass `yarn test` and seem to build fine on my local Scala projects