### PR TITLE
Declare metals.presentation-compiler-diagnostics

### DIFF
--- a/package.json
+++ b/package.json
@@ -674,6 +674,11 @@
           "default": "off",
           "description": "Traces the communication between VS Code and the Metals language server.",
           "scope": "window"
+        },
+        "metals.presentation-compiler-diagnostics": {
+          "type": "boolean",
+          "default": true,
+          "markdownDescription": "Use Presentation Compiler."
         }
       }
     },


### PR DESCRIPTION
Fixes #1942 

<img width="359" height="104" alt="metalspc" src="https://github.com/user-attachments/assets/34cf01b8-a859-4383-a04f-83da8670c3e4" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new configuration option for Presentation Compiler diagnostics, enabled by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->