### PR TITLE
bugfix: Fix releasing VS Code extension

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -30,8 +30,8 @@ jobs:
         run: |
           git add .
           git commit -m "Increase patch version for pre-release"
-      # Pre release version requires vscode ^1.63
-      # but we don't want to force normal users to update, modify it
+      # Pre release version requires vscode ^1.74 (minimum for LogOutputChannel)
+      # but we don't want to force normal users to update to ^1.89, modify it
       - name: Update required vs code version
         run: |
           node ./update-version.js

--- a/update-version.js
+++ b/update-version.js
@@ -7,8 +7,8 @@ const json = JSON.parse(package);
 json.contributes.configuration.properties[
   "metals.suggestLatestUpgrade"
 ].default = true;
-json.engines.vscode = "^1.63.0";
-json.devDependencies["@types/vscode"] = "1.63.0";
+json.engines.vscode = "^1.74.0";
+json.devDependencies["@types/vscode"] = "1.74.0";
 
 const updated = JSON.stringify(json, null, 2);
 fs.writeFileSync(path, updated);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated minimum required VS Code version to 1.74.0. Users must ensure they're running this version or later to use this extension.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->