### PR TITLE
.metals/mbt.json watcher is not called

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1821,6 +1821,7 @@ function configureSettingsDefaults() {
     })();
     delete currentValues["**/.bloop"];
     delete currentValues["**/.metals"];
+    delete currentValues["**/.metals/**"];
     delete currentValues["**/target"];
     config.update(
       propertyKey,
@@ -1833,7 +1834,7 @@ function configureSettingsDefaults() {
     "watcherExclude",
     {
       "**/.bloop/**": true,
-      "**/.metals/**": true,
+      "**/.metals/**/*.{java,scala}": true,
     },
     ConfigurationTarget.Global,
   );


### PR DESCRIPTION
Fixes #1978 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * File watcher exclusions refined: now only specific source file types within metadata folders are excluded from watching, rather than excluding entire metadata folders.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/scalameta/metals-vscode/pull/1979?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->