### PR TITLE
Activate Metals for proto files

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,8 @@
     "onDebugResolve:scala",
     "onLanguage:scala",
     "onLanguage:java",
+    "onLanguage:proto",
+    "onLanguage:prototext",
     "onLanguage:twirl-html",
     "onLanguage:twirl-xml",
     "onLanguage:twirl-js",


### PR DESCRIPTION
## Summary

Adds proto and prototext language activation events so Metals can start when opening protobuf files directly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed VS Code extension activation to properly trigger when opening Proto and ProtoText files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->