### PR TITLE
improvement: Remove metals paste and copy

### DIFF
--- a/package.json
+++ b/package.json
@@ -798,18 +798,6 @@
         "mac": "cmd+alt+shift+o",
         "command": "metals.scalafix-run",
         "when": "editorLangId == scala"
-      },
-      {
-        "command": "metals.copy-selection",
-        "key": "ctrl+c",
-        "mac": "cmd+c",
-        "when": "editorTextFocus && editorHasSelection && editorLangId == 'scala'"
-      },
-      {
-        "command": "metals.paste-selection",
-        "key": "ctrl+v",
-        "mac": "cmd+v",
-        "when": "editorTextFocus && editorLangId == 'scala'"
       }
     ],
     "menus": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -113,7 +113,7 @@ import { MetalsQuickPickType } from "./interfaces/MetalsQuickPick";
 import { MetalsSlowTaskType } from "./interfaces/MetalsSlowTask";
 import { downloadProgress } from "./downloadProgress";
 import { detectLaunchConfigurationChanges } from "./detectLaunchConfigurationChanges";
-import { registerCopyPasteCommands } from "./metalsCopyPaste";
+import { registerCopyPasteHooks } from "./metalsCopyPaste";
 
 const outputChannel = window.createOutputChannel("Metals");
 
@@ -139,8 +139,8 @@ export interface MetalsApi {
 }
 
 export async function activate(context: ExtensionContext): Promise<MetalsApi> {
-  // Register copy and paste commands
-  registerCopyPasteCommands(context, () => currentClient);
+  // Register copy and paste hooks for Scala files
+  registerCopyPasteHooks(context, () => currentClient);
   const serverVersion = getServerVersion(config, context);
   detectConfigurationChanges();
   configureSettingsDefaults();


### PR DESCRIPTION
Instead we now add hooks on selection and document changed events

Fixes https://github.com/scalameta/metals-vscode/issues/1813