### PR TITLE
feat: add TextMate grammar syntax for Twirl HTML files

### DIFF
--- a/package.json
+++ b/package.json
@@ -162,19 +162,16 @@
           "light": "icons/scalameta-logo.png"
         }
       },
-      {
-        "id": "twirl-html",
-        "aliases": [
-          "Twirl HTML"
-        ],
-        "extensions": [
-          ".scala.html"
-        ],
+			{
+				"id": "twirl-html",
+				"extensions": ["*.scala.html"],
+				"aliases": ["Twirl HTML"],
+				"configuration": "./language-configuration.json",
         "icon": {
           "dark": "icons/file_type_play.svg",
           "light": "icons/file_type_play.svg"
         }
-      },
+			},
       {
         "id": "twirl-xml",
         "aliases": [

--- a/package.json
+++ b/package.json
@@ -249,7 +249,7 @@
       },
       {
         "language": "twirl-html",
-        "scopeName": "text.html.twirl",
+        "scopeName": "source.twirl",
         "path": "./syntaxes/twirl-html.json",
         "embeddedLanguages": {
           "text.html.basic": "html"

--- a/package.json
+++ b/package.json
@@ -162,16 +162,20 @@
           "light": "icons/scalameta-logo.png"
         }
       },
-			{
-				"id": "twirl-html",
-				"extensions": ["*.scala.html"],
-				"aliases": ["Twirl HTML"],
-				"configuration": "./syntaxes/language-configurations/twirl-html.language-configuration.json",
+      {
+        "id": "twirl-html",
+        "extensions": [
+          "*.scala.html"
+        ],
+        "aliases": [
+          "Twirl HTML"
+        ],
+        "configuration": "./syntaxes/language-configurations/twirl-html.language-configuration.json",
         "icon": {
           "dark": "icons/file_type_play.svg",
           "light": "icons/file_type_play.svg"
         }
-			},
+      },
       {
         "id": "twirl-xml",
         "aliases": [

--- a/package.json
+++ b/package.json
@@ -251,7 +251,9 @@
         "language": "twirl-html",
         "scopeName": "source.twirl",
         "path": "./syntaxes/twirl-html.json",
-				"unbalancedBracketScopes": ["source.twirl"],
+        "unbalancedBracketScopes": [
+          "source.twirl"
+        ],
         "embeddedLanguages": {
           "text.html.basic": "html"
         }

--- a/package.json
+++ b/package.json
@@ -165,7 +165,7 @@
       {
         "id": "twirl-html",
         "extensions": [
-          "*.scala.html"
+          ".scala.html"
         ],
         "aliases": [
           "Twirl HTML"

--- a/package.json
+++ b/package.json
@@ -251,6 +251,7 @@
         "language": "twirl-html",
         "scopeName": "source.twirl",
         "path": "./syntaxes/twirl-html.json",
+				"unbalancedBracketScopes": ["source.twirl"],
         "embeddedLanguages": {
           "text.html.basic": "html"
         }

--- a/package.json
+++ b/package.json
@@ -166,7 +166,7 @@
 				"id": "twirl-html",
 				"extensions": ["*.scala.html"],
 				"aliases": ["Twirl HTML"],
-				"configuration": "./language-configuration.json",
+				"configuration": "./syntaxes/language-configurations/twirl-html.language-configuration.json",
         "icon": {
           "dark": "icons/file_type_play.svg",
           "light": "icons/file_type_play.svg"

--- a/syntaxes/language-configurations/twirl-html.language-configuration.json
+++ b/syntaxes/language-configurations/twirl-html.language-configuration.json
@@ -1,9 +1,9 @@
 {
   "comments": {
     "lineComment": {
-			"comment": "//",
-			"noIndent": false
-		},
+      "comment": "//",
+      "noIndent": false
+    },
     "blockComment": ["@*", "*@"]
   },
   "brackets": [
@@ -34,47 +34,47 @@
     "markers": {
       "start": "^[^\\S\r\n]*@\\*[^\\S\r\n]*[^\\S\r\n]*.*$",
       "end": "^[\\s]*\\*@[^\\S\\r\\n]*$"
-    },
+    }
   },
   "wordPattern": "(-?\\d*\\.\\d\\w*)|([^\\`\\~\\!\\@\\#\\%\\^\\&\\*\\(\\)\\-\\=\\+\\[\\{\\]\\}\\\\\\|\\;\\:\\'\\\"\\,\\.\\<\\>\\/\\?\\s]+)",
   "indentationRules": {
     "increaseIndentPattern": "^((?!\\/\\/).)*(\\{[^}\"'`]*|\\([^)\"'`]*|\\[[^\\]\"'`]*)$",
     "decreaseIndentPattern": "^((?!.*?\\/\\*).*\\*/)?\\s*[\\)\\}\\]].*$"
   },
-	"onEnterRules": [
-		/* Used to help provide support for block comments */
-		{
-			// if the previous line is a comment AND ends with "*@" (indicating the end of a block comment)
-			"previousLineText": "^[\\s]*\\*[^*@]*$",
-			"beforeText": "^[\\s]*\\*[^*@]*$",
-			"afterText": "^.*\\*\\@$",
-			"action": {
-				"indent": "none",
-				// then do not append " * " to indicate another comment line
-			}
-		},
-		{
-			"beforeText": "^@\\*(?!.*\\*@)[^@\\*]*", // match the start of a Twirl block comment
-			"action": {
-				"indent": "none",
-				"appendText": " * " // then add another comment to the next line
-			},
-		},
-		{
-			"previousLineText": "^@\\*[^]*$", // matches the start of a Twirl block comment with anything following it
-			"beforeText": "^.*$", // matches " * comment" but not " * comment *@"
-			"action": {
-				"indent": "none",
-				"appendText": "* " // then append another comment
-			}
-		},
+  "onEnterRules": [
+    /* Used to help provide support for block comments */
+    {
+      // if the previous line is a comment AND ends with "*@" (indicating the end of a block comment)
+      "previousLineText": "^[\\s]*\\*[^*@]*$",
+      "beforeText": "^[\\s]*\\*[^*@]*$",
+      "afterText": "^.*\\*\\@$",
+      "action": {
+        "indent": "none"
+        // then do not append " * " to indicate another comment line
+      }
+    },
+    {
+      "beforeText": "^@\\*(?!.*\\*@)[^@\\*]*", // match the start of a Twirl block comment
+      "action": {
+        "indent": "none",
+        "appendText": " * " // then add another comment to the next line
+      }
+    },
+    {
+      "previousLineText": "^@\\*[^]*$", // matches the start of a Twirl block comment with anything following it
+      "beforeText": "^.*$", // matches " * comment" but not " * comment *@"
+      "action": {
+        "indent": "none",
+        "appendText": "* " // then append another comment
+      }
+    },
     // This rule was meant to auto-add additional * lines for when a user is inside a
     // like this:
     // @**
     //   * comments
     //   * the "* " was added
     //  *@
-    // twirl comment block, but adding this would cause for every other line to be matched as a comment 
+    // twirl comment block, but adding this would cause for every other line to be matched as a comment
     {
       "beforeText": "^ *\\*[^\\n\\r\\*@]*$",
       "action": {
@@ -82,11 +82,11 @@
         "indent": "none"
       }
     }
-	],
-	"colorizedBracketPairs": [
-		["(", ")"],
-		["[", "]"],
-		["{", "}"],
+  ],
+  "colorizedBracketPairs": [
+    ["(", ")"],
+    ["[", "]"],
+    ["{", "}"],
     ["<", ">"]
-	]
+  ]
 }

--- a/syntaxes/language-configurations/twirl-html.language-configuration.json
+++ b/syntaxes/language-configurations/twirl-html.language-configuration.json
@@ -12,14 +12,14 @@
     ["(", ")"]
   ],
   "autoClosingPairs": [
-    { "open": "{", "close": "}" },
-    { "open": "[", "close": "]" },
-    { "open": "(", "close": ")" },
-    { "open": "'", "close": "'", "notIn": ["string"] },
-    { "open": "\"", "close": "\"" },
-    { "open": "`", "close": "`" },
-    { "open": "@*", "close": "*@", "notIn": ["string", "comment"] },
-    { "open": "/**", "close": " */", "notIn": ["string", "comment"] }
+    { "open": "{", 		"close": "}" 		},
+    { "open": "[", 		"close": "]" 		},
+    { "open": "(", 		"close": ")" 		},
+    { "open": "'", 		"close": "'", 	"notIn": ["string"] },
+    { "open": "\"", 	"close": "\"" 	},
+    { "open": "`", 		"close": "`"		},
+    { "open": "@*", 	"close": "*@", 	"notIn": ["string", "comment"] },
+    { "open": "/**",  "close": " */", "notIn": ["string", "comment"] }
   ],
   "autoCloseBefore": ";:.,=}])><` \n\t",
   "surroundingPairs": [

--- a/syntaxes/language-configurations/twirl-html.language-configuration.json
+++ b/syntaxes/language-configurations/twirl-html.language-configuration.json
@@ -1,0 +1,92 @@
+{
+  "comments": {
+    "lineComment": {
+			"comment": "//",
+			"noIndent": false
+		},
+    "blockComment": ["@*", "*@"]
+  },
+  "brackets": [
+    ["{", "}"],
+    ["[", "]"],
+    ["(", ")"]
+  ],
+  "autoClosingPairs": [
+    { "open": "{", "close": "}" },
+    { "open": "[", "close": "]" },
+    { "open": "(", "close": ")" },
+    { "open": "'", "close": "'", "notIn": ["string"] },
+    { "open": "\"", "close": "\"" },
+    { "open": "`", "close": "`" },
+    { "open": "@*", "close": "*@", "notIn": ["string", "comment"] },
+    { "open": "/**", "close": " */", "notIn": ["string", "comment"] }
+  ],
+  "autoCloseBefore": ";:.,=}])><` \n\t",
+  "surroundingPairs": [
+    ["{", "}"],
+    ["[", "]"],
+    ["(", ")"],
+    ["'", "'"],
+    ["\"", "\""],
+    ["`", "`"]
+  ],
+  "folding": {
+    "markers": {
+      "start": "^[^\\S\r\n]*@\\*[^\\S\r\n]*[^\\S\r\n]*.*$",
+      "end": "^[\\s]*\\*@[^\\S\\r\\n]*$"
+    },
+  },
+  "wordPattern": "(-?\\d*\\.\\d\\w*)|([^\\`\\~\\!\\@\\#\\%\\^\\&\\*\\(\\)\\-\\=\\+\\[\\{\\]\\}\\\\\\|\\;\\:\\'\\\"\\,\\.\\<\\>\\/\\?\\s]+)",
+  "indentationRules": {
+    "increaseIndentPattern": "^((?!\\/\\/).)*(\\{[^}\"'`]*|\\([^)\"'`]*|\\[[^\\]\"'`]*)$",
+    "decreaseIndentPattern": "^((?!.*?\\/\\*).*\\*/)?\\s*[\\)\\}\\]].*$"
+  },
+	"onEnterRules": [
+		/* Used to help provide support for block comments */
+		{
+			// if the previous line is a comment AND ends with "*@" (indicating the end of a block comment)
+			"previousLineText": "^[\\s]*\\*[^*@]*$",
+			"beforeText": "^[\\s]*\\*[^*@]*$",
+			"afterText": "^.*\\*\\@$",
+			"action": {
+				"indent": "none",
+				// then do not append " * " to indicate another comment line
+			}
+		},
+		{
+			"beforeText": "^@\\*(?!.*\\*@)[^@\\*]*", // match the start of a Twirl block comment
+			"action": {
+				"indent": "none",
+				"appendText": " * " // then add another comment to the next line
+			},
+		},
+		{
+			"previousLineText": "^@\\*[^]*$", // matches the start of a Twirl block comment with anything following it
+			"beforeText": "^.*$", // matches " * comment" but not " * comment *@"
+			"action": {
+				"indent": "none",
+				"appendText": "* " // then append another comment
+			}
+		},
+    // This rule was meant to auto-add additional * lines for when a user is inside a
+    // like this:
+    // @**
+    //   * comments
+    //   * the "* " was added
+    //  *@
+    // twirl comment block, but adding this would cause for every other line to be matched as a comment 
+    {
+      "beforeText": "^ *\\*[^\\n\\r\\*@]*$",
+      "action": {
+        "appendText": "* ",
+        "indent": "none"
+      }
+    }
+	],
+	"colorizedBracketPairs": [
+		["(", ")"],
+		["[", "]"],
+		["{", "}"],
+    ["<", ">"]
+	]
+}

--- a/syntaxes/language-configurations/twirl-html.language-configuration.json
+++ b/syntaxes/language-configurations/twirl-html.language-configuration.json
@@ -12,14 +12,14 @@
     ["(", ")"]
   ],
   "autoClosingPairs": [
-    { "open": "{", 		"close": "}" 		},
-    { "open": "[", 		"close": "]" 		},
-    { "open": "(", 		"close": ")" 		},
-    { "open": "'", 		"close": "'", 	"notIn": ["string"] },
-    { "open": "\"", 	"close": "\"" 	},
-    { "open": "`", 		"close": "`"		},
-    { "open": "@*", 	"close": "*@", 	"notIn": ["string", "comment"] },
-    { "open": "/**",  "close": " */", "notIn": ["string", "comment"] }
+    { "open": "{", "close": "}" },
+    { "open": "[", "close": "]" },
+    { "open": "(", "close": ")" },
+    { "open": "'", "close": "'", "notIn": ["string"] },
+    { "open": "\"", "close": "\"" },
+    { "open": "`", "close": "`" },
+    { "open": "@*", "close": "*@", "notIn": ["string", "comment"] },
+    { "open": "/**", "close": " */", "notIn": ["string", "comment"] }
   ],
   "autoCloseBefore": ";:.,=}])><` \n\t",
   "surroundingPairs": [

--- a/syntaxes/twirl-html.json
+++ b/syntaxes/twirl-html.json
@@ -8,7 +8,7 @@
   "repository": {
     "util-match-parens": {
       "name": "meta.util.twirl.parens",
-			"comment": "A utility pattern to match everything inside a set of braces, including nested braces )(, as Scala source.",
+      "comment": "A utility pattern to match everything inside a set of braces, including nested braces )(, as Scala source.",
       "begin": "\\(",
       "end": "\\)",
       "patterns": [
@@ -18,19 +18,19 @@
     },
     "util-match-curly": {
       "name": "meta.util.twirl.curly",
-			"comment": "A utility pattern to match everything inside a set of curly braces }{ as HTML-first source and then further nested @ScalaExpr expressions.",
+      "comment": "A utility pattern to match everything inside a set of curly braces }{ as HTML-first source and then further nested @ScalaExpr expressions.",
       "begin": "\\{",
       "end": "\\}",
       "patterns": [{ "include": "#util-match-curly" }, { "include": "$self" }]
     },
     "symbols-at": {
       "name": "keyword.interpolation.scala",
-			"comment": "Applies colouring to the magic Twirl character @.",
+      "comment": "Applies colouring to the magic Twirl character @.",
       "match": "@"
     },
     "comment-block-twirl": {
       "name": "comment.block",
-			"comment": "A block comment @**@.",
+      "comment": "A block comment @**@.",
       "begin": "@\\*",
       "end": "\\*@"
     },
@@ -53,7 +53,7 @@
       "applyEndPatternLast": 1,
       "begin": "(@)([\\w\\.]*)",
       "end": "(?=[\\n\\r;!#%&*+\\-<@>\/?\\^|~£§])",
-			"comment": "Tries its best to match inline Scala code, starting with @ and ending at some characters where it's not possible to define something by in the Scala program (and is therefore definitely just a normal string)",
+      "comment": "Tries its best to match inline Scala code, starting with @ and ending at some characters where it's not possible to define something by in the Scala program (and is therefore definitely just a normal string)",
       "beginCaptures": {
         "1": { "patterns": [{ "include": "#symbols-at" }] },
         "2": { "name": "keyword.control.twirl.m" }
@@ -65,7 +65,7 @@
     },
     "scala-line": {
       "name": "meta.embedded.scala.scalaLine",
-			"comment": "Scala expression @(t: T) , matching nested braces.",
+      "comment": "Scala expression @(t: T) , matching nested braces.",
       "begin": "(@)[\\w\\.]*\\(",
       "end": "\\)",
       "beginCaptures": {
@@ -82,7 +82,7 @@
       "name": "meta.embedded.scala.curly",
       "begin": "(@)[^\\S\r\n]*\\{$",
       "end": "(?=[\\n ;!#%&*+\\-<@>\/?\\^|~£§])",
-			"comment": "Same as #scala-inline but for curly braces }{ instead.",
+      "comment": "Same as #scala-inline but for curly braces }{ instead.",
       "beginCaptures": {
         "1": { "patterns": [{ "include": "#symbols-at" }] }
       },
@@ -92,7 +92,7 @@
       "name": "meta.embedded.scala.source.block",
       "begin": "(@)[\\w\\.]*\\{",
       "end": "\\}",
-			"comment": "I don't know what this does anymore. I learnt that we could add comments here too late.",
+      "comment": "I don't know what this does anymore. I learnt that we could add comments here too late.",
       "beginCaptures": {
         "1": { "patterns": [{ "include": "#symbols-at" }] }
       },
@@ -105,7 +105,7 @@
       "name": "meta.embedded.scala.source.expr",
       "begin": "(@)([\\w\\.]*)\\(",
       "end": "\\)",
-			"comment": "A Scala expression in Twirl - matching @something(...).",
+      "comment": "A Scala expression in Twirl - matching @something(...).",
       "beginCaptures": {
         "1": { "patterns": [{ "include": "#symbols-at" }] },
         "2": {
@@ -124,7 +124,7 @@
     "scala-importStatement": {
       "name": "meta.embedded.scala.source.importStatementLine",
       "match": "(@)[ ]*(import [^@*\\n\\r]*)(.*)",
-			"comment": "An import statement, attempts to capture anything that isn't @* and then match that as Scala source, then match the remainder after that as a Twirl comment.",
+      "comment": "An import statement, attempts to capture anything that isn't @* and then match that as Scala source, then match the remainder after that as a Twirl comment.",
       "captures": {
         "1": { "patterns": [{ "include": "#symbols-at" }] },
         "2": { "patterns": [{ "include": "source.scala" }] },
@@ -142,7 +142,7 @@
       "name": "meta.embedded.twirl.source.templateBlock",
       "begin": "(@)([\\w\\.]*)\\s*\\=\\s*\\{",
       "end": "\\}",
-			"comment": "Attempts to match a template block in assignment, so @ something = { ... }",
+      "comment": "Attempts to match a template block in assignment, so @ something = { ... }",
       "beginCaptures": {
         "1": { "patterns": [{ "include": "#symbols-at" }] },
         "2": { "patterns": [{ "name": "keyword.control" }] }
@@ -156,7 +156,7 @@
       "name": "meta.embedded.twirl.templateHeader.parameters.ident",
       "begin": "(@)([\\s]+[(][^)]*\\))(\\g<2>*)",
       "end": "(?:[\\s]*)[)]([\\s]*[(][^)]*[)])*",
-			"comment": "Attempts to match the template parameters of a Twirl HTML file.",
+      "comment": "Attempts to match the template parameters of a Twirl HTML file.",
       "beginCaptures": {
         "1": { "patterns": [{ "include": "#symbols-at" }] },
         "0": { "patterns": [{ "include": "source.scala" }] }

--- a/syntaxes/twirl-html.json
+++ b/syntaxes/twirl-html.json
@@ -141,12 +141,6 @@
         { "include": "$self" }
       ]
     },
-    "twirl-in-html": {
-      "name": "meta.embedded.twirl.inlineTwirl",
-      "begin": "<",
-      "end": ">",
-      "patterns": [{ "include": "$self" }, { "include": "#html-inline-attr" }]
-    },
     "twirl-template-params": {
       "name": "meta.embedded.twirl.templateHeader.parameters.ident",
       "begin": "(@)([\\s]+[(][^)]*\\))(\\g<2>*)",

--- a/syntaxes/twirl-html.json
+++ b/syntaxes/twirl-html.json
@@ -1,10 +1,195 @@
 {
   "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
   "name": "Twirl HTML",
-  "scopeName": "text.html.twirl",
-  "patterns": [
-    {
-      "include": "text.html.basic"
+  "scopeName": "source.twirl",
+  "fileTypes": ["scala.html"],
+  "foldingStartMarker": "^[^\\S\\r\\n]*@\\*[^\\S\\r\\n]*[^\\S\\r\\n]*.*$",
+  "foldingStopMarker": "^[\\s]*\\*@[^\\S\\r\\n]*$",
+  "repository": {
+    "util-match-parens": {
+      "name": "meta.util.twirl.parens",
+      "begin": "\\(",
+      "end": "\\)",
+      "patterns": [
+        { "include": "#util-match-parens" },
+        { "include": "source.scala" }
+      ]
+    },
+    "util-match-curly": {
+      "name": "meta.util.twirl.curly",
+      "begin": "\\{",
+      "end": "\\}",
+      "patterns": [
+        { "include": "#util-match-curly" },
+        { "include": "$self" }
+      ]
+    },
+    "symbols-at": {
+      "name": "keyword.interpolation.scala",
+      "match": "@"
+    },
+    "comment-block-twirl": {
+      "name": "comment.block",
+      "begin": "@\\*",
+      "end": "\\*@"
+    },
+    "comment-line-twirl": {
+      "name": "comment.line",
+      "match": "\/\/\/*.*"
+    },
+
+    "scala-explicit-implicits": {
+      "name": "meta.embedded.scala.explicitImplicits",
+      "match": "(@)([^\\)\\n\\r]*\\([^\\)\\n\\r]*\\)[ ]*\\([^\\)\\n\\r]*\\)[ ]*)",
+      "comment": "Matches implicit values provided to any method.",
+      "captures": {
+        "1": { "patterns": [{ "include": "#symbols-at" }] },
+        "2": { "patterns": [{ "include": "source.scala" }] }
+      }
+    },
+    "scala-inline": {
+      "name": "meta.embedded.scala.inlineScala",
+      "applyEndPatternLast": 1,
+      "begin": "(@)([\\w\\.]*)",
+      "end": "(?=[\\n\\r;!#%&*+\\-<@>\/?\\^|~£§])",
+      "beginCaptures": {
+        "1": { "patterns": [{ "include": "#symbols-at" }] },
+        "2": { "name": "keyword.control.twirl.m" }
+      },
+      "patterns": [
+        { "include": "#comment-block-twirl" },
+        { "include": "source.scala" }
+      ]
+    },
+    "scala-line": {
+      "name": "meta.embedded.scala.scalaLine",
+      "begin": "(@)[\\w\\.]*\\(",
+      "end": "\\)",
+      "beginCaptures": {
+        "1": { "patterns": [{ "include": "#symbols-at" }] }
+      },
+      "patterns": [
+        { "include": "#util-match-parens" },
+        { "include": "#symbols-at" },
+        { "include": "#comment-block-twirl" },
+        { "include": "source.scala" }
+      ]
+    },
+    "scala-line-curly": {
+      "name": "meta.embedded.scala.curly",
+      "begin": "(@)[^\\S\r\n]*\\{$",
+      "end": "(?=[\\n ;!#%&*+\\-<@>\/?\\^|~£§])",
+      "beginCaptures": {
+        "1": { "patterns": [{ "include": "#symbols-at" }] }
+      },
+      "patterns": [
+        { "include": "#util-match-curly" },
+        { "include": "$self" }
+      ]
+    },
+    "scala-block": {
+      "name": "meta.embedded.scala.source.block",
+      "begin": "(@)[\\w\\.]*\\{",
+      "end": "\\}",
+      "beginCaptures": {
+        "1": { "patterns": [{ "include": "#symbols-at" }] }
+      },
+      "patterns": [
+        { "include": "#util-match-curly" },
+        { "include": "source.scala" }
+      ]
+    },
+    "scala-expr": {
+      "name": "meta.embedded.scala.source.expr",
+      "begin": "(@)([\\w\\.]*)\\(",
+      "end": "\\)",
+      "beginCaptures": {
+        "1": { "patterns": [{ "include": "#symbols-at" }] },
+        "2": { "patterns": [{ "include": "#keyword-this" }, { "include": "source.scala" }] }
+      },
+      "patterns": [
+        { "include": "#util-match-parens" },
+        { "include": "#keyword-this" },
+        { "include": "source.scala" }
+      ]
+    },
+    "scala-importStatement": {
+      "name": "meta.embedded.scala.source.importStatementLine",
+      "match": "(@)[ ]*(import [^@*\\n\\r]*)(.*)",
+      "captures": {
+        "1": { "patterns": [{ "include": "#symbols-at" }] },
+        "2": { "patterns": [{ "include": "source.scala" }] },
+        "3": { "patterns": [{ "include": "#comment-block-twirl" }] }
+      }
+    },
+
+    "util-match-curly-template-block": {
+      "name": "meta.embedded.util.matchCurlyTemplateBlock",
+      "begin": "\\{",
+      "end": "\\}",
+      "patterns": [
+        { "include": "#twirl-in-html" },
+        { "include": "$self" }
+      ]
+    },
+    "scala-template-block": {
+      "name": "meta.embedded.twirl.source.templateBlock",
+      "begin": "(@)([\\w\\.]*)\\s*\\=\\s*\\{",
+      "end": "\\}",
+      "beginCaptures": {
+        "1": { "patterns": [{ "include": "#symbols-at" }] },
+        "2": { "patterns": [{ "name": "keyword.control" }] }
+      },
+      "patterns": [
+        { "include": "#util-match-curly-template-block" },
+        { "include": "$self" }
+      ]
+    },
+		"twirl-in-html": {
+			"name": "meta.embedded.twirl.inlineTwirl",
+			"begin": "<",
+			"end": ">",
+			"patterns": [
+				{ "include": "$self" },
+				{ "include": "#html-inline-attr" }
+			]
+		},
+    "twirl-template-params": {
+      "name": "meta.embedded.twirl.templateHeader.parameters.ident",
+      "begin": "(@)([\\s]*[(][^)]*\\))(\\g<2>*)",
+      "end": "(?:[\\s]*)[)]([\\s]*[(][^)]*[)])*",
+      "beginCaptures": {
+        "1": { "patterns": [{ "include": "#keyword-at" }] },
+        "0": { "patterns": [{ "include": "source.scala" }] }
+      },
+      "endCaptures": { "0": { "patterns": [{ "include": "source.scala" }] } },
+      "patterns": [
+        { "include": "source.scala" }
+      ]
+    },
+    "escape-at": {
+      "name": "string",
+      "match": "@@"
+    },
+    "keyword-this": {
+      "name": "keyword",
+      "match": "\\b(this)\\b"
     }
+  },
+  "patterns": [
+    { "include": "#escape-at" },
+    { "include": "#comment-line-twirl" },
+    { "include": "#comment-block-twirl" },
+    { "include": "#twirl-template-params" },
+    { "include": "#scala-explicit-implicits" },
+    { "include": "#scala-template-block" },
+    { "include": "#scala-block" },
+    { "include": "#scala-expr" },
+    { "include": "#scala-line" },
+    { "include": "#scala-importStatement" },
+    { "include": "#scala-inline" },
+    { "include": "#scala-line-curly" },
+    { "include": "#symbols-at" },
+    { "include": "text.html.derivative" }
   ]
 }

--- a/syntaxes/twirl-html.json
+++ b/syntaxes/twirl-html.json
@@ -126,7 +126,7 @@
       "name": "meta.embedded.util.matchCurlyTemplateBlock",
       "begin": "\\{",
       "end": "\\}",
-      "patterns": [{ "include": "#twirl-in-html" }, { "include": "$self" }]
+      "patterns": [{ "include": "$self" }]
     },
     "scala-template-block": {
       "name": "meta.embedded.twirl.source.templateBlock",

--- a/syntaxes/twirl-html.json
+++ b/syntaxes/twirl-html.json
@@ -152,7 +152,7 @@
       "begin": "(@)([\\s]*[(][^)]*\\))(\\g<2>*)",
       "end": "(?:[\\s]*)[)]([\\s]*[(][^)]*[)])*",
       "beginCaptures": {
-        "1": { "patterns": [{ "include": "#keyword-at" }] },
+        "1": { "patterns": [{ "include": "#symbols-at" }] },
         "0": { "patterns": [{ "include": "source.scala" }] }
       },
       "endCaptures": { "0": { "patterns": [{ "include": "source.scala" }] } },

--- a/syntaxes/twirl-html.json
+++ b/syntaxes/twirl-html.json
@@ -19,10 +19,7 @@
       "name": "meta.util.twirl.curly",
       "begin": "\\{",
       "end": "\\}",
-      "patterns": [
-        { "include": "#util-match-curly" },
-        { "include": "$self" }
-      ]
+      "patterns": [{ "include": "#util-match-curly" }, { "include": "$self" }]
     },
     "symbols-at": {
       "name": "keyword.interpolation.scala",
@@ -82,10 +79,7 @@
       "beginCaptures": {
         "1": { "patterns": [{ "include": "#symbols-at" }] }
       },
-      "patterns": [
-        { "include": "#util-match-curly" },
-        { "include": "$self" }
-      ]
+      "patterns": [{ "include": "#util-match-curly" }, { "include": "$self" }]
     },
     "scala-block": {
       "name": "meta.embedded.scala.source.block",
@@ -105,7 +99,12 @@
       "end": "\\)",
       "beginCaptures": {
         "1": { "patterns": [{ "include": "#symbols-at" }] },
-        "2": { "patterns": [{ "include": "#keyword-this" }, { "include": "source.scala" }] }
+        "2": {
+          "patterns": [
+            { "include": "#keyword-this" },
+            { "include": "source.scala" }
+          ]
+        }
       },
       "patterns": [
         { "include": "#util-match-parens" },
@@ -127,10 +126,7 @@
       "name": "meta.embedded.util.matchCurlyTemplateBlock",
       "begin": "\\{",
       "end": "\\}",
-      "patterns": [
-        { "include": "#twirl-in-html" },
-        { "include": "$self" }
-      ]
+      "patterns": [{ "include": "#twirl-in-html" }, { "include": "$self" }]
     },
     "scala-template-block": {
       "name": "meta.embedded.twirl.source.templateBlock",
@@ -145,15 +141,12 @@
         { "include": "$self" }
       ]
     },
-		"twirl-in-html": {
-			"name": "meta.embedded.twirl.inlineTwirl",
-			"begin": "<",
-			"end": ">",
-			"patterns": [
-				{ "include": "$self" },
-				{ "include": "#html-inline-attr" }
-			]
-		},
+    "twirl-in-html": {
+      "name": "meta.embedded.twirl.inlineTwirl",
+      "begin": "<",
+      "end": ">",
+      "patterns": [{ "include": "$self" }, { "include": "#html-inline-attr" }]
+    },
     "twirl-template-params": {
       "name": "meta.embedded.twirl.templateHeader.parameters.ident",
       "begin": "(@)([\\s]*[(][^)]*\\))(\\g<2>*)",
@@ -163,9 +156,7 @@
         "0": { "patterns": [{ "include": "source.scala" }] }
       },
       "endCaptures": { "0": { "patterns": [{ "include": "source.scala" }] } },
-      "patterns": [
-        { "include": "source.scala" }
-      ]
+      "patterns": [{ "include": "source.scala" }]
     },
     "escape-at": {
       "name": "string",

--- a/syntaxes/twirl-html.json
+++ b/syntaxes/twirl-html.json
@@ -149,7 +149,7 @@
     },
     "twirl-template-params": {
       "name": "meta.embedded.twirl.templateHeader.parameters.ident",
-      "begin": "(@)([\\s]*[(][^)]*\\))(\\g<2>*)",
+      "begin": "(@)([\\s]+[(][^)]*\\))(\\g<2>*)",
       "end": "(?:[\\s]*)[)]([\\s]*[(][^)]*[)])*",
       "beginCaptures": {
         "1": { "patterns": [{ "include": "#symbols-at" }] },

--- a/syntaxes/twirl-html.json
+++ b/syntaxes/twirl-html.json
@@ -8,6 +8,7 @@
   "repository": {
     "util-match-parens": {
       "name": "meta.util.twirl.parens",
+			"comment": "A utility pattern to match everything inside a set of braces, including nested braces )(, as Scala source.",
       "begin": "\\(",
       "end": "\\)",
       "patterns": [
@@ -17,16 +18,19 @@
     },
     "util-match-curly": {
       "name": "meta.util.twirl.curly",
+			"comment": "A utility pattern to match everything inside a set of curly braces }{ as HTML-first source and then further nested @ScalaExpr expressions.",
       "begin": "\\{",
       "end": "\\}",
       "patterns": [{ "include": "#util-match-curly" }, { "include": "$self" }]
     },
     "symbols-at": {
       "name": "keyword.interpolation.scala",
+			"comment": "Applies colouring to the magic Twirl character @.",
       "match": "@"
     },
     "comment-block-twirl": {
       "name": "comment.block",
+			"comment": "A block comment @**@.",
       "begin": "@\\*",
       "end": "\\*@"
     },
@@ -49,6 +53,7 @@
       "applyEndPatternLast": 1,
       "begin": "(@)([\\w\\.]*)",
       "end": "(?=[\\n\\r;!#%&*+\\-<@>\/?\\^|~£§])",
+			"comment": "Tries its best to match inline Scala code, starting with @ and ending at some characters where it's not possible to define something by in the Scala program (and is therefore definitely just a normal string)",
       "beginCaptures": {
         "1": { "patterns": [{ "include": "#symbols-at" }] },
         "2": { "name": "keyword.control.twirl.m" }
@@ -60,6 +65,7 @@
     },
     "scala-line": {
       "name": "meta.embedded.scala.scalaLine",
+			"comment": "Scala expression @(t: T) , matching nested braces.",
       "begin": "(@)[\\w\\.]*\\(",
       "end": "\\)",
       "beginCaptures": {
@@ -76,6 +82,7 @@
       "name": "meta.embedded.scala.curly",
       "begin": "(@)[^\\S\r\n]*\\{$",
       "end": "(?=[\\n ;!#%&*+\\-<@>\/?\\^|~£§])",
+			"comment": "Same as #scala-inline but for curly braces }{ instead.",
       "beginCaptures": {
         "1": { "patterns": [{ "include": "#symbols-at" }] }
       },
@@ -85,6 +92,7 @@
       "name": "meta.embedded.scala.source.block",
       "begin": "(@)[\\w\\.]*\\{",
       "end": "\\}",
+			"comment": "I don't know what this does anymore. I learnt that we could add comments here too late.",
       "beginCaptures": {
         "1": { "patterns": [{ "include": "#symbols-at" }] }
       },
@@ -97,6 +105,7 @@
       "name": "meta.embedded.scala.source.expr",
       "begin": "(@)([\\w\\.]*)\\(",
       "end": "\\)",
+			"comment": "A Scala expression in Twirl - matching @something(...).",
       "beginCaptures": {
         "1": { "patterns": [{ "include": "#symbols-at" }] },
         "2": {
@@ -115,6 +124,7 @@
     "scala-importStatement": {
       "name": "meta.embedded.scala.source.importStatementLine",
       "match": "(@)[ ]*(import [^@*\\n\\r]*)(.*)",
+			"comment": "An import statement, attempts to capture anything that isn't @* and then match that as Scala source, then match the remainder after that as a Twirl comment.",
       "captures": {
         "1": { "patterns": [{ "include": "#symbols-at" }] },
         "2": { "patterns": [{ "include": "source.scala" }] },
@@ -132,6 +142,7 @@
       "name": "meta.embedded.twirl.source.templateBlock",
       "begin": "(@)([\\w\\.]*)\\s*\\=\\s*\\{",
       "end": "\\}",
+			"comment": "Attempts to match a template block in assignment, so @ something = { ... }",
       "beginCaptures": {
         "1": { "patterns": [{ "include": "#symbols-at" }] },
         "2": { "patterns": [{ "name": "keyword.control" }] }
@@ -145,6 +156,7 @@
       "name": "meta.embedded.twirl.templateHeader.parameters.ident",
       "begin": "(@)([\\s]+[(][^)]*\\))(\\g<2>*)",
       "end": "(?:[\\s]*)[)]([\\s]*[(][^)]*[)])*",
+			"comment": "Attempts to match the template parameters of a Twirl HTML file.",
       "beginCaptures": {
         "1": { "patterns": [{ "include": "#symbols-at" }] },
         "0": { "patterns": [{ "include": "source.scala" }] }


### PR DESCRIPTION
This is an initial PR asking for initial feedback on a TextMate grammar that I have been working on for Twirl's HTML files.

It is important to know that there are definitely some edge cases to this Twirl syntax. I have tried my absolute best with whatever knowledge I currently have about regex, but it seems that you can't get more-complex regexes working correctly.

Some of these edge cases can be:
- Note that the second paramter list is not coloured or picked up as scala source
<img width="249" height="63" alt="Image" src="https://github.com/user-attachments/assets/7abc02fc-2ec4-4a25-b8c6-e0b832a32041" />

- There are also some issues with an example such as this below:
<img width="303" height="61" alt="image" src="https://github.com/user-attachments/assets/16eedf50-fe20-4530-b0cb-dac0eaeb5a4f" />

- ~~`<`, `>` chars always show up as red - not exactly sure why this is happening, my guess is that it it doesn't get picked up as scala source, and then goes through to the HTML grammar, which expects a tag and doesn't find that, so shows up as an illegal char.~~ (resolved)
 This is an example of what I have tried to remedy the issue:
```json
		"ignore-only-gtlt": {
			"name": "string.other",
			"match": "(.*)(<|>)(.*)",
			"captures": {
				"1": { "patterns": [{ "include": "source.scala" }] },
				"2": { "name": "string.other" },
				"3": { "patterns": [{ "include": "source.scala" }] }
			}
		},
```
The main idea here is that we catch anything before and after `<` or `>`, and then we manually catch `<`, `>` and put them as strings or something, but I have found that this generally causes more harm than good, see:
<img width="435" height="35" alt="image" src="https://github.com/user-attachments/assets/4f78df17-09c8-4219-9f70-6f70ba9abf7a" />

> There are also some concerns around the performance of the regex `.*(<|>).*` - see [[Details of the Cloudflare outage on July 2, 2019](https://blog.cloudflare.com/details-of-the-cloudflare-outage-on-july-2-2019/)] in which a similar regex, `.*=.*` led to catastrophic backtracking and heavy CPU utilisation.

It also seems to mess up HTML tags -
<img width="1044" height="25" alt="image" src="https://github.com/user-attachments/assets/1bf6a6f6-eb47-4518-99e7-8cde4c05da54" />

I think it's probably best to leave to just leave this and let semantic tokens pick up the slack here.

- As you can see in the below screenshot, any inline scala is not recognised inside HTML tags. If I wanted to correct this, I would have effectively had to fork the HTML grammar and add my own patterns in there which definitely isn't a good idea (adding lots of maintenance overhead, complexity, etc).

<img width="680" height="310" alt="Image" src="https://github.com/user-attachments/assets/2a9dad31-a581-43ff-8d0d-4d77079cf26d" />

Perhaps one of the worser-instances of this is as follows:
<img width="973" height="21" alt="image" src="https://github.com/user-attachments/assets/9009ca26-c13c-4f12-9b00-9096da25b4c7" />

The idea here is that the implementation of semantic highlighting is going to address a lot of these issues, and that the textmate grammar added here is enough for _most_ cases and should serve fine as a temporary colouring until the language server (in this instance, Metals) can jump in and resolve the tokens and traverse the AST. I am currently working on an implementation of these in my own repository in https://github.com/AsadHumayun/twirl-semantic-tokens/blob/main/src/main/scala/traverser/Traverser.scala. I am working on it, don't expect it soon, but I am making some progress on adding these. 

This PR brings in https://github.com/AsadHumayun/twirl-grammars/commit/fb7f6108067d048cb6c8b4937fec5024e7635cab of the grammar. (not as a submodule or anything, just a note for myself to where this was taken from)

Partially addresses #1882.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced Twirl language support with broader file recognition and improved syntax highlighting
  * Added smart bracket/quote auto-closing, auto-indentation, and bracket colorization
  * Improved folding for Twirl block comments and template sections
  * Automatic comment formatting and on-enter behavior for Twirl block comments
<!-- end of auto-generated comment: release notes by coderabbit.ai -->