### PR TITLE
Problem with files.watcherExclude on Windows

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1819,6 +1819,9 @@ function configureSettingsDefaults() {
           return configProperty?.workspaceValue ?? {};
       }
     })();
+    delete currentValues["**/.bloop"];
+    delete currentValues["**/.metals"];
+    delete currentValues["**/target"];
     config.update(
       propertyKey,
       { ...currentValues, ...newValues },
@@ -1829,8 +1832,8 @@ function configureSettingsDefaults() {
     "files",
     "watcherExclude",
     {
-      "**/.bloop": true,
-      "**/.metals": true,
+      "**/.bloop/**": true,
+      "**/.metals/**": true,
     },
     ConfigurationTarget.Global,
   );
@@ -1838,7 +1841,7 @@ function configureSettingsDefaults() {
     "files",
     "watcherExclude",
     {
-      "**/target": true,
+      "**/target/**": true,
     },
     ConfigurationTarget.Workspace,
   );


### PR DESCRIPTION
Fixes #1968 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file watcher exclusion patterns to more comprehensively exclude nested directories from build-related folders.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/scalameta/metals-vscode/pull/1969?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->