### PR TITLE
chore: Bump metals to 1.6.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -351,7 +351,7 @@
         },
         "metals.serverVersion": {
           "type": "string",
-          "default": "1.6.5",
+          "default": "1.6.6",
           "markdownDescription": "The version of the Metals server artifact. Requires reloading the window.  \n\n**VS Code extension version is guaranteed to work only with the default version, change if you know what you're doing**"
         },
         "metals.serverProperties": {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the default Metals server version to 1.6.6 in the VSCode extension configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->