### PR TITLE
Declare metals.trace.server

### DIFF
--- a/package.json
+++ b/package.json
@@ -663,6 +663,17 @@
           "type": "boolean",
           "default": false,
           "markdownDescription": "If Metals should start an HTTP Model Context Protocol server, that can be used by AI tools to provide better context about the codebase. Needs to be enabled in the client as well."
+        },
+        "metals.trace.server": {
+          "type": "string",
+          "enum": [
+            "off",
+            "messages",
+            "verbose"
+          ],
+          "default": "off",
+          "description": "Traces the communication between VS Code and the Metals language server.",
+          "scope": "window"
         }
       }
     },


### PR DESCRIPTION
Fixes #1931 

<img width="410" height="249" alt="metalstrace" src="https://github.com/user-attachments/assets/3dde3e4d-c6df-4897-a1c4-c1a1b5c9c9f7" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new tracing setting for the Metals language server. Users can now control trace levels (`off`, `messages`, `verbose`) to monitor and debug communication between VS Code and the language server.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->