### PR TITLE
Add proto document selector for protobuf LSP

### DIFF
--- a/package.json
+++ b/package.json
@@ -369,7 +369,7 @@
         },
         "metals.protobufLsp": {
           "type": "boolean",
-          "default": false,
+          "default": true,
           "scope": "window",
           "markdownDescription": "Enable Metals language server support for Protocol Buffers files. Requires another extension to contribute the `proto` language and reloading the window."
         },

--- a/package.json
+++ b/package.json
@@ -367,6 +367,12 @@
           "scope": "window",
           "markdownDescription": "Enable best effort mode for Metals in Scala 3. If enabled, Metals will try to provide most up to date information from the codebase even if it's not compiling."
         },
+        "metals.protobufLsp": {
+          "type": "boolean",
+          "default": false,
+          "scope": "window",
+          "markdownDescription": "Enable Metals language server support for Protocol Buffers files. Requires another extension to contribute the `proto` language and reloading the window."
+        },
         "metals.defaultShell": {
           "type": "string",
           "scope": "machine-overridable",

--- a/src/documentSelector.ts
+++ b/src/documentSelector.ts
@@ -1,0 +1,38 @@
+import { LanguageClientOptions } from "vscode-languageclient/node";
+
+export interface LanguageSupport {
+  protobuf: boolean;
+  prototext: boolean;
+}
+
+export function buildDocumentSelector({
+  protobuf,
+  prototext,
+}: LanguageSupport): LanguageClientOptions["documentSelector"] {
+  const documentSelector: LanguageClientOptions["documentSelector"] = [
+    { scheme: "file", language: "scala" },
+    { scheme: "file", language: "java" },
+    { scheme: "file", language: "twirl-html" },
+    { scheme: "file", language: "twirl-xml" },
+    { scheme: "file", language: "twirl-js" },
+    { scheme: "file", language: "twirl-txt" },
+    { scheme: "jar", language: "scala" },
+    { scheme: "jar", language: "java" },
+  ];
+
+  if (protobuf) {
+    documentSelector.push(
+      { scheme: "file", language: "proto" },
+      { scheme: "jar", language: "proto" },
+    );
+  }
+
+  if (prototext) {
+    documentSelector.push(
+      { scheme: "file", language: "prototext" },
+      { scheme: "jar", language: "prototext" },
+    );
+  }
+
+  return documentSelector;
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -678,7 +678,7 @@ async function launchMetalsWithServerOptions(
 
   const clientOptions: LanguageClientOptions = {
     documentSelector: buildDocumentSelector({
-      protobuf: config.get<boolean>("protobufLsp") ?? false,
+      protobuf: config.get<boolean>("protobufLsp") ?? true,
       prototext: false,
     }),
     synchronize: {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -676,10 +676,12 @@ async function launchMetalsWithServerOptions(
     moduleStatusBarProvider: "on",
   };
 
+  const protobufLsp = config.get<boolean>("protobufLsp") ?? true;
+
   const clientOptions: LanguageClientOptions = {
     documentSelector: buildDocumentSelector({
-      protobuf: config.get<boolean>("protobufLsp") ?? true,
-      prototext: false,
+      protobuf: protobufLsp,
+      prototext: protobufLsp,
     }),
     synchronize: {
       configurationSection: "metals",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -122,6 +122,7 @@ import { MetalsSlowTaskType } from "./interfaces/MetalsSlowTask";
 import { downloadProgress } from "./downloadProgress";
 import { detectLaunchConfigurationChanges } from "./detectLaunchConfigurationChanges";
 import { registerCopyPasteHooks } from "./metalsCopyPaste";
+import { buildDocumentSelector } from "./documentSelector";
 
 const outputChannel = window.createOutputChannel("Metals", { log: true });
 
@@ -676,16 +677,10 @@ async function launchMetalsWithServerOptions(
   };
 
   const clientOptions: LanguageClientOptions = {
-    documentSelector: [
-      { scheme: "file", language: "scala" },
-      { scheme: "file", language: "java" },
-      { scheme: "file", language: "twirl-html" },
-      { scheme: "file", language: "twirl-xml" },
-      { scheme: "file", language: "twirl-js" },
-      { scheme: "file", language: "twirl-txt" },
-      { scheme: "jar", language: "scala" },
-      { scheme: "jar", language: "java" },
-    ],
+    documentSelector: buildDocumentSelector({
+      protobuf: config.get<boolean>("protobufLsp") ?? false,
+      prototext: false,
+    }),
     synchronize: {
       configurationSection: "metals",
     },

--- a/src/test/unit/documentSelector.test.ts
+++ b/src/test/unit/documentSelector.test.ts
@@ -1,0 +1,76 @@
+import * as assert from "assert";
+import { buildDocumentSelector } from "../../documentSelector";
+
+describe("buildDocumentSelector", () => {
+  it("does not include proto documents by default", () => {
+    assert.deepStrictEqual(
+      buildDocumentSelector({ protobuf: false, prototext: false }),
+      [
+        { scheme: "file", language: "scala" },
+        { scheme: "file", language: "java" },
+        { scheme: "file", language: "twirl-html" },
+        { scheme: "file", language: "twirl-xml" },
+        { scheme: "file", language: "twirl-js" },
+        { scheme: "file", language: "twirl-txt" },
+        { scheme: "jar", language: "scala" },
+        { scheme: "jar", language: "java" },
+      ],
+    );
+  });
+
+  it("includes proto documents when protobuf LSP is enabled", () => {
+    assert.deepStrictEqual(
+      buildDocumentSelector({ protobuf: true, prototext: false }),
+      [
+        { scheme: "file", language: "scala" },
+        { scheme: "file", language: "java" },
+        { scheme: "file", language: "twirl-html" },
+        { scheme: "file", language: "twirl-xml" },
+        { scheme: "file", language: "twirl-js" },
+        { scheme: "file", language: "twirl-txt" },
+        { scheme: "jar", language: "scala" },
+        { scheme: "jar", language: "java" },
+        { scheme: "file", language: "proto" },
+        { scheme: "jar", language: "proto" },
+      ],
+    );
+  });
+
+  it("includes prototext documents when prototext LSP is enabled", () => {
+    assert.deepStrictEqual(
+      buildDocumentSelector({ protobuf: false, prototext: true }),
+      [
+        { scheme: "file", language: "scala" },
+        { scheme: "file", language: "java" },
+        { scheme: "file", language: "twirl-html" },
+        { scheme: "file", language: "twirl-xml" },
+        { scheme: "file", language: "twirl-js" },
+        { scheme: "file", language: "twirl-txt" },
+        { scheme: "jar", language: "scala" },
+        { scheme: "jar", language: "java" },
+        { scheme: "file", language: "prototext" },
+        { scheme: "jar", language: "prototext" },
+      ],
+    );
+  });
+
+  it("includes proto and prototext documents when both are enabled", () => {
+    assert.deepStrictEqual(
+      buildDocumentSelector({ protobuf: true, prototext: true }),
+      [
+        { scheme: "file", language: "scala" },
+        { scheme: "file", language: "java" },
+        { scheme: "file", language: "twirl-html" },
+        { scheme: "file", language: "twirl-xml" },
+        { scheme: "file", language: "twirl-js" },
+        { scheme: "file", language: "twirl-txt" },
+        { scheme: "jar", language: "scala" },
+        { scheme: "jar", language: "java" },
+        { scheme: "file", language: "proto" },
+        { scheme: "jar", language: "proto" },
+        { scheme: "file", language: "prototext" },
+        { scheme: "jar", language: "prototext" },
+      ],
+    );
+  });
+});

--- a/src/test/unit/documentSelector.test.ts
+++ b/src/test/unit/documentSelector.test.ts
@@ -2,7 +2,7 @@ import * as assert from "assert";
 import { buildDocumentSelector } from "../../documentSelector";
 
 describe("buildDocumentSelector", () => {
-  it("does not include proto documents by default", () => {
+  it("does not include proto documents when protobuf LSP is disabled", () => {
     assert.deepStrictEqual(
       buildDocumentSelector({ protobuf: false, prototext: false }),
       [


### PR DESCRIPTION
Committed-By-Agent: codex

### Summary
Per the tin, lets users configure the proto document selector for Metals LSP when the `protobufLsp` flag is set to true. I was able to connect [`peterj.protobuf`](https://github.com/peterj/vscode-protobuf/blob/main/package.json) to Metals and proceeded to jump-to-def between proto to proto, instead of just Java to proto.

(Recent changes): prototext support follows the same setting as protobuf here.

We use the peterj extension at Stripe which already contributes .proto as language id proto. 
We may consider switching to DrBlury.protobuf-vsc, though longer term I think we would need to evaluate the scalameta protobuf extension before shifting over all protobuf LS usages.

More context (thread with @olafurpg): https://bazelbuild.slack.com/archives/C0A8ZMZSHL0/p1781018942853479?thread_ts=1781013257.001399&cid=C0A8ZMZSHL0

Requesting a review @tgodzik (for some reason the UI on the right side doesn't let me add reviewers 😅)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds a new setting "metals.protobufLsp" (window, default: true) to enable Metals language server support for Protocol Buffers.
  * Prototext support is controlled by the same setting.
  * Enabling this requires a separate extension that contributes the proto language and a window reload.

* **Tests**
  * Updated tests to validate document selector behavior across protobuf/prototext flag combinations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->