### PR TITLE
improvement: Read zip inside the plugin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: coursier/setup-action@v1
       - uses: actions/setup-node@v2
         with:
           node-version: "22"

--- a/package.json
+++ b/package.json
@@ -374,6 +374,12 @@
           "scope": "window",
           "markdownDescription": "Enable Metals language server support for Protocol Buffers files. Requires another extension to contribute the `proto` language and reloading the window."
         },
+        "metals.experimentalJarFileSystemEnabled": {
+          "type": "boolean",
+          "default": false,
+          "scope": "window",
+          "markdownDescription": "Enable the experimental JAR filesystem provider (`jar-fs:`). When enabled, dependency sources opened from JARs use a real filesystem provider, which improves breadcrumbs and navigation. Requires reloading the window."
+        },
         "metals.defaultShell": {
           "type": "string",
           "scope": "machine-overridable",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "onLanguage:twirl-xml",
     "onLanguage:twirl-js",
     "onLanguage:twirl-txt",
+    "onFileSystem:jar-fs",
     "workspaceContains:build.sbt",
     "workspaceContains:build.sc",
     "workspaceContains:build.mill",

--- a/src/detectLaunchConfigurationChanges.ts
+++ b/src/detectLaunchConfigurationChanges.ts
@@ -20,6 +20,7 @@ export function detectLaunchConfigurationChanges(
       UserConfiguration.MetalsJavaHome,
       UserConfiguration.CustomRepositories,
       UserConfiguration.CoursierMirror,
+      "experimentalJarFileSystemEnabled",
       ...additionalRestartKeys,
     ];
     const shouldPromptRestart = promptRestartKeys.some((key) =>

--- a/src/documentSelector.ts
+++ b/src/documentSelector.ts
@@ -3,11 +3,13 @@ import { LanguageClientOptions } from "vscode-languageclient/node";
 export interface LanguageSupport {
   protobuf: boolean;
   prototext: boolean;
+  jarFileSystem: boolean;
 }
 
 export function buildDocumentSelector({
   protobuf,
   prototext,
+  jarFileSystem,
 }: LanguageSupport): LanguageClientOptions["documentSelector"] {
   const documentSelector: LanguageClientOptions["documentSelector"] = [
     { scheme: "file", language: "scala" },
@@ -18,24 +20,33 @@ export function buildDocumentSelector({
     { scheme: "file", language: "twirl-txt" },
     { scheme: "jar", language: "scala" },
     { scheme: "jar", language: "java" },
-    { scheme: "jar-fs", language: "scala" },
-    { scheme: "jar-fs", language: "java" },
   ];
+
+  if (jarFileSystem) {
+    documentSelector.push(
+      { scheme: "jar-fs", language: "scala" },
+      { scheme: "jar-fs", language: "java" },
+    );
+  }
 
   if (protobuf) {
     documentSelector.push(
       { scheme: "file", language: "proto" },
       { scheme: "jar", language: "proto" },
-      { scheme: "jar-fs", language: "proto" },
     );
+    if (jarFileSystem) {
+      documentSelector.push({ scheme: "jar-fs", language: "proto" });
+    }
   }
 
   if (prototext) {
     documentSelector.push(
       { scheme: "file", language: "prototext" },
       { scheme: "jar", language: "prototext" },
-      { scheme: "jar-fs", language: "prototext" },
     );
+    if (jarFileSystem) {
+      documentSelector.push({ scheme: "jar-fs", language: "prototext" });
+    }
   }
 
   return documentSelector;

--- a/src/documentSelector.ts
+++ b/src/documentSelector.ts
@@ -18,12 +18,15 @@ export function buildDocumentSelector({
     { scheme: "file", language: "twirl-txt" },
     { scheme: "jar", language: "scala" },
     { scheme: "jar", language: "java" },
+    { scheme: "jar-fs", language: "scala" },
+    { scheme: "jar-fs", language: "java" },
   ];
 
   if (protobuf) {
     documentSelector.push(
       { scheme: "file", language: "proto" },
       { scheme: "jar", language: "proto" },
+      { scheme: "jar-fs", language: "proto" },
     );
   }
 
@@ -31,6 +34,7 @@ export function buildDocumentSelector({
     documentSelector.push(
       { scheme: "file", language: "prototext" },
       { scheme: "jar", language: "prototext" },
+      { scheme: "jar-fs", language: "prototext" },
     );
   }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -61,6 +61,11 @@ import {
 } from "./findInFiles";
 import * as ext from "./hoverExtension";
 import { decodeAndShowFile, MetalsFileProvider } from "./metalsContentProvider";
+import {
+  JarFileSystemProvider,
+  translateJarFsToJar,
+  translateJarToJarFs,
+} from "./jarFileSystemProvider";
 import { registerMetalsClassFileCustomEditor } from "./classFileCustomEditor";
 import {
   currentWorkspaceFolder,
@@ -694,6 +699,16 @@ async function launchMetalsWithServerOptions(
     revealOutputChannelOn: RevealOutputChannelOn.Never,
     outputChannel: outputChannel as LogOutputChannel,
     initializationOptions,
+    uriConverters: {
+      code2Protocol: (uri: Uri) => translateJarFsToJar(uri),
+      protocol2Code: (uriString: string) => {
+        const uri = Uri.parse(uriString);
+        if (uri.scheme === "jar") {
+          return translateJarToJarFs(uri);
+        }
+        return uri;
+      },
+    },
     middleware: {
       provideHover: hoverLinksMiddlewareHook,
     },
@@ -772,9 +787,17 @@ async function launchMetalsWithServerOptions(
   }
 
   const metalsFileProvider = new MetalsFileProvider(client);
+  const jarFsProvider = new JarFileSystemProvider();
 
   registerTextDocumentContentProvider("metalsDecode", metalsFileProvider);
   registerTextDocumentContentProvider("jar", metalsFileProvider);
+
+  context.subscriptions.push(
+    workspace.registerFileSystemProvider("jar-fs", jarFsProvider, {
+      isReadonly: true,
+      isCaseSensitive: true,
+    }),
+  );
 
   registerMetalsClassFileCustomEditor(context, client, metalsFileProvider);
 
@@ -1048,6 +1071,10 @@ async function launchMetalsWithServerOptions(
       );
       languages.registerCodeLensProvider(
         { scheme: "jar", language: "scala" },
+        codeLensRefresher,
+      );
+      languages.registerCodeLensProvider(
+        { scheme: "jar-fs", language: "scala" },
         codeLensRefresher,
       );
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -704,7 +704,7 @@ async function launchMetalsWithServerOptions(
       protocol2Code: (uriString: string) => {
         const uri = Uri.parse(uriString);
         if (uri.scheme === "jar") {
-          return translateJarToJarFs(uri);
+          return translateJarToJarFs(uri, uriString);
         }
         return uri;
       },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -73,6 +73,7 @@ import {
   getJavaVersionOverride,
   getTextDocumentPositionParams,
   getValueFromConfig,
+  isExperimentalJarFileSystemEnabled,
   metalsDir,
 } from "./util";
 import { createTestManager } from "./testExplorer/testManager";
@@ -687,11 +688,13 @@ async function launchMetalsWithServerOptions(
   };
 
   const protobufLsp = config.get<boolean>("protobufLsp") ?? true;
+  const jarFileSystemEnabled = isExperimentalJarFileSystemEnabled();
 
   const clientOptions: LanguageClientOptions = {
     documentSelector: buildDocumentSelector({
       protobuf: protobufLsp,
       prototext: protobufLsp,
+      jarFileSystem: jarFileSystemEnabled,
     }),
     synchronize: {
       configurationSection: "metals",
@@ -699,16 +702,6 @@ async function launchMetalsWithServerOptions(
     revealOutputChannelOn: RevealOutputChannelOn.Never,
     outputChannel: outputChannel as LogOutputChannel,
     initializationOptions,
-    uriConverters: {
-      code2Protocol: (uri: Uri) => translateJarFsToJar(uri),
-      protocol2Code: (uriString: string) => {
-        const uri = Uri.parse(uriString);
-        if (uri.scheme === "jar") {
-          return translateJarToJarFs(uri, uriString);
-        }
-        return uri;
-      },
-    },
     middleware: {
       provideHover: hoverLinksMiddlewareHook,
     },
@@ -717,6 +710,19 @@ async function launchMetalsWithServerOptions(
     },
     diagnosticCollectionName: "Metals",
   };
+
+  if (jarFileSystemEnabled) {
+    clientOptions.uriConverters = {
+      code2Protocol: (uri: Uri) => translateJarFsToJar(uri),
+      protocol2Code: (uriString: string) => {
+        const uri = Uri.parse(uriString);
+        if (uri.scheme === "jar") {
+          return translateJarToJarFs(uri, uriString);
+        }
+        return uri;
+      },
+    };
+  }
 
   function hoverLinksMiddlewareHook(
     document: TextDocument,
@@ -787,17 +793,19 @@ async function launchMetalsWithServerOptions(
   }
 
   const metalsFileProvider = new MetalsFileProvider(client);
-  const jarFsProvider = new JarFileSystemProvider();
 
   registerTextDocumentContentProvider("metalsDecode", metalsFileProvider);
   registerTextDocumentContentProvider("jar", metalsFileProvider);
 
-  context.subscriptions.push(
-    workspace.registerFileSystemProvider("jar-fs", jarFsProvider, {
-      isReadonly: true,
-      isCaseSensitive: true,
-    }),
-  );
+  if (jarFileSystemEnabled) {
+    const jarFsProvider = new JarFileSystemProvider();
+    context.subscriptions.push(
+      workspace.registerFileSystemProvider("jar-fs", jarFsProvider, {
+        isReadonly: true,
+        isCaseSensitive: true,
+      }),
+    );
+  }
 
   registerMetalsClassFileCustomEditor(context, client, metalsFileProvider);
 
@@ -1073,10 +1081,12 @@ async function launchMetalsWithServerOptions(
         { scheme: "jar", language: "scala" },
         codeLensRefresher,
       );
-      languages.registerCodeLensProvider(
-        { scheme: "jar-fs", language: "scala" },
-        codeLensRefresher,
-      );
+      if (jarFileSystemEnabled) {
+        languages.registerCodeLensProvider(
+          { scheme: "jar-fs", language: "scala" },
+          codeLensRefresher,
+        );
+      }
 
       const getTestUI = () =>
         getValueFromConfig<TestUIKind>(

--- a/src/goToLocation.ts
+++ b/src/goToLocation.ts
@@ -1,6 +1,7 @@
 import { workspace, window, ViewColumn, Uri, Range } from "vscode";
 import { DocumentUri, Range as LspRange } from "vscode-languageclient/node";
 import { MetalsFileProvider } from "./metalsContentProvider";
+import { translateJarToJarFs } from "./jarFileSystemProvider";
 
 export interface WindowLocation {
   uri: DocumentUri;
@@ -29,7 +30,11 @@ export function gotoLocation(
         )
         .pop()?.viewColumn || ViewColumn.Beside;
   }
-  const uri = Uri.parse(location.uri);
+  let uri = Uri.parse(location.uri);
+  // Translate jar: URIs to jar-fs: URIs for better breadcrumb navigation
+  if (uri.scheme === "jar") {
+    uri = translateJarToJarFs(uri);
+  }
   // vscode will cache the virtual documents even after closing unless onDidChange is fired
   if (uri.scheme == "metalsDecode" && metalsFileProvider) {
     metalsFileProvider.onDidChangeEmitter.fire(uri);

--- a/src/goToLocation.ts
+++ b/src/goToLocation.ts
@@ -2,6 +2,7 @@ import { workspace, window, ViewColumn, Uri, Range } from "vscode";
 import { DocumentUri, Range as LspRange } from "vscode-languageclient/node";
 import { MetalsFileProvider } from "./metalsContentProvider";
 import { translateJarToJarFs } from "./jarFileSystemProvider";
+import { isExperimentalJarFileSystemEnabled } from "./util";
 
 export interface WindowLocation {
   uri: DocumentUri;
@@ -32,7 +33,7 @@ export function gotoLocation(
   }
   let uri = Uri.parse(location.uri);
   // Translate jar: URIs to jar-fs: URIs for better breadcrumb navigation
-  if (uri.scheme === "jar") {
+  if (uri.scheme === "jar" && isExperimentalJarFileSystemEnabled()) {
     uri = translateJarToJarFs(uri, location.uri);
   }
   // vscode will cache the virtual documents even after closing unless onDidChange is fired

--- a/src/goToLocation.ts
+++ b/src/goToLocation.ts
@@ -33,7 +33,7 @@ export function gotoLocation(
   let uri = Uri.parse(location.uri);
   // Translate jar: URIs to jar-fs: URIs for better breadcrumb navigation
   if (uri.scheme === "jar") {
-    uri = translateJarToJarFs(uri);
+    uri = translateJarToJarFs(uri, location.uri);
   }
   // vscode will cache the virtual documents even after closing unless onDidChange is fired
   if (uri.scheme == "metalsDecode" && metalsFileProvider) {

--- a/src/jarFileSystemProvider.ts
+++ b/src/jarFileSystemProvider.ts
@@ -44,6 +44,18 @@ export function translateJarFsToJar(uri: Uri): string {
     return uri.toString();
   }
 
+  // First, try to reconstruct from query parameter (self-contained URI)
+  if (uri.query) {
+    const params = new URLSearchParams(uri.query);
+    const jarPath = params.get("jarPath");
+    if (jarPath) {
+      // Path format: /jarName.jar/internal/path
+      const pathParts = uri.path.split("/").filter((p) => p);
+      const internalPath = pathParts.slice(1).join("/");
+      return `jar:file://${jarPath}!/${internalPath}`;
+    }
+  }
+
   const uriString = uri.toString();
 
   // Direct lookup in the registry
@@ -261,16 +273,48 @@ export class JarFileSystemProvider implements FileSystemProvider {
    * Resolve a jar-fs URI to its JAR file path and internal path components.
    */
   private resolveJarComponents(uri: Uri): JarUriComponents | undefined {
+    // First, try to extract from query parameter (self-contained URI)
+    const fromQuery = this.parseJarFsUriFromQuery(uri);
+    if (fromQuery) {
+      return fromQuery;
+    }
+
+    // Fall back to registry lookup
     const originalJarUri = jarFsToJarUri.get(uri.toString());
-    if (!originalJarUri) {
-      const fromPath = this.parseJarFsUriFromPath(uri);
-      if (fromPath) {
-        return fromPath;
-      }
+    if (originalJarUri) {
+      return parseJarUri(originalJarUri);
+    }
+
+    // Try to find from path matching
+    return this.parseJarFsUriFromPath(uri);
+  }
+
+  /**
+   * Parse jar-fs URI components from the query parameter.
+   * URI format: jar-fs:/jarName.jar/internal/path?jarPath=%2Fpath%2Fto%2FjarName.jar
+   */
+  private parseJarFsUriFromQuery(uri: Uri): JarUriComponents | undefined {
+    if (!uri.query) {
       return undefined;
     }
 
-    return parseJarUri(originalJarUri);
+    const params = new URLSearchParams(uri.query);
+    const jarPath = params.get("jarPath");
+    if (!jarPath) {
+      return undefined;
+    }
+
+    // Path format: /jarName.jar/internal/path
+    // We need to extract the internal path (everything after the JAR name)
+    const pathParts = uri.path.split("/").filter((p) => p);
+    if (pathParts.length < 1) {
+      return undefined;
+    }
+
+    // First part is the JAR name, rest is the internal path
+    const internalPath = pathParts.slice(1).join("/");
+
+    return { jarPath, internalPath };
   }
 
   /**
@@ -430,9 +474,10 @@ export function parseJarUri(uriString: string): JarUriComponents | undefined {
  * Translates a jar: URI to a jar-fs: URI for use with the FileSystemProvider.
  *
  * Input format:  jar:file:///path/to/scala-library-2.13.12.jar!/scala/Option.scala
- * Output format: jar-fs:/scala-library-2.13.12.jar/scala/Option.scala
+ * Output format: jar-fs:/scala-library-2.13.12.jar/scala/Option.scala?jarPath=%2Fpath%2Fto%2Fscala-library-2.13.12.jar
  *
- * This also registers the mapping so the provider can resolve it back.
+ * The full JAR path is encoded in the query parameter so the URI is self-contained
+ * and can be resolved without needing a registry (survives extension restarts).
  */
 export function translateJarToJarFs(uri: Uri): Uri {
   if (uri.scheme !== "jar") {
@@ -446,14 +491,29 @@ export function translateJarToJarFs(uri: Uri): Uri {
     return uri;
   }
 
-  const jarPath = decoded.substring(0, jarSeparatorIndex);
+  let fullJarPath = decoded.substring(0, jarSeparatorIndex);
   const internalPath = decoded.substring(jarSeparatorIndex + 2);
 
-  const lastSlash = jarPath.lastIndexOf("/");
-  const jarName = lastSlash !== -1 ? jarPath.substring(lastSlash + 1) : jarPath;
+  // Extract the actual filesystem path from jar:file:// prefix
+  if (fullJarPath.startsWith("jar:file://")) {
+    fullJarPath = fullJarPath.substring("jar:file://".length);
+  } else if (fullJarPath.startsWith("jar:file:")) {
+    fullJarPath = fullJarPath.substring("jar:file:".length);
+  }
+  if (fullJarPath.startsWith("//")) {
+    fullJarPath = fullJarPath.substring(1);
+  }
 
-  const jarFsUri = Uri.parse(`jar-fs:/${jarName}/${internalPath}`);
+  const lastSlash = fullJarPath.lastIndexOf("/");
+  const jarName =
+    lastSlash !== -1 ? fullJarPath.substring(lastSlash + 1) : fullJarPath;
 
+  // Encode the full JAR path in the query parameter
+  const jarFsUri = Uri.parse(`jar-fs:/${jarName}/${internalPath}`).with({
+    query: `jarPath=${encodeURIComponent(fullJarPath)}`,
+  });
+
+  // Also store in registry for backwards compatibility and translateJarFsToJar
   jarFsToJarUri.set(jarFsUri.toString(), decoded);
 
   return jarFsUri;

--- a/src/jarFileSystemProvider.ts
+++ b/src/jarFileSystemProvider.ts
@@ -36,6 +36,17 @@ interface JarUriComponents {
 const jarFsToJarUri = new Map<string, string>();
 
 /**
+ * Reconstruct a jar: URI from a filesystem JAR path and internal entry path.
+ * Uses the Uri API so spaces and other encoded archive-path characters survive.
+ */
+function toJarUriString(jarPath: string, internalPath: string): string {
+  return Uri.from({
+    scheme: "jar",
+    path: `${Uri.file(jarPath).toString()}!/${internalPath}`,
+  }).toString(true);
+}
+
+/**
  * Translates a jar-fs: URI back to the original jar: URI for sending to Metals.
  * Returns the original URI string if no translation is found or if not a jar-fs URI.
  */
@@ -44,7 +55,15 @@ export function translateJarFsToJar(uri: Uri): string {
     return uri.toString();
   }
 
-  // First, try to reconstruct from query parameter (self-contained URI)
+  const uriString = uri.toString();
+
+  // Direct lookup in the registry preserves the original serialized jar URI
+  const directMatch = jarFsToJarUri.get(uriString);
+  if (directMatch) {
+    return directMatch;
+  }
+
+  // Reconstruct from query parameter (self-contained URI, e.g. after restart)
   if (uri.query) {
     const params = new URLSearchParams(uri.query);
     const jarPath = params.get("jarPath");
@@ -52,16 +71,8 @@ export function translateJarFsToJar(uri: Uri): string {
       // Path format: /jarName.jar/internal/path
       const pathParts = uri.path.split("/").filter((p) => p);
       const internalPath = pathParts.slice(1).join("/");
-      return `jar:file://${jarPath}!/${internalPath}`;
+      return toJarUriString(jarPath, internalPath);
     }
-  }
-
-  const uriString = uri.toString();
-
-  // Direct lookup in the registry
-  const directMatch = jarFsToJarUri.get(uriString);
-  if (directMatch) {
-    return directMatch;
   }
 
   // Try to find a matching base URI and reconstruct the full path
@@ -478,8 +489,15 @@ export function parseJarUri(uriString: string): JarUriComponents | undefined {
  *
  * The full JAR path is encoded in the query parameter so the URI is self-contained
  * and can be resolved without needing a registry (survives extension restarts).
+ *
+ * @param uri Parsed jar URI
+ * @param originalJarUri Original serialized jar URI from Metals. Prefer this over
+ *   `uri.toString()` so percent-encoded archive paths are preserved when translating back.
  */
-export function translateJarToJarFs(uri: Uri): Uri {
+export function translateJarToJarFs(
+  uri: Uri,
+  originalJarUri: string = uri.toString(true),
+): Uri {
   if (uri.scheme !== "jar") {
     return uri;
   }
@@ -508,13 +526,15 @@ export function translateJarToJarFs(uri: Uri): Uri {
   const jarName =
     lastSlash !== -1 ? fullJarPath.substring(lastSlash + 1) : fullJarPath;
 
-  // Encode the full JAR path in the query parameter
-  const jarFsUri = Uri.parse(`jar-fs:/${jarName}/${internalPath}`).with({
-    query: `jarPath=${encodeURIComponent(fullJarPath)}`,
+  // Build via the Uri API so archive path and query encoding stay consistent
+  const jarFsUri = Uri.from({
+    scheme: "jar-fs",
+    path: `/${jarName}/${internalPath}`,
+    query: `jarPath=${fullJarPath}`,
   });
 
-  // Also store in registry for backwards compatibility and translateJarFsToJar
-  jarFsToJarUri.set(jarFsUri.toString(), decoded);
+  // Store the original serialized jar URI so round-trips keep Metals encoding
+  jarFsToJarUri.set(jarFsUri.toString(), originalJarUri);
 
   return jarFsUri;
 }

--- a/src/jarFileSystemProvider.ts
+++ b/src/jarFileSystemProvider.ts
@@ -1,0 +1,471 @@
+import {
+  FileSystemProvider,
+  FileType,
+  FileStat,
+  Uri,
+  Event,
+  EventEmitter,
+  Disposable,
+  FileChangeEvent,
+  FileSystemError,
+} from "vscode";
+import * as yauzl from "yauzl";
+import * as fs from "fs";
+
+/**
+ * Entry in a JAR directory listing
+ */
+interface JarEntry {
+  name: string;
+  type: FileType;
+  size: number;
+}
+
+/**
+ * Parsed components of a jar: URI
+ */
+interface JarUriComponents {
+  jarPath: string;
+  internalPath: string;
+}
+
+/**
+ * Global registry mapping jar-fs URIs back to original jar: URIs.
+ * This is populated by translateJarToJarFs and used by JarFileSystemProvider.
+ */
+const jarFsToJarUri = new Map<string, string>();
+
+/**
+ * Translates a jar-fs: URI back to the original jar: URI for sending to Metals.
+ * Returns the original URI string if no translation is found or if not a jar-fs URI.
+ */
+export function translateJarFsToJar(uri: Uri): string {
+  if (uri.scheme !== "jar-fs") {
+    return uri.toString();
+  }
+
+  const uriString = uri.toString();
+
+  // Direct lookup in the registry
+  const directMatch = jarFsToJarUri.get(uriString);
+  if (directMatch) {
+    return directMatch;
+  }
+
+  // Try to find a matching base URI and reconstruct the full path
+  const path = uri.path;
+  const parts = path.split("/").filter((p) => p);
+
+  for (let i = parts.length; i >= 1; i--) {
+    const testPath = "/" + parts.slice(0, i).join("/");
+    const testUri = uri.with({ path: testPath }).toString();
+
+    const jarUri = jarFsToJarUri.get(testUri);
+    if (jarUri) {
+      const additionalPath = path.substring(testPath.length);
+      const separatorIndex = jarUri.indexOf("!/");
+      if (separatorIndex !== -1) {
+        const basePart = jarUri.substring(0, separatorIndex + 2);
+        const internalPart = jarUri.substring(separatorIndex + 2);
+        return basePart + internalPart + additionalPath;
+      }
+    }
+  }
+
+  return uriString;
+}
+
+/**
+ * FileSystemProvider implementation for browsing JAR dependency sources.
+ *
+ * This provider enables proper file path breadcrumbs and enhanced navigation
+ * for dependency sources by implementing VS Code's FileSystemProvider interface.
+ *
+ * URI scheme: jar-fs:/artifact-name-1.0.0.jar/com/example/MyClass.scala
+ *
+ * The provider reads JAR files directly using the yauzl library, without
+ * requiring server-side support.
+ *
+ * Caching is implemented for all operations since JAR contents don't change.
+ */
+export class JarFileSystemProvider implements FileSystemProvider {
+  private _onDidChangeFile = new EventEmitter<FileChangeEvent[]>();
+  readonly onDidChangeFile: Event<FileChangeEvent[]> =
+    this._onDidChangeFile.event;
+
+  private statCache = new Map<string, FileStat>();
+  private dirCache = new Map<string, [string, FileType][]>();
+  private contentCache = new Map<string, Uint8Array>();
+  private jarEntriesCache = new Map<string, Map<string, JarEntry>>();
+
+  /**
+   * Get file/directory metadata.
+   * Results are cached since JAR contents don't change.
+   */
+  async stat(uri: Uri): Promise<FileStat> {
+    const key = uri.toString();
+
+    const cached = this.statCache.get(key);
+    if (cached) {
+      return cached;
+    }
+
+    const components = this.resolveJarComponents(uri);
+    if (!components) {
+      throw FileSystemError.FileNotFound(uri);
+    }
+
+    const entries = await this.getJarEntries(components.jarPath);
+    const entry = entries.get(components.internalPath);
+
+    if (!entry) {
+      if (components.internalPath === "" || components.internalPath === "/") {
+        const stat: FileStat = {
+          type: FileType.Directory,
+          ctime: 0,
+          mtime: 0,
+          size: 0,
+        };
+        this.statCache.set(key, stat);
+        return stat;
+      }
+      throw FileSystemError.FileNotFound(uri);
+    }
+
+    const stat: FileStat = {
+      type: entry.type,
+      ctime: 0,
+      mtime: 0,
+      size: entry.size,
+    };
+
+    this.statCache.set(key, stat);
+    return stat;
+  }
+
+  /**
+   * List directory contents.
+   * This enables breadcrumb dropdowns for navigating package hierarchies.
+   * Results are cached since JAR contents don't change.
+   */
+  async readDirectory(uri: Uri): Promise<[string, FileType][]> {
+    const key = uri.toString();
+
+    const cached = this.dirCache.get(key);
+    if (cached) {
+      return cached;
+    }
+
+    const components = this.resolveJarComponents(uri);
+    if (!components) {
+      throw FileSystemError.FileNotFound(uri);
+    }
+
+    const entries = await this.getJarEntries(components.jarPath);
+    const dirPath = components.internalPath.endsWith("/")
+      ? components.internalPath
+      : components.internalPath + "/";
+    const normalizedDirPath = dirPath === "/" ? "" : dirPath;
+
+    const result: [string, FileType][] = [];
+    const seen = new Set<string>();
+
+    for (const [entryPath, entry] of entries) {
+      if (!entryPath.startsWith(normalizedDirPath)) {
+        continue;
+      }
+
+      const relativePath = entryPath.substring(normalizedDirPath.length);
+      if (!relativePath || relativePath.startsWith("/")) {
+        continue;
+      }
+
+      const slashIndex = relativePath.indexOf("/");
+      if (slashIndex === -1) {
+        if (!seen.has(relativePath)) {
+          seen.add(relativePath);
+          result.push([relativePath, entry.type]);
+        }
+      } else {
+        const dirName = relativePath.substring(0, slashIndex);
+        if (!seen.has(dirName)) {
+          seen.add(dirName);
+          result.push([dirName, FileType.Directory]);
+        }
+      }
+    }
+
+    this.dirCache.set(key, result);
+    return result;
+  }
+
+  /**
+   * Read file content directly from the JAR.
+   * Results are cached since JAR contents don't change.
+   */
+  async readFile(uri: Uri): Promise<Uint8Array> {
+    const key = uri.toString();
+
+    const cached = this.contentCache.get(key);
+    if (cached) {
+      return cached;
+    }
+
+    const components = this.resolveJarComponents(uri);
+    if (!components) {
+      throw FileSystemError.FileNotFound(uri);
+    }
+
+    const content = await this.readJarEntry(
+      components.jarPath,
+      components.internalPath,
+    );
+    this.contentCache.set(key, content);
+    return content;
+  }
+
+  /**
+   * Watch for file changes - no-op since JAR contents are read-only.
+   */
+  watch(): Disposable {
+    return { dispose: () => {} };
+  }
+
+  /**
+   * Clear all caches. Call when JARs may have changed (e.g., after build import).
+   */
+  clearCache(): void {
+    this.statCache.clear();
+    this.dirCache.clear();
+    this.contentCache.clear();
+    this.jarEntriesCache.clear();
+  }
+
+  createDirectory(): void {
+    throw FileSystemError.NoPermissions("JAR filesystem is read-only");
+  }
+
+  writeFile(): void {
+    throw FileSystemError.NoPermissions("JAR filesystem is read-only");
+  }
+
+  delete(): void {
+    throw FileSystemError.NoPermissions("JAR filesystem is read-only");
+  }
+
+  rename(): void {
+    throw FileSystemError.NoPermissions("JAR filesystem is read-only");
+  }
+
+  /**
+   * Resolve a jar-fs URI to its JAR file path and internal path components.
+   */
+  private resolveJarComponents(uri: Uri): JarUriComponents | undefined {
+    const originalJarUri = jarFsToJarUri.get(uri.toString());
+    if (!originalJarUri) {
+      const fromPath = this.parseJarFsUriFromPath(uri);
+      if (fromPath) {
+        return fromPath;
+      }
+      return undefined;
+    }
+
+    return parseJarUri(originalJarUri);
+  }
+
+  /**
+   * Try to find the JAR path from a jar-fs URI by looking up parent paths
+   * in the registry.
+   */
+  private parseJarFsUriFromPath(uri: Uri): JarUriComponents | undefined {
+    const path = uri.path;
+    const parts = path.split("/").filter((p) => p);
+
+    for (let i = parts.length; i >= 1; i--) {
+      const testPath = "/" + parts.slice(0, i).join("/");
+      const testUri = uri.with({ path: testPath }).toString();
+
+      for (const [jarFsUri, jarUri] of jarFsToJarUri) {
+        if (jarFsUri.startsWith(testUri) || testUri.startsWith(jarFsUri)) {
+          const components = parseJarUri(jarUri);
+          if (components) {
+            const jarFsParsed = Uri.parse(jarFsUri);
+            const jarFsInternalStart = jarFsParsed.path.length;
+            const additionalPath = path.substring(jarFsInternalStart);
+            return {
+              jarPath: components.jarPath,
+              internalPath: components.internalPath + additionalPath,
+            };
+          }
+        }
+      }
+    }
+
+    return undefined;
+  }
+
+  /**
+   * Get all entries from a JAR file, cached for performance.
+   */
+  private async getJarEntries(jarPath: string): Promise<Map<string, JarEntry>> {
+    const cached = this.jarEntriesCache.get(jarPath);
+    if (cached) {
+      return cached;
+    }
+
+    const entries = new Map<string, JarEntry>();
+
+    await new Promise<void>((resolve, reject) => {
+      yauzl.open(jarPath, { lazyEntries: true }, (err, zipfile) => {
+        if (err || !zipfile) {
+          reject(err || new Error("Failed to open JAR"));
+          return;
+        }
+
+        zipfile.readEntry();
+        zipfile.on("entry", (entry: yauzl.Entry) => {
+          const isDirectory = entry.fileName.endsWith("/");
+          const name = isDirectory
+            ? entry.fileName.slice(0, -1)
+            : entry.fileName;
+
+          entries.set(name, {
+            name: name.split("/").pop() || name,
+            type: isDirectory ? FileType.Directory : FileType.File,
+            size: entry.uncompressedSize,
+          });
+
+          zipfile.readEntry();
+        });
+
+        zipfile.on("end", () => resolve());
+        zipfile.on("error", reject);
+      });
+    });
+
+    this.jarEntriesCache.set(jarPath, entries);
+    return entries;
+  }
+
+  /**
+   * Read a specific entry from a JAR file.
+   */
+  private async readJarEntry(
+    jarPath: string,
+    internalPath: string,
+  ): Promise<Uint8Array> {
+    return new Promise((resolve, reject) => {
+      yauzl.open(jarPath, { lazyEntries: true }, (err, zipfile) => {
+        if (err || !zipfile) {
+          reject(err || new Error("Failed to open JAR"));
+          return;
+        }
+
+        zipfile.readEntry();
+        zipfile.on("entry", (entry: yauzl.Entry) => {
+          const entryName = entry.fileName.endsWith("/")
+            ? entry.fileName.slice(0, -1)
+            : entry.fileName;
+
+          if (entryName === internalPath) {
+            zipfile.openReadStream(entry, (err, readStream) => {
+              if (err || !readStream) {
+                reject(err || new Error("Failed to read entry"));
+                return;
+              }
+
+              const chunks: Buffer[] = [];
+              readStream.on("data", (chunk: Buffer) => chunks.push(chunk));
+              readStream.on("end", () => {
+                resolve(new Uint8Array(Buffer.concat(chunks)));
+                zipfile.close();
+              });
+              readStream.on("error", reject);
+            });
+          } else {
+            zipfile.readEntry();
+          }
+        });
+
+        zipfile.on("end", () => {
+          reject(FileSystemError.FileNotFound(internalPath));
+        });
+        zipfile.on("error", reject);
+      });
+    });
+  }
+}
+
+/**
+ * Parse a jar: URI into its components.
+ *
+ * Input: jar:file:///path/to/scala-library-2.13.12.jar!/scala/Option.scala
+ * Output: { jarPath: "/path/to/scala-library-2.13.12.jar", internalPath: "scala/Option.scala" }
+ */
+export function parseJarUri(uriString: string): JarUriComponents | undefined {
+  const decoded = decodeURIComponent(uriString);
+
+  const jarSeparatorIndex = decoded.indexOf("!/");
+  if (jarSeparatorIndex === -1) {
+    return undefined;
+  }
+
+  let jarPath = decoded.substring(0, jarSeparatorIndex);
+  const internalPath = decoded.substring(jarSeparatorIndex + 2);
+
+  if (jarPath.startsWith("jar:file://")) {
+    jarPath = jarPath.substring("jar:file://".length);
+  } else if (jarPath.startsWith("jar:file:")) {
+    jarPath = jarPath.substring("jar:file:".length);
+  }
+
+  if (jarPath.startsWith("//")) {
+    jarPath = jarPath.substring(1);
+  }
+
+  return { jarPath, internalPath };
+}
+
+/**
+ * Translates a jar: URI to a jar-fs: URI for use with the FileSystemProvider.
+ *
+ * Input format:  jar:file:///path/to/scala-library-2.13.12.jar!/scala/Option.scala
+ * Output format: jar-fs:/scala-library-2.13.12.jar/scala/Option.scala
+ *
+ * This also registers the mapping so the provider can resolve it back.
+ */
+export function translateJarToJarFs(uri: Uri): Uri {
+  if (uri.scheme !== "jar") {
+    return uri;
+  }
+
+  const decoded = decodeURIComponent(uri.toString());
+
+  const jarSeparatorIndex = decoded.indexOf("!/");
+  if (jarSeparatorIndex === -1) {
+    return uri;
+  }
+
+  const jarPath = decoded.substring(0, jarSeparatorIndex);
+  const internalPath = decoded.substring(jarSeparatorIndex + 2);
+
+  const lastSlash = jarPath.lastIndexOf("/");
+  const jarName = lastSlash !== -1 ? jarPath.substring(lastSlash + 1) : jarPath;
+
+  const jarFsUri = Uri.parse(`jar-fs:/${jarName}/${internalPath}`);
+
+  jarFsToJarUri.set(jarFsUri.toString(), decoded);
+
+  return jarFsUri;
+}
+
+/**
+ * Check if a JAR file exists on the filesystem.
+ */
+export function jarExists(jarPath: string): boolean {
+  try {
+    return fs.existsSync(jarPath);
+  } catch {
+    return false;
+  }
+}

--- a/src/jarFileSystemProvider.ts
+++ b/src/jarFileSystemProvider.ts
@@ -32,6 +32,10 @@ interface JarUriComponents {
 /**
  * Global registry mapping jar-fs URIs back to original jar: URIs.
  * This is populated by translateJarToJarFs and used by JarFileSystemProvider.
+ *
+ * Keys are the full document jar-fs URI (exact round-trip) and a query-free
+ * JAR-root URI (`jar-fs:/name.jar` → `jar:file://...jar!/`) used to resolve
+ * parent and sibling paths.
  */
 const jarFsToJarUri = new Map<string, string>();
 
@@ -44,6 +48,37 @@ function toJarUriString(jarPath: string, internalPath: string): string {
     scheme: "jar",
     path: `${Uri.file(jarPath).toString()}!/${internalPath}`,
   }).toString(true);
+}
+
+/**
+ * Query-free jar-fs root key, e.g. jar-fs:/scala-library-2.13.12.jar
+ */
+function toJarFsRootKey(jarName: string): string {
+  return Uri.from({
+    scheme: "jar-fs",
+    path: `/${jarName}`,
+  }).toString();
+}
+
+/**
+ * Look up the registered JAR root for a jar-fs URI and the internal path
+ * relative to that root. Works for query-free parent and sibling URIs.
+ */
+function lookupJarFsRoot(
+  uri: Uri,
+): { jarRootUri: string; internalPath: string } | undefined {
+  const pathParts = uri.path.split("/").filter((p) => p);
+  if (pathParts.length < 1) {
+    return undefined;
+  }
+  const jarRootUri = jarFsToJarUri.get(toJarFsRootKey(pathParts[0]));
+  if (!jarRootUri) {
+    return undefined;
+  }
+  return {
+    jarRootUri,
+    internalPath: pathParts.slice(1).join("/"),
+  };
 }
 
 /**
@@ -75,23 +110,15 @@ export function translateJarFsToJar(uri: Uri): string {
     }
   }
 
-  // Try to find a matching base URI and reconstruct the full path
-  const path = uri.path;
-  const parts = path.split("/").filter((p) => p);
-
-  for (let i = parts.length; i >= 1; i--) {
-    const testPath = "/" + parts.slice(0, i).join("/");
-    const testUri = uri.with({ path: testPath }).toString();
-
-    const jarUri = jarFsToJarUri.get(testUri);
-    if (jarUri) {
-      const additionalPath = path.substring(testPath.length);
-      const separatorIndex = jarUri.indexOf("!/");
-      if (separatorIndex !== -1) {
-        const basePart = jarUri.substring(0, separatorIndex + 2);
-        const internalPart = jarUri.substring(separatorIndex + 2);
-        return basePart + internalPart + additionalPath;
-      }
+  // Query-free parent/sibling: resolve internalPath relative to the JAR root
+  const fromRoot = lookupJarFsRoot(uri);
+  if (fromRoot) {
+    const separatorIndex = fromRoot.jarRootUri.indexOf("!/");
+    if (separatorIndex !== -1) {
+      return (
+        fromRoot.jarRootUri.substring(0, separatorIndex + 2) +
+        fromRoot.internalPath
+      );
     }
   }
 
@@ -329,34 +356,25 @@ export class JarFileSystemProvider implements FileSystemProvider {
   }
 
   /**
-   * Try to find the JAR path from a jar-fs URI by looking up parent paths
-   * in the registry.
+   * Resolve a query-free jar-fs URI from the registered JAR-root mapping.
+   * internalPath is the remainder after the JAR name, so parent and sibling
+   * paths resolve correctly.
    */
   private parseJarFsUriFromPath(uri: Uri): JarUriComponents | undefined {
-    const path = uri.path;
-    const parts = path.split("/").filter((p) => p);
-
-    for (let i = parts.length; i >= 1; i--) {
-      const testPath = "/" + parts.slice(0, i).join("/");
-      const testUri = uri.with({ path: testPath }).toString();
-
-      for (const [jarFsUri, jarUri] of jarFsToJarUri) {
-        if (jarFsUri.startsWith(testUri) || testUri.startsWith(jarFsUri)) {
-          const components = parseJarUri(jarUri);
-          if (components) {
-            const jarFsParsed = Uri.parse(jarFsUri);
-            const jarFsInternalStart = jarFsParsed.path.length;
-            const additionalPath = path.substring(jarFsInternalStart);
-            return {
-              jarPath: components.jarPath,
-              internalPath: components.internalPath + additionalPath,
-            };
-          }
-        }
-      }
+    const fromRoot = lookupJarFsRoot(uri);
+    if (!fromRoot) {
+      return undefined;
     }
 
-    return undefined;
+    const components = parseJarUri(fromRoot.jarRootUri);
+    if (!components) {
+      return undefined;
+    }
+
+    return {
+      jarPath: components.jarPath,
+      internalPath: fromRoot.internalPath,
+    };
   }
 
   /**
@@ -550,10 +568,17 @@ export function translateJarToJarFs(
   const jarFsUri = Uri.from({
     scheme: "jar-fs",
     path: `/${jarName}/${internalPath}`,
-    query: `jarPath=${fullJarPath}`,
+    query: new URLSearchParams({ jarPath: fullJarPath }).toString(),
   });
 
-  // Store the original serialized jar URI so round-trips keep Metals encoding
+  // Full document URI preserves Metals encoding on exact round-trip.
+  // Query-free JAR root lets parent/sibling paths resolve relative to the archive.
+  const separatorIndex = originalJarUri.indexOf("!/");
+  const jarRootUri =
+    separatorIndex === -1
+      ? originalJarUri
+      : originalJarUri.substring(0, separatorIndex + 2);
+  jarFsToJarUri.set(toJarFsRootKey(jarName), jarRootUri);
   jarFsToJarUri.set(jarFsUri.toString(), originalJarUri);
 
   return jarFsUri;

--- a/src/jarFileSystemProvider.ts
+++ b/src/jarFileSystemProvider.ts
@@ -389,6 +389,7 @@ export class JarFileSystemProvider implements FileSystemProvider {
             type: isDirectory ? FileType.Directory : FileType.File,
             size: entry.uncompressedSize,
           });
+          addMissingParentDirectories(entries, name);
 
           zipfile.readEntry();
         });
@@ -448,6 +449,25 @@ export class JarFileSystemProvider implements FileSystemProvider {
         zipfile.on("error", reject);
       });
     });
+  }
+}
+
+/** Index implicit package directories without replacing explicit archive entries. */
+function addMissingParentDirectories(
+  entries: Map<string, JarEntry>,
+  entryPath: string,
+): void {
+  let slashIndex = entryPath.lastIndexOf("/");
+  while (slashIndex > 0) {
+    const parentPath = entryPath.substring(0, slashIndex);
+    if (!entries.has(parentPath)) {
+      entries.set(parentPath, {
+        name: parentPath.split("/").pop() || parentPath,
+        type: FileType.Directory,
+        size: 0,
+      });
+    }
+    slashIndex = parentPath.lastIndexOf("/");
   }
 }
 

--- a/src/test/extension/suites/jarFileSystemProvider.test.ts
+++ b/src/test/extension/suites/jarFileSystemProvider.test.ts
@@ -34,11 +34,8 @@ suite("jar URI translation", () => {
     const jarFs = translateJarToJarFs(Uri.parse(original), original);
 
     assert.strictEqual(jarFs.scheme, "jar-fs");
-    assert.ok(
-      jarFs.toString().includes("jarPath=") &&
-        (jarFs.toString().includes("My%20Libraries") ||
-          jarFs.query.includes("My Libraries")),
-    );
+    const jarPath = new URLSearchParams(jarFs.query).get("jarPath");
+    assert.ok(jarPath?.includes("My Libraries"));
     assert.strictEqual(translateJarFsToJar(jarFs), original);
   });
 

--- a/src/test/extension/suites/jarFileSystemProvider.test.ts
+++ b/src/test/extension/suites/jarFileSystemProvider.test.ts
@@ -22,9 +22,20 @@ suite("jar URI translation", () => {
       "/scala-library-2.13.12.jar/scala/Option.scala",
     );
     assert.strictEqual(
-      jarFs.query,
-      "jarPath=/home/user/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-library/2.13.12/scala-library-2.13.12.jar",
+      new URLSearchParams(jarFs.query).get("jarPath"),
+      "/home/user/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-library/2.13.12/scala-library-2.13.12.jar",
     );
+    assert.strictEqual(translateJarFsToJar(jarFs), original);
+  });
+
+  test("round-trips a jar URI with an ampersand in the archive path", () => {
+    const original =
+      "jar:file:///home/user/foo%26bar/scala-library-2.13.12.jar!/scala/Option.scala";
+    const jarFs = translateJarToJarFs(Uri.parse(original), original);
+
+    assert.strictEqual(jarFs.scheme, "jar-fs");
+    const jarPath = new URLSearchParams(jarFs.query).get("jarPath");
+    assert.strictEqual(jarPath, "/home/user/foo&bar/scala-library-2.13.12.jar");
     assert.strictEqual(translateJarFsToJar(jarFs), original);
   });
 
@@ -37,6 +48,52 @@ suite("jar URI translation", () => {
     const jarPath = new URLSearchParams(jarFs.query).get("jarPath");
     assert.ok(jarPath?.includes("My Libraries"));
     assert.strictEqual(translateJarFsToJar(jarFs), original);
+  });
+
+  test("round-trips query-free parent and sibling URIs via the JAR root mapping", () => {
+    const jarFile =
+      "jar:file:///home/user/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-library/2.13.12/scala-library-2.13.12.jar";
+    const original = `${jarFile}!/scala/Option.scala`;
+    translateJarToJarFs(Uri.parse(original), original);
+
+    const parent = Uri.from({
+      scheme: "jar-fs",
+      path: "/scala-library-2.13.12.jar/scala",
+    });
+    const sibling = Uri.from({
+      scheme: "jar-fs",
+      path: "/scala-library-2.13.12.jar/scala/Some.scala",
+    });
+
+    assert.strictEqual(translateJarFsToJar(parent), `${jarFile}!/scala`);
+    assert.strictEqual(
+      translateJarFsToJar(sibling),
+      `${jarFile}!/scala/Some.scala`,
+    );
+  });
+
+  test("round-trips query-free parent and sibling URIs with encoded archive paths", () => {
+    const original =
+      "jar:file:///home/user/My%20Libraries/scala-library-2.13.12.jar!/scala/Option.scala";
+    translateJarToJarFs(Uri.parse(original), original);
+
+    const parent = Uri.from({
+      scheme: "jar-fs",
+      path: "/scala-library-2.13.12.jar/scala",
+    });
+    const sibling = Uri.from({
+      scheme: "jar-fs",
+      path: "/scala-library-2.13.12.jar/scala/Some.scala",
+    });
+
+    assert.strictEqual(
+      translateJarFsToJar(parent),
+      "jar:file:///home/user/My%20Libraries/scala-library-2.13.12.jar!/scala",
+    );
+    assert.strictEqual(
+      translateJarFsToJar(sibling),
+      "jar:file:///home/user/My%20Libraries/scala-library-2.13.12.jar!/scala/Some.scala",
+    );
   });
 
   test("reconstructs encoded archive paths from query without a registry entry", () => {

--- a/src/test/extension/suites/jarFileSystemProvider.test.ts
+++ b/src/test/extension/suites/jarFileSystemProvider.test.ts
@@ -1,0 +1,151 @@
+import * as assert from "assert";
+import * as fs from "fs";
+import * as path from "path";
+import { spawn } from "promisify-child-process";
+import { FileSystemError, FileType, Uri } from "vscode";
+import {
+  JarFileSystemProvider,
+  translateJarFsToJar,
+  translateJarToJarFs,
+} from "../../../jarFileSystemProvider";
+import { validateCoursier } from "../../../setupCoursier";
+
+suite("jar URI translation", () => {
+  test("round-trips a plain jar URI", () => {
+    const original =
+      "jar:file:///home/user/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-library/2.13.12/scala-library-2.13.12.jar!/scala/Option.scala";
+    const jarFs = translateJarToJarFs(Uri.parse(original), original);
+
+    assert.strictEqual(jarFs.scheme, "jar-fs");
+    assert.strictEqual(
+      jarFs.path,
+      "/scala-library-2.13.12.jar/scala/Option.scala",
+    );
+    assert.strictEqual(
+      jarFs.query,
+      "jarPath=/home/user/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-library/2.13.12/scala-library-2.13.12.jar",
+    );
+    assert.strictEqual(translateJarFsToJar(jarFs), original);
+  });
+
+  test("round-trips a jar URI with an encoded archive path", () => {
+    const original =
+      "jar:file:///home/user/My%20Libraries/scala-library-2.13.12.jar!/scala/Option.scala";
+    const jarFs = translateJarToJarFs(Uri.parse(original), original);
+
+    assert.strictEqual(jarFs.scheme, "jar-fs");
+    assert.ok(
+      jarFs.toString().includes("jarPath=") &&
+        (jarFs.toString().includes("My%20Libraries") ||
+          jarFs.query.includes("My Libraries")),
+    );
+    assert.strictEqual(translateJarFsToJar(jarFs), original);
+  });
+
+  test("reconstructs encoded archive paths from query without a registry entry", () => {
+    const jarFs = Uri.from({
+      scheme: "jar-fs",
+      path: "/other.jar/com/example/Foo.scala",
+      query: "jarPath=/home/user/My Libraries/other.jar",
+    });
+
+    const reconstructed = translateJarFsToJar(jarFs);
+
+    assert.ok(reconstructed.startsWith("jar:file:"));
+    assert.ok(reconstructed.includes("My%20Libraries"));
+    assert.ok(reconstructed.endsWith("!/com/example/Foo.scala"));
+  });
+});
+
+suite("JarFileSystemProvider archive indexing", () => {
+  let jarPath: string;
+  let provider: JarFileSystemProvider;
+
+  suiteSetup(async function () {
+    this.timeout(120000);
+    jarPath = await fetchScalaLibrarySources();
+    provider = new JarFileSystemProvider();
+  });
+
+  function jarFsUri(internalPath: string): Uri {
+    const jarName = path.basename(jarPath);
+    const suffix = internalPath ? `/${internalPath}` : "";
+    return Uri.from({
+      scheme: "jar-fs",
+      path: `/${jarName}${suffix}`,
+      query: `jarPath=${encodeURIComponent(jarPath)}`,
+    });
+  }
+
+  test("stat resolves implicit package directories", async () => {
+    // scala-library-sources omits an explicit META-INF/ zip entry.
+    const metaStat = await provider.stat(jarFsUri("META-INF"));
+    const scalaStat = await provider.stat(jarFsUri("scala"));
+
+    assert.strictEqual(metaStat.type, FileType.Directory);
+    assert.strictEqual(metaStat.size, 0);
+    assert.strictEqual(scalaStat.type, FileType.Directory);
+  });
+
+  test("stat and read preserve explicit archive entries", async () => {
+    const fileStat = await provider.stat(jarFsUri("scala/Option.scala"));
+    const content = await provider.readFile(jarFsUri("scala/Option.scala"));
+    const source = Buffer.from(content).toString();
+
+    assert.strictEqual(fileStat.type, FileType.File);
+    assert.ok(fileStat.size > 0);
+    assert.ok(source.includes("package scala"));
+    assert.ok(source.includes("class Option"));
+  });
+
+  test("readDirectory still lists package hierarchies", async () => {
+    const root = new Map(await provider.readDirectory(jarFsUri("")));
+    const scala = new Map(await provider.readDirectory(jarFsUri("scala")));
+
+    assert.strictEqual(root.get("META-INF"), FileType.Directory);
+    assert.strictEqual(root.get("scala"), FileType.Directory);
+    assert.strictEqual(scala.get("Option.scala"), FileType.File);
+    assert.strictEqual(scala.get("collection"), FileType.Directory);
+  });
+
+  test("stat still fails for missing entries", async () => {
+    await assert.rejects(
+      () => provider.stat(jarFsUri("scala/missing")),
+      (err: unknown) => err instanceof FileSystemError,
+    );
+  });
+});
+
+async function fetchScalaLibrarySources(): Promise<string> {
+  const coursier = await validateCoursier();
+  if (!coursier) {
+    throw new Error(
+      "Coursier not found on PATH. Install cs (https://get-coursier.io) to run this test.",
+    );
+  }
+
+  const result = await spawn(
+    coursier,
+    [
+      "fetch",
+      "--ttl",
+      "Inf",
+      "--classifier",
+      "sources",
+      "org.scala-lang:scala-library:2.13.12",
+    ],
+    { encoding: "utf8" },
+  );
+  const stdout = (result.stdout ?? "").toString();
+  const jar = stdout
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .find((line) => line.endsWith("-sources.jar") && fs.existsSync(line));
+
+  if (!jar) {
+    throw new Error(
+      `Coursier fetch did not return scala-library sources:\n${stdout}\n${result.stderr ?? ""}`,
+    );
+  }
+  return jar;
+}

--- a/src/test/unit/documentSelector.test.ts
+++ b/src/test/unit/documentSelector.test.ts
@@ -14,6 +14,8 @@ describe("buildDocumentSelector", () => {
         { scheme: "file", language: "twirl-txt" },
         { scheme: "jar", language: "scala" },
         { scheme: "jar", language: "java" },
+        { scheme: "jar-fs", language: "scala" },
+        { scheme: "jar-fs", language: "java" },
       ],
     );
   });
@@ -30,8 +32,11 @@ describe("buildDocumentSelector", () => {
         { scheme: "file", language: "twirl-txt" },
         { scheme: "jar", language: "scala" },
         { scheme: "jar", language: "java" },
+        { scheme: "jar-fs", language: "scala" },
+        { scheme: "jar-fs", language: "java" },
         { scheme: "file", language: "proto" },
         { scheme: "jar", language: "proto" },
+        { scheme: "jar-fs", language: "proto" },
       ],
     );
   });
@@ -48,8 +53,11 @@ describe("buildDocumentSelector", () => {
         { scheme: "file", language: "twirl-txt" },
         { scheme: "jar", language: "scala" },
         { scheme: "jar", language: "java" },
+        { scheme: "jar-fs", language: "scala" },
+        { scheme: "jar-fs", language: "java" },
         { scheme: "file", language: "prototext" },
         { scheme: "jar", language: "prototext" },
+        { scheme: "jar-fs", language: "prototext" },
       ],
     );
   });
@@ -66,10 +74,14 @@ describe("buildDocumentSelector", () => {
         { scheme: "file", language: "twirl-txt" },
         { scheme: "jar", language: "scala" },
         { scheme: "jar", language: "java" },
+        { scheme: "jar-fs", language: "scala" },
+        { scheme: "jar-fs", language: "java" },
         { scheme: "file", language: "proto" },
         { scheme: "jar", language: "proto" },
+        { scheme: "jar-fs", language: "proto" },
         { scheme: "file", language: "prototext" },
         { scheme: "jar", language: "prototext" },
+        { scheme: "jar-fs", language: "prototext" },
       ],
     );
   });

--- a/src/test/unit/documentSelector.test.ts
+++ b/src/test/unit/documentSelector.test.ts
@@ -1,81 +1,91 @@
 import * as assert from "assert";
 import { buildDocumentSelector } from "../../documentSelector";
 
+const baseSelector = [
+  { scheme: "file", language: "scala" },
+  { scheme: "file", language: "java" },
+  { scheme: "file", language: "twirl-html" },
+  { scheme: "file", language: "twirl-xml" },
+  { scheme: "file", language: "twirl-js" },
+  { scheme: "file", language: "twirl-txt" },
+  { scheme: "jar", language: "scala" },
+  { scheme: "jar", language: "java" },
+];
+
+const jarFsSelector = [
+  { scheme: "jar-fs", language: "scala" },
+  { scheme: "jar-fs", language: "java" },
+];
+
 describe("buildDocumentSelector", () => {
   it("does not include proto documents when protobuf LSP is disabled", () => {
     assert.deepStrictEqual(
-      buildDocumentSelector({ protobuf: false, prototext: false }),
-      [
-        { scheme: "file", language: "scala" },
-        { scheme: "file", language: "java" },
-        { scheme: "file", language: "twirl-html" },
-        { scheme: "file", language: "twirl-xml" },
-        { scheme: "file", language: "twirl-js" },
-        { scheme: "file", language: "twirl-txt" },
-        { scheme: "jar", language: "scala" },
-        { scheme: "jar", language: "java" },
-        { scheme: "jar-fs", language: "scala" },
-        { scheme: "jar-fs", language: "java" },
-      ],
+      buildDocumentSelector({
+        protobuf: false,
+        prototext: false,
+        jarFileSystem: false,
+      }),
+      baseSelector,
     );
   });
 
   it("includes proto documents when protobuf LSP is enabled", () => {
     assert.deepStrictEqual(
-      buildDocumentSelector({ protobuf: true, prototext: false }),
+      buildDocumentSelector({
+        protobuf: true,
+        prototext: false,
+        jarFileSystem: false,
+      }),
       [
-        { scheme: "file", language: "scala" },
-        { scheme: "file", language: "java" },
-        { scheme: "file", language: "twirl-html" },
-        { scheme: "file", language: "twirl-xml" },
-        { scheme: "file", language: "twirl-js" },
-        { scheme: "file", language: "twirl-txt" },
-        { scheme: "jar", language: "scala" },
-        { scheme: "jar", language: "java" },
-        { scheme: "jar-fs", language: "scala" },
-        { scheme: "jar-fs", language: "java" },
+        ...baseSelector,
         { scheme: "file", language: "proto" },
         { scheme: "jar", language: "proto" },
-        { scheme: "jar-fs", language: "proto" },
       ],
     );
   });
 
   it("includes prototext documents when prototext LSP is enabled", () => {
     assert.deepStrictEqual(
-      buildDocumentSelector({ protobuf: false, prototext: true }),
+      buildDocumentSelector({
+        protobuf: false,
+        prototext: true,
+        jarFileSystem: false,
+      }),
       [
-        { scheme: "file", language: "scala" },
-        { scheme: "file", language: "java" },
-        { scheme: "file", language: "twirl-html" },
-        { scheme: "file", language: "twirl-xml" },
-        { scheme: "file", language: "twirl-js" },
-        { scheme: "file", language: "twirl-txt" },
-        { scheme: "jar", language: "scala" },
-        { scheme: "jar", language: "java" },
-        { scheme: "jar-fs", language: "scala" },
-        { scheme: "jar-fs", language: "java" },
+        ...baseSelector,
         { scheme: "file", language: "prototext" },
         { scheme: "jar", language: "prototext" },
-        { scheme: "jar-fs", language: "prototext" },
       ],
     );
   });
 
   it("includes proto and prototext documents when both are enabled", () => {
     assert.deepStrictEqual(
-      buildDocumentSelector({ protobuf: true, prototext: true }),
+      buildDocumentSelector({
+        protobuf: true,
+        prototext: true,
+        jarFileSystem: false,
+      }),
       [
-        { scheme: "file", language: "scala" },
-        { scheme: "file", language: "java" },
-        { scheme: "file", language: "twirl-html" },
-        { scheme: "file", language: "twirl-xml" },
-        { scheme: "file", language: "twirl-js" },
-        { scheme: "file", language: "twirl-txt" },
-        { scheme: "jar", language: "scala" },
-        { scheme: "jar", language: "java" },
-        { scheme: "jar-fs", language: "scala" },
-        { scheme: "jar-fs", language: "java" },
+        ...baseSelector,
+        { scheme: "file", language: "proto" },
+        { scheme: "jar", language: "proto" },
+        { scheme: "file", language: "prototext" },
+        { scheme: "jar", language: "prototext" },
+      ],
+    );
+  });
+
+  it("includes jar-fs documents when the experimental JAR filesystem is enabled", () => {
+    assert.deepStrictEqual(
+      buildDocumentSelector({
+        protobuf: true,
+        prototext: true,
+        jarFileSystem: true,
+      }),
+      [
+        ...baseSelector,
+        ...jarFsSelector,
         { scheme: "file", language: "proto" },
         { scheme: "jar", language: "proto" },
         { scheme: "jar-fs", language: "proto" },

--- a/src/util.ts
+++ b/src/util.ts
@@ -17,6 +17,7 @@ import http from "https";
 
 import { UserConfiguration } from "./interfaces/UserConfiguration";
 import { JavaVersion } from "./getJavaHome";
+import { translateJarFsToJar } from "./jarFileSystemProvider";
 
 declare const sym: unique symbol;
 
@@ -76,8 +77,10 @@ export function getTextDocumentPositionParams(
   editor: TextEditor,
 ): TextDocumentPositionParams {
   const pos = editor.selection.active;
+  // Translate jar-fs URIs back to jar URIs for Metals
+  const uri = translateJarFsToJar(editor.document.uri);
   return {
-    textDocument: { uri: editor.document.uri.toString() },
+    textDocument: { uri },
     position: { line: pos.line, character: pos.character },
   };
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -96,6 +96,14 @@ export function executeCommand<T>(
   });
 }
 
+export function isExperimentalJarFileSystemEnabled(): boolean {
+  return (
+    workspace
+      .getConfiguration("metals")
+      .get<boolean>("experimentalJarFileSystemEnabled") ?? false
+  );
+}
+
 export function getValueFromConfig<T>(
   config: WorkspaceConfiguration,
   key: string,


### PR DESCRIPTION
Instead of reading the files in Metals and sending heavy data using LSP it's much easier to just read the jar in VS Code itself. Virtual docs are anyway only supported in VS Code, so any other editors will just get the normal filesystem breadcrumbs.

This has an added benefit of being able to quickly switch between siblings.

https://github.com/user-attachments/assets/5940345a-cb16-4501-9643-9fc002419d1b


TODO: Metals focus command needs to be fixed.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added experimental, read-only browsing for files and directories inside JAR archives.
  * Scala and Java language features now work with documents opened from JAR files.
  * Protobuf and prototext support includes JAR-based documents when enabled.
  * Navigation and code intelligence correctly resolve locations within JAR contents.
  * Added reliable handling for missing or invalid JAR resources.
  * Added a setting to enable experimental JAR filesystem support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->