### PR TITLE
chore: Update Metals to newest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -380,7 +380,7 @@
         },
         "metals.serverVersion": {
           "type": "string",
-          "default": "1.6.7",
+          "default": "1.6.8",
           "markdownDescription": "The version of the Metals server artifact. Requires reloading the window.  \n\n**VS Code extension version is guaranteed to work only with the default version, change if you know what you're doing**"
         },
         "metals.customServerLauncher": {
@@ -508,7 +508,7 @@
         "metals.bloopVersion": {
           "type": "string",
           "scope": "machine",
-          "default": "2.0.19",
+          "default": "2.1.1",
           "markdownDescription": "This version will be used for the Bloop build tool plugin, for any supported build tool,while importing in Metals as well as for running the embedded server"
         },
         "metals.bloopJvmProperties": {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the default Metals language server version to 1.6.8.
  * Updated the default Bloop build tool version to 2.1.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->