### PR TITLE
 Fixes #2020: Don't echo the verbose run command in the task terminal

### DIFF
--- a/src/debugger/scalaDebugger.ts
+++ b/src/debugger/scalaDebugger.ts
@@ -132,6 +132,9 @@ async function runMain(main: ExtendedScalaRunMain): Promise<boolean> {
       "Metals",
       escapedShellCommand(main, env),
     );
+    // Don't echo the fully-resolved java command line (full JVM path +
+    // classpath jar) into the task terminal; it's long and noisy.
+    task.presentationOptions = { echo: false };
 
     await tasks.executeTask(task);
     return true;


### PR DESCRIPTION
## Problem

When running a main class (Run / code lens / Ctrl+F5), the task terminal prints the entire fully-resolved command line before the program output, e.g.:

```
 *  Executing task: "C:\...\jdk-17.0.12+7\bin\java.exe" "-classpath" "C:\...\.metals\.tmp\classpath_87E92C2A74942D0B363981EDC15246C9.jar" "main"

hello
```

This is long and noisy — it includes the full JVM path and the classpath manifest jar path — and adds little value for a normal run.

## Change

Set `task.presentationOptions = { echo: false }` on the run task in `runMain`, so VS Code no longer echoes the resolved command line. Only the program's output is shown.

## Notes

- `echo` defaults to `true` for tasks, and there is no user-facing setting to disable it for an extension-created task, so this has to be set on the `Task` itself.
- Behavior is otherwise unchanged; this only affects what is printed in the task terminal.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced terminal output noise when running Scala main classes by suppressing the display of the underlying Java command line, resulting in cleaner and more readable terminal output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->