### PR TITLE
Add 'Open Metals Log' command

### DIFF
--- a/package.json
+++ b/package.json
@@ -960,6 +960,11 @@
         "command": "metals.find-text-in-dependency-jars",
         "category": "Metals",
         "title": "Find text in dependency JAR files"
+      },
+      {
+        "command": "metals.open-metals-log",
+        "category": "Metals",
+        "title": "Open Metals Log"
       }
     ],
     "submenus": [
@@ -1160,6 +1165,10 @@
         },
         {
           "command": "metals.scala-cli-stop",
+          "when": "metals:enabled"
+        },
+        {
+          "command": "metals.open-metals-log",
           "when": "metals:enabled"
         }
       ],

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1026,6 +1026,10 @@ async function launchMetalsWithServerOptions(
         },
       );
 
+      registerCommand(`metals.open-metals-log`, async () => {
+        commands.executeCommand(ServerCommands.GotoLog);
+      });
+
       // should be the compilation of a currently opened file
       // but some race conditions may apply
       const compilationDoneEmitter = new EventEmitter<void>();

--- a/src/interfaces/ServerCommands.ts
+++ b/src/interfaces/ServerCommands.ts
@@ -123,6 +123,8 @@ export const ServerCommands = {
    * Delete all directories in .bloop and restart the Bloop server.
    */
   ResetWorkspace: "reset-workspace",
+  /** Focus on the logs in .metals/metals.log */
+  GotoLog: "goto-log",
 } as const;
 
 type ServerCommands = typeof ServerCommands;


### PR DESCRIPTION
Fixes #1985 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a command in the command palette to open the Metals log when Metals is enabled.
* **Chores**
  * Registered the new command in the extension manifest so it appears in the command palette when Metals is active.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->