### PR TITLE
Fixes #2018: Force cmd.exe /c for Windows run task using classpath

### DIFF
--- a/src/debugger/scalaDebugger.ts
+++ b/src/debugger/scalaDebugger.ts
@@ -100,7 +100,7 @@ function escapedShellCommand(
   const mainClass = main.data.class;
   const args = main.data.arguments;
   if (classpath && javaBinary) {
-    const shellOptions = { env };
+    const shellOptions = { ...platformSpecificOptions(), env };
     return taskFromArgs(
       classpath,
       javaBinary,


### PR DESCRIPTION
The `classpath && javaBinary` branch of escapedShellCommand dropped platformSpecificOptions(), so on Windows the no-debug run task fell back to the user's default terminal profile instead of `cmd.exe /c`. With a profile that keeps the shell open (e.g. `cmd.exe /k ...`), the task never terminates and the run hangs forever (the program runs but the session spins indefinitely).

Restore platformSpecificOptions() on this branch, matching the shellCommand fallback, so the run task is launched via a self-terminating `cmd /c` on Windows.

Regression introduced in 4b062cd3 ("Running via cmd might no longer be needed").

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed inconsistent behavior in debugger task execution configuration to ensure consistent operation across different code paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->