### PR TITLE
improvement: Add scalafixLintEnabled setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -505,6 +505,11 @@
           },
           "markdownDescription": "List of Scalafix rules dependencies in case they are not available by default in Metals and running scalafix fails due to 'rule not found' exception. For example: `com.github.liancheng::organize-imports:0.6.0` which follows the [coursier](https://get-coursier.io/) convention."
         },
+        "metals.scalafixLintEnabled": {
+          "type": "boolean",
+          "default": false,
+          "markdownDescription": "Enable/disable scalafix linting. If enabled, Metals will lint the codebase using scalafix with the currently defined rules."
+        },
         "metals.bloopVersion": {
           "type": "string",
           "scope": "machine",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `metals.scalafixLintEnabled` setting to optionally enable Scalafix linting across the codebase.
  * The setting is disabled by default and uses the project’s configured Scalafix rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->