### PR TITLE
Add Metals custom server launcher

### DIFF
--- a/package.json
+++ b/package.json
@@ -377,6 +377,12 @@
           "default": "1.6.7",
           "markdownDescription": "The version of the Metals server artifact. Requires reloading the window.  \n\n**VS Code extension version is guaranteed to work only with the default version, change if you know what you're doing**"
         },
+        "metals.customServerLauncher": {
+          "type": "string",
+          "default": "",
+          "scope": "machine-overridable",
+          "markdownDescription": "Optional command to launch a Metals-compatible language server over standard input/output. When set, this completely overrides the default Metals server launch flow, including `metals.serverVersion`, `metals.serverProperties`, and `metals.customRepositories`."
+        },
         "metals.serverProperties": {
           "type": "array",
           "items": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -92,10 +92,11 @@ import { setupCoursier } from "./setupCoursier";
 import { getJavaOptions } from "./getJavaOptions";
 import { getJavaConfig, JavaConfig } from "./getJavaConfig";
 import { fetchMetals } from "./fetchMetals";
-import { getServerOptions } from "./getServerOptions";
+import { getCustomServerOptions, getServerOptions } from "./getServerOptions";
 import { isSupportedLanguage } from "./isSupportedLanguage";
 import { readRequiredVmOptions } from "./readRequiredVmOptions";
 import { MetalsInitializationOptions } from "./interfaces/MetalsInitializationOptions";
+import { ServerOptions } from "./interfaces/ServerOptions";
 import { restartServer } from "./commands/restartServer";
 import { ServerCommands } from "./interfaces/ServerCommands";
 import { ClientCommands } from "./interfaces/ClientCommands";
@@ -405,12 +406,32 @@ function debugInformation(
     `;
 }
 
+function getConfiguredServerOptions(): ServerOptions | undefined {
+  const command = config.get<string>("customServerLauncher")?.trim();
+  if (!command) {
+    return undefined;
+  }
+
+  return getCustomServerOptions(command);
+}
+
 async function fetchAndLaunchMetals(
   context: ExtensionContext,
   serverVersion: string,
   javaVersion: JavaVersion,
   forceCoursierJar = false,
 ) {
+  const configuredServerOptions = getConfiguredServerOptions();
+  if (configuredServerOptions) {
+    outputChannel.appendLine("Using custom Metals server launcher.");
+    return launchMetalsWithServerOptions(
+      outputChannel,
+      context,
+      configuredServerOptions,
+      serverVersion,
+    );
+  }
+
   outputChannel.appendLine(`Metals version: ${serverVersion}`);
 
   /* eslint-disable @typescript-eslint/no-non-null-assertion */
@@ -567,9 +588,6 @@ async function launchMetals(
   javaConfig: JavaConfig,
   serverVersion: string,
 ) {
-  // Make editing Scala docstrings slightly nicer.
-  enableScaladocIndentation();
-
   // Read required VM options from the Metals JAR (META-INF/metals-required-vm-options.txt)
   const requiredVmOptions = await readRequiredVmOptions(metalsClasspath);
   if (requiredVmOptions.length > 0) {
@@ -592,6 +610,23 @@ async function launchMetals(
     requiredVmOptions,
     activeClientExtensions,
   );
+
+  return launchMetalsWithServerOptions(
+    outputChannel,
+    context,
+    serverOptions,
+    serverVersion,
+  );
+}
+
+async function launchMetalsWithServerOptions(
+  outputChannel: OutputChannel,
+  context: ExtensionContext,
+  serverOptions: ServerOptions,
+  serverVersion: string,
+) {
+  // Make editing Scala docstrings slightly nicer.
+  enableScaladocIndentation();
 
   const commandArgs = [
     serverOptions.run.command,

--- a/src/getServerOptions.ts
+++ b/src/getServerOptions.ts
@@ -1,6 +1,19 @@
 import { ServerOptions } from "./interfaces/ServerOptions";
 import { JavaConfig } from "./getJavaConfig";
 
+export function getCustomServerOptions(command: string): ServerOptions {
+  return {
+    run: {
+      command,
+      options: { env: process.env },
+    },
+    debug: {
+      command,
+      options: { env: process.env },
+    },
+  };
+}
+
 export function getServerOptions(
   metalsClasspath: string,
   serverProperties: string[],

--- a/src/test/unit/getServerOptions.test.ts
+++ b/src/test/unit/getServerOptions.test.ts
@@ -1,0 +1,15 @@
+import * as assert from "assert";
+import { getCustomServerOptions } from "../../getServerOptions";
+
+describe("getServerOptions", () => {
+  describe("getCustomServerOptions", () => {
+    it("uses the configured command and extension host environment", () => {
+      const serverOptions = getCustomServerOptions("/usr/local/bin/metals");
+
+      assert.strictEqual(serverOptions.run.command, "/usr/local/bin/metals");
+      assert.strictEqual(serverOptions.run.options?.env, process.env);
+      assert.strictEqual(serverOptions.debug.command, "/usr/local/bin/metals");
+      assert.strictEqual(serverOptions.debug.options?.env, process.env);
+    });
+  });
+});


### PR DESCRIPTION
### Summary

Adds an external server command option `metals.ServerCommand` of type string.

When serverCommand is set, the Metals VSCode extension will use a custom launcher script that skips coursier/download and starts that command as the Metals-compatible stdio server, while keeping the normal VSCode language client wiring.

### Motivation

At Stripe, we want to point VSCode at a custom wrapper for launching metals so we can integrate with existing lsp-proxy tooling for free metrics and LSP consolidation (i.e. only pick one LSP for the task at hand).

Elsewhere, custom launchers are used but it would be nice to upstream custom launcher scripts as a solution to handle other cases of integration.

### Test plan
- yarn install passed.
- yarn compile passed.
- ./node_modules/.bin/ts-mocha src/test/unit/getServerOptions.test.ts passed.
- yarn format-check passed.
- yarn eslint . passed with existing warnings only.
- added a focused unit test for the new server-option helper 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new configuration, metals.customServerLauncher, allowing you to specify a custom command to launch the Metals language server.

* **Tests**
  * Added unit tests validating the custom server launcher configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/scalameta/metals-vscode/pull/1963?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->