### PR TITLE
fix: preserve env var values containing '=' in runMain

### DIFF
--- a/src/debugger/parseEnvVariables.ts
+++ b/src/debugger/parseEnvVariables.ts
@@ -3,15 +3,17 @@
  * Splits only on the first '=' so that values containing '=' are preserved.
  */
 export function parseEnvVariables(
-    environmentVariables: string[],
+    environmentVariables: string[]
 ): Record<string, string> {
     return environmentVariables.reduce<Record<string, string>>(
         (acc, envKeyValue) => {
             const eqIdx = envKeyValue.indexOf("=");
-            const key = envKeyValue.substring(0, eqIdx);
-            const value = envKeyValue.substring(eqIdx + 1);
-            return { ...acc, [key]: value };
+            if (eqIdx <= 0) return acc; // skip malformed entries and empty keys
+            const key = envKeyValue.slice(0, eqIdx);
+            const value = envKeyValue.slice(eqIdx + 1);
+            acc[key] = value;
+            return acc;
         },
-        {},
+        {}
     );
 }

--- a/src/debugger/parseEnvVariables.ts
+++ b/src/debugger/parseEnvVariables.ts
@@ -3,17 +3,19 @@
  * Splits only on the first '=' so that values containing '=' are preserved.
  */
 export function parseEnvVariables(
-    environmentVariables: string[]
+  environmentVariables: string[],
 ): Record<string, string> {
-    return environmentVariables.reduce<Record<string, string>>(
-        (acc, envKeyValue) => {
-            const eqIdx = envKeyValue.indexOf("=");
-            if (eqIdx <= 0) return acc; // skip malformed entries and empty keys
-            const key = envKeyValue.slice(0, eqIdx);
-            const value = envKeyValue.slice(eqIdx + 1);
-            acc[key] = value;
-            return acc;
-        },
-        {}
-    );
+  return environmentVariables.reduce<Record<string, string>>(
+    (acc, envKeyValue) => {
+      const eqIdx = envKeyValue.indexOf("=");
+      if (eqIdx <= 0) {
+        return acc; // skip malformed entries and empty keys
+      }
+      const key = envKeyValue.slice(0, eqIdx);
+      const value = envKeyValue.slice(eqIdx + 1);
+      acc[key] = value;
+      return acc;
+    },
+    {},
+  );
 }

--- a/src/debugger/parseEnvVariables.ts
+++ b/src/debugger/parseEnvVariables.ts
@@ -1,0 +1,17 @@
+/**
+ * Parse env variable strings of the form "KEY=VALUE" into a record.
+ * Splits only on the first '=' so that values containing '=' are preserved.
+ */
+export function parseEnvVariables(
+    environmentVariables: string[],
+): Record<string, string> {
+    return environmentVariables.reduce<Record<string, string>>(
+        (acc, envKeyValue) => {
+            const eqIdx = envKeyValue.indexOf("=");
+            const key = envKeyValue.substring(0, eqIdx);
+            const value = envKeyValue.substring(eqIdx + 1);
+            return { ...acc, [key]: value };
+        },
+        {},
+    );
+}

--- a/src/debugger/scalaDebugger.ts
+++ b/src/debugger/scalaDebugger.ts
@@ -115,6 +115,10 @@ function escapedShellCommand(
   }
 }
 
