### PR TITLE
Add VSCode filesystem provider for JAR contents

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "onLanguage:twirl-xml",
     "onLanguage:twirl-js",
     "onLanguage:twirl-txt",
+    "onFileSystem:metalsfs",
     "workspaceContains:build.sbt",
     "workspaceContains:build.sc",
     "workspaceContains:build.mill",
@@ -366,6 +367,12 @@
           "default": false,
           "scope": "window",
           "markdownDescription": "Enable best effort mode for Metals in Scala 3. If enabled, Metals will try to provide most up to date information from the codebase even if it's not compiling."
+        },
+        "metals.experimental.librariesFileSystem": {
+          "type": "boolean",
+          "default": false,
+          "scope": "window",
+          "markdownDescription": "(Experimental) Show project dependency JARs and JDK sources as a virtual folder in the Explorer view. Restart Metals after toggling."
         },
         "metals.defaultShell": {
           "type": "string",
@@ -777,6 +784,11 @@
         "title": "Show release notes"
       },
       {
+        "command": "metals.show-libraries-folder",
+        "category": "Metals",
+        "title": "Show libraries folder in file explorer"
+      },
+      {
         "command": "metals.scalafix-run",
         "category": "Metals",
         "title": "Run all Scalafix rules"
@@ -1109,6 +1121,10 @@
         {
           "command": "metals.show-release-notes",
           "when": "metals:enabled"
+        },
+        {
+          "command": "metals.show-libraries-folder",
+          "when": "metals:enabled && config.metals.experimental.librariesFileSystem"
         },
         {
           "command": "metals.scalafix-run",

--- a/src/MetalsFileSystemProvider.ts
+++ b/src/MetalsFileSystemProvider.ts
@@ -1,0 +1,208 @@
+import { ServerCommands } from "./interfaces/ServerCommands";
+import {
+  EventEmitter,
+  FileSystemProvider,
+  Uri,
+  Disposable,
+  Event,
+  FileChangeEvent,
+  FileStat,
+  FileType,
+  FileSystemError,
+  FileChangeType,
+} from "vscode";
+import { ExecuteCommandRequest } from "vscode-languageclient/node";
+import { LanguageClient } from "vscode-languageclient/node";
+
+export interface FSReadDirectoryResponse {
+  name: string;
+  isFile: boolean;
+}
+
+export interface FSReadDirectoriesResponse {
+  name: string;
+  directories?: FSReadDirectoryResponse[];
+  error?: string;
+}
+
+export interface FSReadFileResponse {
+  name: string;
+  value?: string;
+  error?: string;
+}
+
+export interface FSStatResponse {
+  name: string;
+  isFile?: boolean;
+  error?: string;
+}
+
+export class GenericFileStat implements FileStat {
+  type: FileType;
+  ctime: number;
+  mtime: number;
+  size: number;
+
+  constructor(isFile: boolean) {
+    this.type = isFile ? FileType.File : FileType.Directory;
+    this.ctime = Date.now();
+    this.mtime = Date.now();
+    this.size = 0;
+  }
+}
+
+export default class MetalsFileSystemProvider implements FileSystemProvider {
+  readonly client: LanguageClient;
+  readonly exclusions: string[];
+
+  constructor(client: LanguageClient, rootUri: Uri) {
+    // automatically reject files/directories that vscode checks for but will never appear on metalfs
+    this.exclusions = [".vscode", ".git", ".devcontainer"].map(
+      (path) => `${rootUri.path}/${path}`,
+    );
+    this.client = client;
+  }
+
+  private checkUri(uri: Uri) {
+    const path = uri.path;
+    if (
+      this.exclusions.some(
+        (exclusion) => path === exclusion || path.startsWith(exclusion + "/"),
+      )
+    ) {
+      throw FileSystemError.FileNotFound(uri);
+    }
+  }
+
+  stat(uri: Uri): FileStat | Thenable<FileStat> {
+    this.checkUri(uri);
+
+    return this.client
+      .sendRequest(ExecuteCommandRequest.type, {
+        command: ServerCommands.FileSystemStat,
+        arguments: [uri.toString(true)],
+      })
+      .then((result: FSStatResponse) => {
+        const { isFile, error, name } = result;
+        if (isFile !== undefined) {
+          return new GenericFileStat(isFile);
+        } else if (error !== undefined) {
+          throw FileSystemError.FileNotFound(error);
+        } else {
+          throw FileSystemError.FileNotFound(name);
+        }
+      });
+  }
+
+  readDirectory(
+    uri: Uri,
+  ): [string, FileType][] | Thenable<[string, FileType][]> {
+    this.checkUri(uri);
+
+    return this.client
+      .sendRequest(ExecuteCommandRequest.type, {
+        command: ServerCommands.FileSystemReadDirectory,
+        arguments: [uri.toString(true)],
+      })
+      .then((result: FSReadDirectoriesResponse) => {
+        const { directories, error, name } = result;
+        if (directories) {
+          return directories.map(this.toReadDirResult);
+        } else if (error !== undefined) {
+          throw FileSystemError.FileNotFound(error);
+        } else {
+          throw FileSystemError.FileNotFound(name);
+        }
+      });
+  }
+
+  readFile(uri: Uri): Uint8Array | Thenable<Uint8Array> {
+    this.checkUri(uri);
+
+    return this.client
+      .sendRequest(ExecuteCommandRequest.type, {
+        command: ServerCommands.FileSystemReadFile,
+        arguments: [uri.toString(true)],
+      })
+      .then((result: FSReadFileResponse) => {
+        const { value, error, name } = result;
+        if (value !== undefined) {
+          return Buffer.from(value);
+        } else if (error !== undefined) {
+          throw FileSystemError.FileNotFound(error);
+        } else {
+          throw FileSystemError.FileNotFound(name);
+        }
+      });
+  }
+
+  reinitialiseURI(uri: Uri) {
+    this._fireSoon({ type: FileChangeType.Changed, uri: uri });
+  }
+
+  private toReadDirResult(
+    response: FSReadDirectoryResponse,
+  ): [string, FileType] {
+    return [
+      response.name,
+      response.isFile ? FileType.File : FileType.Directory,
+    ];
+  }
+
+  private _emitter = new EventEmitter<FileChangeEvent[]>();
+  private _bufferedEvents: FileChangeEvent[] = [];
+  private _fireSoonHandle?: ReturnType<typeof setTimeout>;
+
+  readonly onDidChangeFile: Event<FileChangeEvent[]> = this._emitter.event;
+
+  private _fireSoon(...events: FileChangeEvent[]): void {
+    this._bufferedEvents.push(...events);
+
+    if (this._fireSoonHandle) {
+      clearTimeout(this._fireSoonHandle);
+    }
+
+    this._fireSoonHandle = setTimeout(() => {
+      this._emitter.fire(this._bufferedEvents);
+      this._bufferedEvents.length = 0;
+    }, 5);
+  }
+
+  watch(
+    _uri: Uri,
+    _options: { recursive: boolean; excludes: string[] },
+  ): Disposable {
+    return new Disposable(() => {
+      // do nothing
+    });
+  }
+
+  createDirectory(uri: Uri): void | Thenable<void> {
+    throw FileSystemError.NoPermissions(uri);
+  }
+
+  delete(uri: Uri, options: { recursive: boolean }): void | Thenable<void> {
+    void options;
+    throw FileSystemError.NoPermissions(uri);
+  }
+
+  rename(
+    oldUri: Uri,
+    newUri: Uri,
+    options: { overwrite: boolean },
+  ): void | Thenable<void> {
+    void newUri;
+    void options;
+    throw FileSystemError.NoPermissions(oldUri);
+  }
+
+  writeFile(
+    uri: Uri,
+    content: Uint8Array,
+    options: { create: boolean; overwrite: boolean },
+  ): void | Thenable<void> {
+    void content;
+    void options;
+    throw FileSystemError.NoPermissions(uri);
+  }
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -34,6 +34,7 @@ import {
   debug,
   DebugSessionCustomEvent,
   ThemeColor,
+  FileSystemProvider,
 } from "vscode";
 import {
   LanguageClient,
@@ -121,8 +122,11 @@ import { MetalsSlowTaskType } from "./interfaces/MetalsSlowTask";
 import { downloadProgress } from "./downloadProgress";
 import { detectLaunchConfigurationChanges } from "./detectLaunchConfigurationChanges";
 import { registerCopyPasteHooks } from "./metalsCopyPaste";
+import MetalsFileSystemProvider from "./MetalsFileSystemProvider";
 
 const outputChannel = window.createOutputChannel("Metals");
+
+const librariesURI = Uri.parse("metalsfs:/metalsLibraries");
 
 let treeViews: MetalsTreeViews | undefined;
 let currentClient: LanguageClient | undefined;
@@ -628,6 +632,10 @@ async function launchMetalsWithServerOptions(
   // Make editing Scala docstrings slightly nicer.
   enableScaladocIndentation();
 
+  const librariesFileSystemEnabled = workspace
+    .getConfiguration("metals")
+    .get<boolean>("experimental.librariesFileSystem", false);
+
   const commandArgs = [
     serverOptions.run.command,
     ...(serverOptions.run.args || []),
@@ -660,6 +668,7 @@ async function launchMetalsWithServerOptions(
     icons: "vscode",
     inputBoxProvider: true,
     isVirtualDocumentSupported: true,
+    isLibraryFileSystemSupported: librariesFileSystemEnabled,
     openFilesOnRenameProvider: true,
     openNewWindowProvider: true,
     quickPickProvider: true,
@@ -684,6 +693,12 @@ async function launchMetalsWithServerOptions(
       { scheme: "file", language: "twirl-txt" },
       { scheme: "jar", language: "scala" },
       { scheme: "jar", language: "java" },
+      ...(librariesFileSystemEnabled
+        ? [
+          { scheme: "metalsfs", language: "scala" },
+          { scheme: "metalsfs", language: "java" },
+        ]
+        : []),
     ],
     synchronize: {
       configurationSection: "metals",
@@ -756,6 +771,18 @@ async function launchMetalsWithServerOptions(
   ) {
     context.subscriptions.push(
       commands.registerTextEditorCommand(command, callback),
+    );
+  }
+
+  function registerFileSystemProvider(
+    scheme: string,
+    provider: FileSystemProvider,
+  ) {
+    context.subscriptions.push(
+      workspace.registerFileSystemProvider(scheme, provider, {
+        isCaseSensitive: true,
+        isReadonly: true,
+      }),
     );
   }
 
@@ -843,6 +870,7 @@ async function launchMetalsWithServerOptions(
     () => {
       registerBloopInstance();
       const doctorProvider = new DoctorProvider(client, context);
+      let metalsFileSystemProvider: MetalsFileSystemProvider | undefined;
       let stacktrace: WebviewPanel | undefined;
 
       function getStacktracePanel(): WebviewPanel {
@@ -1133,6 +1161,24 @@ async function launchMetalsWithServerOptions(
             }
             case ClientCommands.BuildConnect: {
               commands.executeCommand(ServerCommands.BuildConnect);
+              break;
+            }
+            case ClientCommands.LibraryFileSystemReady: {
+              if (!metalsFileSystemProvider) {
+                metalsFileSystemProvider = new MetalsFileSystemProvider(
+                  client,
+                  librariesURI,
+                );
+                registerFileSystemProvider(
+                  librariesURI.scheme,
+                  metalsFileSystemProvider,
+                );
+                registerCommand("metals.show-libraries-folder", async () =>
+                  addLibrariesFolder(),
+                );
+              }
+              metalsFileSystemProvider.reinitialiseURI(librariesURI);
+              addLibrariesFolder();
               break;
             }
             default:
@@ -1795,6 +1841,40 @@ function detectConfigurationChanges() {
           }
         }),
   );
+}
+
+function addLibrariesFolder() {
+  const libraryFolderName = "Metals - Libraries";
+
+  const newLibraryFolder = {
+    uri: librariesURI,
+    name: libraryFolderName,
+  };
+  const folderByUri = workspace.getWorkspaceFolder(librariesURI);
+  if (folderByUri && folderByUri.name !== libraryFolderName) {
+    workspace.updateWorkspaceFolders(folderByUri.index, 1, newLibraryFolder);
+  } else {
+    const folderByName = workspace.workspaceFolders?.find(
+      (folder) => folder.name === libraryFolderName,
+    );
+    if (
+      folderByName &&
+      folderByName.uri.toString() !== librariesURI.toString()
+    ) {
+      if (folderByUri) {
+        workspace.updateWorkspaceFolders(folderByName.index, 1);
+      } else {
+        workspace.updateWorkspaceFolders(
+          folderByName.index,
+          1,
+          newLibraryFolder,
+        );
+      }
+    } else if (!folderByUri) {
+      const workspaceCount = workspace.workspaceFolders?.length ?? 0;
+      workspace.updateWorkspaceFolders(workspaceCount, null, newLibraryFolder);
+    }
+  }
 }
 
 // NOTE(gabro): we would normally use the `configurationDefaults` contribution point in the

--- a/src/interfaces/ClientCommands.ts
+++ b/src/interfaces/ClientCommands.ts
@@ -40,6 +40,8 @@ export const ClientCommands = {
   StartDebugSession: "metals-debug-session-start",
   /** Command to run the codev via a code lens in the editor. */
   StartRunSession: "metals-run-session-start",
+  /** Notifies the client that library filesystem is ready. */
+  LibraryFileSystemReady: "metals-library-filesystem-ready",
   /**
    * Focus or remove focus on the output logs reported by the server via
    * `window/logMessage`.

--- a/src/interfaces/MetalsInitializationOptions.ts
+++ b/src/interfaces/MetalsInitializationOptions.ts
@@ -23,6 +23,7 @@ export interface MetalsInitializationOptions {
   icons?: "vscode" | "octicons" | "atom" | "unicode";
   inputBoxProvider?: boolean;
   isVirtualDocumentSupported?: boolean;
+  isLibraryFileSystemSupported?: boolean;
   isExitOnShutdown?: boolean;
   isHttpEnabled?: boolean;
   openFilesOnRenameProvider?: boolean;

--- a/src/interfaces/ServerCommands.ts
+++ b/src/interfaces/ServerCommands.ts
@@ -70,6 +70,12 @@ export const ServerCommands = {
   DoctorRun: "doctor-run",
   /** Decode a file to human readable format.  E.g. class, semanticdb */
   DecodeFile: "file-decode",
+  /** Get file system stat for the specified uri. */
+  FileSystemStat: "filesystem-stat",
+  /** Read directory for the specified uri. */
+  FileSystemReadDirectory: "filesystem-read-directory",
+  /** Read file for the specified uri. */
+  FileSystemReadFile: "filesystem-read-file",
   /** Retrieve a list of all build targets */
   ListBuildTargets: "list-build-targets",
   /**


### PR DESCRIPTION
Feature:

This PR adds VSCode support for the `metalsfs://` virtual file system. The server side is in a separate PR in `scalameta/metals`

After Metals finishes indexing, the extension registers a file system provider for the `metalsfs` scheme. It also adds a workspace folder "Metals — Libraries" to the Explorer. The folder has three sections: JDK sources, workspace JARs, source JARs

The feature turns on only when the client sends `isLibraryFileSystemSupported: true` in initialization options. If the option is off, nothing happens

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Command to open the "Metals - Libraries" folder in the file explorer.
  * Read-only "Metals - Libraries" filesystem integration exposing library files in the workspace.
  * Workspace is automatically reconciled/updated to include the "Metals - Libraries" folder when available.
  * Experimental setting to enable the libraries filesystem; the command is shown only when enabled.
  * Extension activation now responds to the custom libraries filesystem event.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/scalameta/metals-vscode/pull/1939?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->