### PR TITLE
Revert "Activate Metals for proto files"

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,8 +49,6 @@
     "onDebugResolve:scala",
     "onLanguage:scala",
     "onLanguage:java",
-    "onLanguage:proto",
-    "onLanguage:prototext",
     "onLanguage:twirl-html",
     "onLanguage:twirl-xml",
     "onLanguage:twirl-js",


### PR DESCRIPTION
Reverts scalameta/metals-vscode#2007

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated extension activation behavior by removing language-based activation for `proto` and `prototext`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->