### PR TITLE
fix(extension): remove isActive filter during extension initialization

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -581,7 +581,6 @@ async function launchMetals(
   const allClientExtensions = new Set<string>(["kilocode.kilo-code"]);
 
   const activeClientExtensions = extensions.all
-    .filter((e) => e.isActive)
     .map((e) => e.id)
     .filter((e) => allClientExtensions.has(e));
 


### PR DESCRIPTION
Remove the filter that checks for `e.isActive` when identifying active client extensions. This prevents a race condition where extensions might not yet be marked as active during the initialization phase, ensuring they are correctly identified and managed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed extension selection to properly include all allowlisted extensions instead of only those currently marked as active.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/scalameta/metals-vscode/pull/1953)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->