### PR TITLE
Activate extension for Java files

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
   "activationEvents": [
     "onDebugResolve:scala",
     "onLanguage:scala",
+    "onLanguage:java",
     "workspaceContains:build.sbt",
     "workspaceContains:build.sc",
     "workspaceContains:build.mill",


### PR DESCRIPTION
Previously, the Metals extension didn't activate if you opened a Java
file. This was problematic since the upcoming v2 milestone releases have
greatly improved Java support and we have many Java users wanting to try it
out. This PR fixes the issue by making Metals also activate if you open
a Java file.

This has introduces a possible regression for users who don't want to
use Metals in pure Java codebases. A workaround for these people will be
to explicitly disable the Metals extension in workspaces where they want
to use alterantive Java extensions.

<!-- jj-stack-begin -->
- → **#1816** ← [[Commit](https://github.com/scalameta/metals-vscode/pull/1816/commits/b997904322d22fc424c0804d73fca55367460ecc)]
  - #1817 [[Commit](https://github.com/scalameta/metals-vscode/pull/1817/commits/c4ff2163567aa4edd99c1cf1b366c2b430119465)]
    - #1818 [[Commit](https://github.com/scalameta/metals-vscode/pull/1818/commits/814af55b74c88a6b2b38e99caadf34058f5d859d)]
<!-- jj-stack-end -->