### PR TITLE
bugfix: Allow default syntax to be used for now

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,10 @@
     "onDebugResolve:scala",
     "onLanguage:scala",
     "onLanguage:java",
-    "onLanguage:twirl",
+    "onLanguage:twirl-html",
+    "onLanguage:twirl-xml",
+    "onLanguage:twirl-js",
+    "onLanguage:twirl-txt",
     "workspaceContains:build.sbt",
     "workspaceContains:build.sc",
     "workspaceContains:build.mill",
@@ -138,14 +141,50 @@
         }
       },
       {
-        "id": "twirl",
+        "id": "twirl-html",
         "aliases": [
-          "Twirl"
+          "Twirl HTML"
         ],
         "extensions": [
-          ".scala.html",
-          ".scala.xml",
-          ".scala.js",
+          ".scala.html"
+        ],
+        "icon": {
+          "dark": "icons/file_type_scala.svg",
+          "light": "icons/file_type_scala.svg"
+        }
+      },
+      {
+        "id": "twirl-xml",
+        "aliases": [
+          "Twirl XML"
+        ],
+        "extensions": [
+          ".scala.xml"
+        ],
+        "icon": {
+          "dark": "icons/file_type_scala.svg",
+          "light": "icons/file_type_scala.svg"
+        }
+      },
+      {
+        "id": "twirl-js",
+        "aliases": [
+          "Twirl JavaScript"
+        ],
+        "extensions": [
+          ".scala.js"
+        ],
+        "icon": {
+          "dark": "icons/file_type_scala.svg",
+          "light": "icons/file_type_scala.svg"
+        }
+      },
+      {
+        "id": "twirl-txt",
+        "aliases": [
+          "Twirl Text"
+        ],
+        "extensions": [
           ".scala.txt"
         ],
         "icon": {
@@ -179,6 +218,30 @@
         "language": "semanticdb",
         "scopeName": "source.semanticdb",
         "path": "./syntaxes/semanticdb.json"
+      },
+      {
+        "language": "twirl-html",
+        "scopeName": "text.html.twirl",
+        "path": "./syntaxes/twirl-html.json",
+        "embeddedLanguages": {
+          "text.html.basic": "html"
+        }
+      },
+      {
+        "language": "twirl-xml",
+        "scopeName": "text.xml.twirl",
+        "path": "./syntaxes/twirl-xml.json",
+        "embeddedLanguages": {
+          "text.xml": "xml"
+        }
+      },
+      {
+        "language": "twirl-js",
+        "scopeName": "source.js.twirl",
+        "path": "./syntaxes/twirl-js.json",
+        "embeddedLanguages": {
+          "source.js": "javascript"
+        }
       }
     ],
     "configurationDefaults": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -643,7 +643,10 @@ async function launchMetals(
     documentSelector: [
       { scheme: "file", language: "scala" },
       { scheme: "file", language: "java" },
-      { scheme: "file", language: "twirl" },
+      { scheme: "file", language: "twirl-html" },
+      { scheme: "file", language: "twirl-xml" },
+      { scheme: "file", language: "twirl-js" },
+      { scheme: "file", language: "twirl-txt" },
       { scheme: "jar", language: "scala" },
       { scheme: "jar", language: "java" },
     ],

--- a/src/isSupportedLanguage.ts
+++ b/src/isSupportedLanguage.ts
@@ -8,7 +8,10 @@ export function isSupportedLanguage(languageId: string): boolean {
     case "scala":
     case "sc":
     case "java":
-    case "twirl":
+    case "twirl-html":
+    case "twirl-xml":
+    case "twirl-js":
+    case "twirl-txt":
       return true;
     default:
       return false;

--- a/syntaxes/twirl-html.json
+++ b/syntaxes/twirl-html.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+  "name": "Twirl HTML",
+  "scopeName": "text.html.twirl",
+  "patterns": [
+    {
+      "include": "text.html.basic"
+    }
+  ]
+}

--- a/syntaxes/twirl-js.json
+++ b/syntaxes/twirl-js.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+  "name": "Twirl JavaScript",
+  "scopeName": "source.js.twirl",
+  "patterns": [
+    {
+      "include": "source.js"
+    }
+  ]
+}

--- a/syntaxes/twirl-xml.json
+++ b/syntaxes/twirl-xml.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+  "name": "Twirl XML",
+  "scopeName": "text.xml.twirl",
+  "patterns": [
+    {
+      "include": "text.xml"
+    }
+  ]
+}


### PR DESCRIPTION
Alternative would be to use semantic highlight for this, but that would require much more work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced Twirl template support with separate syntax highlighting for HTML, XML, JavaScript, and text variants.
  * Improved file extension detection for .scala.html, .scala.xml, .scala.js, and .scala.txt files.

* **Chores**
  * Updated extension configuration to recognize distinct Twirl language variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->