### PR TITLE
Passthrough noDebug into the metals server

### DIFF
--- a/src/debugger/scalaDebugger.ts
+++ b/src/debugger/scalaDebugger.ts
@@ -197,11 +197,21 @@ async function debug(
 ): Promise<boolean> {
   await commands.executeCommand("workbench.action.files.save");
 
+  // Only ScalaCodeLensesParams has a `dataKind` field here
+  // and only it needs to have the noDebug field added.
+  let paramsToSend: DebugDiscoveryParams | ScalaCodeLensesParams;
+  if ("dataKind" in debugParams) {
+    const codeLensParams: ScalaCodeLensesParams = { ...debugParams, noDebug };
+    paramsToSend = codeLensParams;
+  } else {
+    paramsToSend = debugParams;
+  }
+
   let response: DebugSession | undefined;
   try {
     response = await vscode.commands.executeCommand<DebugSession>(
       ServerCommands.DebugAdapterStart,
-      debugParams,
+      paramsToSend,
     );
   } catch (error) {
     if (error instanceof ResponseError && error.code === workspaceHadErrors) {

--- a/src/debugger/types.ts
+++ b/src/debugger/types.ts
@@ -33,6 +33,7 @@ export interface ScalaTestSuitesDebugRequest {
   /** The build target that contains the test classes. */
   target: BuildTargetIdentifier;
   requestData: ScalaTestSuites;
+  noDebug?: boolean;
 }
 export interface ScalaTestSuites {
   /** The fully qualified names of the test classes in this target and the tests in this test classes */

--- a/src/debugger/types.ts
+++ b/src/debugger/types.ts
@@ -20,6 +20,7 @@ interface BaseScalaRunMain {
   data: ScalaMainData;
   dataKind: "scala-main-class";
   targets: BuildTargetIdentifier[];
+  noDebug?: boolean;
 }
 export interface OldScalaRunMain extends BaseScalaRunMain {
   data: OldScalaMainData;
@@ -55,12 +56,14 @@ interface ScalaRunTestSuites {
   data: FullyQualifiedClassName[];
   dataKind: "scala-test-suite";
   targets: BuildTargetIdentifier[];
+  noDebug?: boolean;
 }
 
 interface ScalaRunTestSuitesSelection {
   data: ScalaTestSuites[];
   dataKind: "scala-test-suites-selection";
   targets: BuildTargetIdentifier[];
+  noDebug?: boolean;
 }
 
 type ScalaRunTests = ScalaRunTestSuites | ScalaRunTestSuitesSelection;

--- a/src/testExplorer/testRunHandler.ts
+++ b/src/testExplorer/testRunHandler.ts
@@ -167,6 +167,7 @@ async function runDebugSession(
     targetUri,
     testSuiteSelection,
     environmentVariables,
+    noDebug,
   );
   if (!session) {
     return;
@@ -198,6 +199,7 @@ async function createDebugSession(
   targetUri: TargetUri,
   suites: ScalaTestSuiteSelection[],
   environmentVariables: Record<string, string> = {},
+  noDebug = false,
 ): Promise<DebugSession | undefined> {
   const debugSessionParams: ScalaTestSuitesDebugRequest = {
     target: { uri: targetUri },
@@ -208,6 +210,7 @@ async function createDebugSession(
         ([key, value]) => `${key}=${value}`,
       ),
     },
+    noDebug,
   };
   return vscode.commands.executeCommand<DebugSession>(
     ServerCommands.DebugAdapterStart,


### PR DESCRIPTION
VS code gives us a noDebug parameter (set for TestExplorer's "run test" commands), but we lose it at some point instead of passing to the server. We need to pass them for the linked PR to work. This is a safe change - the parameter should be ignored by the server if that version does not support it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for running Scala test suites in “no debug” mode.
  * When enabled via run/debug actions, the intent is now passed through to the debug adapter so tests can execute without attaching a debugger while preserving the existing debug workflow.
* **Chores**
  * Updated request payload shapes to include an optional `noDebug` flag across the relevant Scala run/test debug requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->