### PR TITLE
improvement: Set default Bloop version manually

### DIFF
--- a/package.json
+++ b/package.json
@@ -354,6 +354,7 @@
         "metals.bloopVersion": {
           "type": "string",
           "scope": "machine",
+          "default": "2.0.16",
           "markdownDescription": "This version will be used for the Bloop build tool plugin, for any supported build tool,while importing in Metals as well as for running the embedded server"
         },
         "metals.bloopJvmProperties": {


### PR DESCRIPTION
Thanks to this, users will not get the pop up to update the version. I tried making the pop up just not appear, but if we run an old Metals instance at the same time, the other version will fall back to the old Bloop version causing an infinite loop.