+/**
+ * Run a Scala main class as a VS Code task with the given environment variables.
+ * Falls back to a debug session if no workspace folder is available.
+ */
 async function runMain(main: ExtendedScalaRunMain): Promise<boolean> {
   const environmentVariables = main.data.environmentVariables;
   const workspaceFolder = currentWorkspaceFolder();

--- a/src/debugger/scalaDebugger.ts
+++ b/src/debugger/scalaDebugger.ts
@@ -19,6 +19,7 @@ import {
   RunType,
 } from "../interfaces/DebugDiscoveryParams";
 import { ServerCommands } from "../interfaces/ServerCommands";
+import { parseEnvVariables } from "./parseEnvVariables";
 
 const configurationType = "scala";
 
@@ -118,13 +119,7 @@ async function runMain(main: ExtendedScalaRunMain): Promise<boolean> {
   const environmentVariables = main.data.environmentVariables;
   const workspaceFolder = currentWorkspaceFolder();
   if (workspaceFolder) {
-    const env = environmentVariables.reduce<Record<string, string>>(
-      (acc, envKeyValue) => {
-        const [key, value] = envKeyValue.split("=");
-        return { ...acc, [key]: value };
-      },
-      {},
-    );
+    const env = parseEnvVariables(environmentVariables);
 
     const task = new Task(
       { type: "scala", task: "run", class: main.data.class },

--- a/src/test/unit/parseEnvVariables.test.ts
+++ b/src/test/unit/parseEnvVariables.test.ts
@@ -2,33 +2,40 @@ import * as assert from "assert";
 import { parseEnvVariables } from "../../debugger/parseEnvVariables";
 
 describe("parseEnvVariables", () => {
-  it("parses simple key=value pairs", () => {
-    const result = parseEnvVariables(["FOO=bar", "BAZ=qux"]);
-    assert.deepStrictEqual(result, { FOO: "bar", BAZ: "qux" });
-  });
 
-  it("preserves values containing '=' characters", () => {
-    const result = parseEnvVariables([
-      "JAVA_TOOL_OPTIONS=-Dhttp.proxyHost=cias.example.com -Dhttp.proxyPort=8080",
-    ]);
-    assert.deepStrictEqual(result, {
-      JAVA_TOOL_OPTIONS:
-        "-Dhttp.proxyHost=cias.example.com -Dhttp.proxyPort=8080",
+    it("ignores malformed entries without a valid key", () => {
+        const result = parseEnvVariables(["NO_EQUALS", "=value", "OK=1"]);
+        assert.deepStrictEqual(result, { OK: "1" });
     });
-  });
 
-  it("handles multiple '=' in value", () => {
-    const result = parseEnvVariables(["OPTS=a=b=c=d"]);
-    assert.deepStrictEqual(result, { OPTS: "a=b=c=d" });
-  });
 
-  it("handles empty value", () => {
-    const result = parseEnvVariables(["EMPTY="]);
-    assert.deepStrictEqual(result, { EMPTY: "" });
-  });
+    it("parses simple key=value pairs", () => {
+        const result = parseEnvVariables(["FOO=bar", "BAZ=qux"]);
+        assert.deepStrictEqual(result, { FOO: "bar", BAZ: "qux" });
+    });
 
-  it("returns empty object for empty input", () => {
-    const result = parseEnvVariables([]);
-    assert.deepStrictEqual(result, {});
-  });
+    it("preserves values containing '=' characters", () => {
+        const result = parseEnvVariables([
+            "JAVA_TOOL_OPTIONS=-Dhttp.proxyHost=cias.example.com -Dhttp.proxyPort=8080",
+        ]);
+        assert.deepStrictEqual(result, {
+            JAVA_TOOL_OPTIONS:
+                "-Dhttp.proxyHost=cias.example.com -Dhttp.proxyPort=8080",
+        });
+    });
+
+    it("handles multiple '=' in value", () => {
+        const result = parseEnvVariables(["OPTS=a=b=c=d"]);
+        assert.deepStrictEqual(result, { OPTS: "a=b=c=d" });
+    });
+
+    it("handles empty value", () => {
+        const result = parseEnvVariables(["EMPTY="]);
+        assert.deepStrictEqual(result, { EMPTY: "" });
+    });
+
+    it("returns empty object for empty input", () => {
+        const result = parseEnvVariables([]);
+        assert.deepStrictEqual(result, {});
+    });
 });

--- a/src/test/unit/parseEnvVariables.test.ts
+++ b/src/test/unit/parseEnvVariables.test.ts
@@ -2,40 +2,38 @@ import * as assert from "assert";
 import { parseEnvVariables } from "../../debugger/parseEnvVariables";
 
 describe("parseEnvVariables", () => {
+  it("ignores malformed entries without a valid key", () => {
+    const result = parseEnvVariables(["NO_EQUALS", "=value", "OK=1"]);
+    assert.deepStrictEqual(result, { OK: "1" });
+  });
 
-    it("ignores malformed entries without a valid key", () => {
-        const result = parseEnvVariables(["NO_EQUALS", "=value", "OK=1"]);
-        assert.deepStrictEqual(result, { OK: "1" });
+  it("parses simple key=value pairs", () => {
+    const result = parseEnvVariables(["FOO=bar", "BAZ=qux"]);
+    assert.deepStrictEqual(result, { FOO: "bar", BAZ: "qux" });
+  });
+
+  it("preserves values containing '=' characters", () => {
+    const result = parseEnvVariables([
+      "JAVA_TOOL_OPTIONS=-Dhttp.proxyHost=cias.example.com -Dhttp.proxyPort=8080",
+    ]);
+    assert.deepStrictEqual(result, {
+      JAVA_TOOL_OPTIONS:
+        "-Dhttp.proxyHost=cias.example.com -Dhttp.proxyPort=8080",
     });
+  });
 
+  it("handles multiple '=' in value", () => {
+    const result = parseEnvVariables(["OPTS=a=b=c=d"]);
+    assert.deepStrictEqual(result, { OPTS: "a=b=c=d" });
+  });
 
-    it("parses simple key=value pairs", () => {
-        const result = parseEnvVariables(["FOO=bar", "BAZ=qux"]);
-        assert.deepStrictEqual(result, { FOO: "bar", BAZ: "qux" });
-    });
+  it("handles empty value", () => {
+    const result = parseEnvVariables(["EMPTY="]);
+    assert.deepStrictEqual(result, { EMPTY: "" });
+  });
 
-    it("preserves values containing '=' characters", () => {
-        const result = parseEnvVariables([
-            "JAVA_TOOL_OPTIONS=-Dhttp.proxyHost=cias.example.com -Dhttp.proxyPort=8080",
-        ]);
-        assert.deepStrictEqual(result, {
-            JAVA_TOOL_OPTIONS:
-                "-Dhttp.proxyHost=cias.example.com -Dhttp.proxyPort=8080",
-        });
-    });
-
-    it("handles multiple '=' in value", () => {
-        const result = parseEnvVariables(["OPTS=a=b=c=d"]);
-        assert.deepStrictEqual(result, { OPTS: "a=b=c=d" });
-    });
-
-    it("handles empty value", () => {
-        const result = parseEnvVariables(["EMPTY="]);
-        assert.deepStrictEqual(result, { EMPTY: "" });
-    });
-
-    it("returns empty object for empty input", () => {
-        const result = parseEnvVariables([]);
-        assert.deepStrictEqual(result, {});
-    });
+  it("returns empty object for empty input", () => {
+    const result = parseEnvVariables([]);
+    assert.deepStrictEqual(result, {});
+  });
 });

--- a/src/test/unit/parseEnvVariables.test.ts
+++ b/src/test/unit/parseEnvVariables.test.ts
@@ -1,0 +1,34 @@
+import * as assert from "assert";
+import { parseEnvVariables } from "../../debugger/parseEnvVariables";
+
+describe("parseEnvVariables", () => {
+  it("parses simple key=value pairs", () => {
+    const result = parseEnvVariables(["FOO=bar", "BAZ=qux"]);
+    assert.deepStrictEqual(result, { FOO: "bar", BAZ: "qux" });
+  });
+
+  it("preserves values containing '=' characters", () => {
+    const result = parseEnvVariables([
+      "JAVA_TOOL_OPTIONS=-Dhttp.proxyHost=cias.example.com -Dhttp.proxyPort=8080",
+    ]);
+    assert.deepStrictEqual(result, {
+      JAVA_TOOL_OPTIONS:
+        "-Dhttp.proxyHost=cias.example.com -Dhttp.proxyPort=8080",
+    });
+  });
+
+  it("handles multiple '=' in value", () => {
+    const result = parseEnvVariables(["OPTS=a=b=c=d"]);
+    assert.deepStrictEqual(result, { OPTS: "a=b=c=d" });
+  });
+
+  it("handles empty value", () => {
+    const result = parseEnvVariables(["EMPTY="]);
+    assert.deepStrictEqual(result, { EMPTY: "" });
+  });
+
+  it("returns empty object for empty input", () => {
+    const result = parseEnvVariables([]);
+    assert.deepStrictEqual(result, {});
+  });
+});


### PR DESCRIPTION
Addressing Issue #1921 


split("=") splits on every '=' character, causing values like JAVA_TOOL_OPTIONS="-Dhttp.proxyHost=example.com -Dhttp.proxyPort=8080" to be truncated at the first '=' in the value.

Use indexOf("=") to split only on the first '=' so the full value is preserved. Extract parseEnvVariables into its own module for testability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved environment variable parsing in the debugger by extracting parsing logic into a dedicated helper, enhancing maintainability and code reusability.

* **Tests**
  * Added comprehensive unit tests covering standard parsing, values with special characters, and edge cases for environment variable handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->